### PR TITLE
Feat/마이페이지 이미지 저장 컨트롤러 구현#17

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -31,6 +31,7 @@ dependencies {
     implementation 'com.sun.xml.bind:jaxb-core:4.0.1'
     implementation 'javax.xml.bind:jaxb-api:2.1'
     implementation 'com.google.code.gson:gson:2.9.1'
+    implementation 'org.springframework.cloud:spring-cloud-starter-aws:3.0.0'
     compileOnly 'org.projectlombok:lombok'
     runtimeOnly 'org.postgresql:postgresql'
     annotationProcessor 'org.projectlombok:lombok'

--- a/build.gradle
+++ b/build.gradle
@@ -31,7 +31,7 @@ dependencies {
     implementation 'com.sun.xml.bind:jaxb-core:4.0.1'
     implementation 'javax.xml.bind:jaxb-api:2.1'
     implementation 'com.google.code.gson:gson:2.9.1'
-    implementation 'org.springframework.cloud:spring-cloud-starter-aws:3.0.0'
+    implementation 'io.awspring.cloud:spring-cloud-aws-starter-s3:3.0.0'
     compileOnly 'org.projectlombok:lombok'
     runtimeOnly 'org.postgresql:postgresql'
     annotationProcessor 'org.projectlombok:lombok'

--- a/src/main/java/com/habitpay/habitpay/domain/member/api/MemberApi.java
+++ b/src/main/java/com/habitpay/habitpay/domain/member/api/MemberApi.java
@@ -10,7 +10,10 @@ import lombok.extern.slf4j.Slf4j;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
+import org.springframework.web.multipart.MultipartFile;
 
+import java.io.File;
+import java.io.IOException;
 import java.util.StringTokenizer;
 
 @RestController
@@ -22,8 +25,8 @@ public class MemberApi {
 
     @PostMapping("/member")
     @ResponseStatus(HttpStatus.CREATED)
-    public ResponseEntity<String> updateMember(@RequestBody MemberRequest memberRequest,
-                                               @RequestHeader("Authorization") String authorizationHeader) {
+    public ResponseEntity<String> activateMember(@RequestBody MemberRequest memberRequest,
+                                                 @RequestHeader("Authorization") String authorizationHeader) {
 
         // todo: 예외처리 추가하기
 //        if (authorizationHeader == null || authorizationHeader.startsWith("Bearer") {
@@ -56,5 +59,20 @@ public class MemberApi {
         }
 
         return ResponseEntity.status(HttpStatus.UNAUTHORIZED).body("올바른 접근이 아닙니다.");
+    }
+
+    @PatchMapping("/member")
+    @ResponseStatus(HttpStatus.OK)
+    public ResponseEntity<String> patchMember(@ModelAttribute MemberRequest memberRequest) throws IOException {
+        log.info("[PATCH /member] nickname: {}", memberRequest.getNickname());
+        if (memberRequest.getProfileImage() != null) {
+            MultipartFile profileImage = memberRequest.getProfileImage();
+            String fileName = profileImage.getOriginalFilename();
+            log.info("[PATCH /member] fileName: {}", fileName);
+            String filePath = "/Users/joonhyuk/workspace/habitpay/HabitPay/backend/images/" + fileName;
+            log.info("[PATCH /member] filePath: {}", filePath);
+            profileImage.transferTo(new File(filePath));
+        }
+        return ResponseEntity.status(HttpStatus.OK).body("Test");
     }
 }

--- a/src/main/java/com/habitpay/habitpay/domain/member/api/MemberApi.java
+++ b/src/main/java/com/habitpay/habitpay/domain/member/api/MemberApi.java
@@ -6,13 +6,16 @@ import com.habitpay.habitpay.domain.member.domain.Member;
 import com.habitpay.habitpay.domain.member.dto.MemberRequest;
 import com.habitpay.habitpay.global.config.aws.S3FileService;
 import com.habitpay.habitpay.global.config.jwt.TokenService;
+import com.habitpay.habitpay.global.error.ErrorResponse;
+import com.habitpay.habitpay.global.util.ImageUtil;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
 
-import java.util.StringTokenizer;
+import java.util.Optional;
+import java.util.UUID;
 
 @RestController
 @RequiredArgsConstructor
@@ -27,49 +30,61 @@ public class MemberApi {
     public ResponseEntity<String> activateMember(@RequestBody MemberRequest memberRequest,
                                                  @RequestHeader("Authorization") String authorizationHeader) {
 
-        // todo: 예외처리 추가하기
-//        if (authorizationHeader == null || authorizationHeader.startsWith("Bearer") {
-//
-//        }
-
-        StringTokenizer tokenizer = new StringTokenizer(authorizationHeader);
-        if (tokenizer.countTokens() == 2 && tokenizer.nextToken().equals("Bearer")) {
-            String token = tokenizer.nextToken();
-            log.info("[POST /member] token: {}", token);
-            String email = tokenService.getEmail(token);
-            String nickname = memberRequest.getNickname();
-
-            log.info("[POST /member] email: {}, nickname: {}", email, nickname);
-
-            Member member = memberService.findByEmail(email);
-
-            log.info("[POST /member] 회원 조회 성공");
-
-            member.activate(nickname);
-            memberService.save(member);
-
-            log.info("[POST /member] 회원 활성화 성공");
-
-            String newToken = tokenService.createAccessToken(email);
-            JsonObject responseBody = new JsonObject();
-            responseBody.addProperty("accessToken", newToken);
-
-            return ResponseEntity.status(HttpStatus.CREATED).body(responseBody.toString());
+        // TODO: Interceptor 나 Filter 에서 먼저 처리해주기 때문에 나중에 삭제하기
+        Optional<String> optionalToken = tokenService.getTokenFromHeader(authorizationHeader);
+        if (optionalToken.isEmpty()) {
+            String message = ErrorResponse.UNAUTHORIZED.getMessage();
+            return ResponseEntity.status(HttpStatus.UNAUTHORIZED).body(message);
         }
 
-        return ResponseEntity.status(HttpStatus.UNAUTHORIZED).body("올바른 접근이 아닙니다.");
+        String token = optionalToken.get();
+        log.info("[POST /member] token: {}", token);
+
+        String email = tokenService.getEmail(token);
+        String nickname = memberRequest.getNickname();
+        log.info("[POST /member] email: {}, nickname: {}", email, nickname);
+
+        Member member = memberService.findByEmail(email);
+
+        log.info("[POST /member] 회원 조회 성공");
+
+        member.activate(nickname);
+        memberService.save(member);
+
+        log.info("[POST /member] 회원 활성화 성공");
+
+        String newToken = tokenService.createAccessToken(email);
+        JsonObject responseBody = new JsonObject();
+        responseBody.addProperty("accessToken", newToken);
+
+        return ResponseEntity.status(HttpStatus.CREATED).body(responseBody.toString());
+
     }
 
     @PatchMapping("/member")
     @ResponseStatus(HttpStatus.OK)
-    public ResponseEntity<String> patchMember(@RequestBody MemberRequest memberRequest) {
-        log.info("[PATCH /member] nickname: {}", memberRequest.getNickname());
-        if (memberRequest.getProfileImageName() != null) {
-            String fileName = memberRequest.getProfileImageName();
-            log.info("[PATCH /member] fileName: {}", fileName);
-            String preSignedUrl = s3FileService.getPreSignedUrl("profiles", fileName);
-            return ResponseEntity.status(HttpStatus.OK).body(preSignedUrl);
+    public ResponseEntity<String> patchMember(@RequestBody MemberRequest memberRequest,
+                                              @RequestHeader("Authorization") String authorizationHeader) {
+        // TODO: Interceptor 나 Filter 에서 먼저 처리해주기 때문에 나중에 삭제하기
+        Optional<String> optionalToken = tokenService.getTokenFromHeader(authorizationHeader);
+        if (optionalToken.isEmpty()) {
+            String message = ErrorResponse.UNAUTHORIZED.getMessage();
+            return ResponseEntity.status(HttpStatus.UNAUTHORIZED).body(message);
         }
-        return ResponseEntity.status(HttpStatus.OK).body("OK");
+
+        String imageExtension = memberRequest.getImageExtension();
+        log.info("[PATCH /member] imageExtension: {}", imageExtension);
+        if (ImageUtil.isValidImageExtension(imageExtension) == false) {
+            String message = ErrorResponse.UNSUPPORTED_IMAGE_EXTENSION.getMessage();
+            return ResponseEntity.status(HttpStatus.UNSUPPORTED_MEDIA_TYPE).body(message);
+        }
+
+        log.info("[PATCH /member] nickname: {}", memberRequest.getNickname());
+
+        String randomFileName = UUID.randomUUID().toString();
+        log.info("[PATCH /member] randomFileName: {}", randomFileName);
+        String preSignedUrl = s3FileService.getPreSignedUrl("profiles", randomFileName);
+        return ResponseEntity.status(HttpStatus.OK).body(preSignedUrl);
     }
+
 }

--- a/src/main/java/com/habitpay/habitpay/domain/member/api/MemberApi.java
+++ b/src/main/java/com/habitpay/habitpay/domain/member/api/MemberApi.java
@@ -118,6 +118,9 @@ public class MemberApi {
             memberService.save(member);
             return ResponseEntity.status(HttpStatus.OK).body(Response.PROFILE_UPDATE_SUCCESS.getMessage());
         } else if (ImageUtil.isValidImageExtension(imageExtension)) {
+            // 기존 이미지 삭제
+            s3FileService.deleteImage("profiles", member.getImageFileName());
+
             String randomFileName = UUID.randomUUID().toString();
             String savedFileName = String.format("%s.%s", randomFileName, imageExtension);
             log.info("[PATCH /member] savedFileName: {}", savedFileName);

--- a/src/main/java/com/habitpay/habitpay/domain/member/api/MemberApi.java
+++ b/src/main/java/com/habitpay/habitpay/domain/member/api/MemberApi.java
@@ -81,9 +81,17 @@ public class MemberApi {
 
         log.info("[PATCH /member] nickname: {}", memberRequest.getNickname());
 
+
         String randomFileName = UUID.randomUUID().toString();
         log.info("[PATCH /member] randomFileName: {}", randomFileName);
-        String preSignedUrl = s3FileService.getPreSignedUrl("profiles", randomFileName);
+
+        String token = optionalToken.get();
+        String email = tokenService.getEmail(token);
+        Member member = memberService.findByEmail(email);
+        member.updateProfile(memberRequest.getNickname(), randomFileName);
+        memberService.save(member);
+
+        String preSignedUrl = s3FileService.getPutPreSignedUrl("profiles", randomFileName);
         return ResponseEntity.status(HttpStatus.OK).body(preSignedUrl);
     }
 

--- a/src/main/java/com/habitpay/habitpay/domain/member/api/MemberProfileService.java
+++ b/src/main/java/com/habitpay/habitpay/domain/member/api/MemberProfileService.java
@@ -1,0 +1,20 @@
+package com.habitpay.habitpay.domain.member.api;
+
+import lombok.AllArgsConstructor;
+import org.springframework.stereotype.Service;
+
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+
+@Service
+@AllArgsConstructor
+public class MemberProfileService {
+    public boolean isValidNickname(String nickname) {
+        String regex = "^[a-zA-Z0-9가-힣]{2,15}$";
+        Pattern pattern = Pattern.compile(regex);
+        Matcher matcher = pattern.matcher(nickname);
+
+        return matcher.matches();
+    }
+
+}

--- a/src/main/java/com/habitpay/habitpay/domain/member/application/MemberService.java
+++ b/src/main/java/com/habitpay/habitpay/domain/member/application/MemberService.java
@@ -4,6 +4,7 @@ import com.habitpay.habitpay.domain.member.dao.MemberRepository;
 import com.habitpay.habitpay.domain.member.domain.Member;
 import lombok.AllArgsConstructor;
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
 
 import java.util.Optional;
 
@@ -19,6 +20,7 @@ public class MemberService {
         return optionalMember.get();
     }
 
+    @Transactional
     public void save(Member member) {
         memberRepository.save(member);
     }

--- a/src/main/java/com/habitpay/habitpay/domain/member/domain/Member.java
+++ b/src/main/java/com/habitpay/habitpay/domain/member/domain/Member.java
@@ -19,7 +19,7 @@ public class Member extends BaseTime {
     private String nickname;
 
     @Column()
-    private String imageUrl;
+    private String imageFileName;
 
     @Column(nullable = false)
     private String email;
@@ -32,10 +32,17 @@ public class Member extends BaseTime {
     private Role role;
 
     @Builder
-    public Member(String email, Role role) {
+    public Member(String email, String imageFileName, String nickname, Role role) {
         this.email = email;
+        this.imageFileName = imageFileName;
+        this.nickname = nickname;
         this.isActive = false;
         this.role = role;
+    }
+
+    public void updateProfile(String nickname, String imageFileName) {
+        this.nickname = nickname;
+        this.imageFileName = imageFileName;
     }
 
     public void activate(String nickname) {

--- a/src/main/java/com/habitpay/habitpay/domain/member/domain/Member.java
+++ b/src/main/java/com/habitpay/habitpay/domain/member/domain/Member.java
@@ -18,6 +18,9 @@ public class Member extends BaseTime {
     @Column()
     private String nickname;
 
+    @Column()
+    private String imageUrl;
+
     @Column(nullable = false)
     private String email;
 

--- a/src/main/java/com/habitpay/habitpay/domain/member/dto/MemberRequest.java
+++ b/src/main/java/com/habitpay/habitpay/domain/member/dto/MemberRequest.java
@@ -1,9 +1,12 @@
 package com.habitpay.habitpay.domain.member.dto;
 
 import lombok.Getter;
+import lombok.Setter;
+import org.springframework.web.multipart.MultipartFile;
 
 @Getter
+@Setter
 public class MemberRequest {
     private String nickname;
-    private String email;
+    private MultipartFile profileImage;
 }

--- a/src/main/java/com/habitpay/habitpay/domain/member/dto/MemberRequest.java
+++ b/src/main/java/com/habitpay/habitpay/domain/member/dto/MemberRequest.java
@@ -3,8 +3,7 @@ package com.habitpay.habitpay.domain.member.dto;
 import lombok.Getter;
 
 @Getter
-//@Setter
 public class MemberRequest {
     private String nickname;
-    private String profileImageName;
+    private String imageExtension;
 }

--- a/src/main/java/com/habitpay/habitpay/domain/member/dto/MemberRequest.java
+++ b/src/main/java/com/habitpay/habitpay/domain/member/dto/MemberRequest.java
@@ -1,12 +1,10 @@
 package com.habitpay.habitpay.domain.member.dto;
 
 import lombok.Getter;
-import lombok.Setter;
-import org.springframework.web.multipart.MultipartFile;
 
 @Getter
-@Setter
+//@Setter
 public class MemberRequest {
     private String nickname;
-    private MultipartFile profileImage;
+    private String profileImageName;
 }

--- a/src/main/java/com/habitpay/habitpay/domain/member/dto/MemberRequest.java
+++ b/src/main/java/com/habitpay/habitpay/domain/member/dto/MemberRequest.java
@@ -6,4 +6,5 @@ import lombok.Getter;
 public class MemberRequest {
     private String nickname;
     private String imageExtension;
+    private Long contentLength;
 }

--- a/src/main/java/com/habitpay/habitpay/domain/member/dto/MemberResponse.java
+++ b/src/main/java/com/habitpay/habitpay/domain/member/dto/MemberResponse.java
@@ -1,0 +1,11 @@
+package com.habitpay.habitpay.domain.member.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+@Getter
+@AllArgsConstructor
+public class MemberResponse {
+    private String nickname;
+    private String imageUrl;
+}

--- a/src/main/java/com/habitpay/habitpay/domain/model/Image.java
+++ b/src/main/java/com/habitpay/habitpay/domain/model/Image.java
@@ -1,0 +1,22 @@
+package com.habitpay.habitpay.domain.model;
+
+import java.util.Arrays;
+import java.util.Set;
+import java.util.stream.Collectors;
+
+public enum Image {
+    VALID_EXTENSION("JPG,JPEG,PNG");
+
+    private Set<String> imageExtensionSet;
+
+    Image(String extensionString) {
+        this.imageExtensionSet = Arrays.stream(extensionString.split(","))
+                .map(String::trim)
+                .collect(Collectors.toSet());
+    }
+
+    public boolean contains(String extension) {
+        return this.imageExtensionSet.contains(extension);
+    }
+
+}

--- a/src/main/java/com/habitpay/habitpay/domain/model/Response.java
+++ b/src/main/java/com/habitpay/habitpay/domain/model/Response.java
@@ -1,0 +1,13 @@
+package com.habitpay.habitpay.domain.model;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+@Getter
+@AllArgsConstructor
+public enum Response {
+    PROFILE_UPDATE_SUCCESS("프로필 업데이트에 성공했습니다.");
+
+    private final String message;
+
+}

--- a/src/main/java/com/habitpay/habitpay/global/config/aws/S3FileService.java
+++ b/src/main/java/com/habitpay/habitpay/global/config/aws/S3FileService.java
@@ -1,10 +1,12 @@
 package com.habitpay.habitpay.global.config.aws;
 
-import io.awspring.cloud.s3.S3Operations;
+import io.awspring.cloud.s3.S3Exception;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Service;
+import software.amazon.awssdk.services.s3.S3Client;
+import software.amazon.awssdk.services.s3.model.DeleteObjectRequest;
 import software.amazon.awssdk.services.s3.model.GetObjectRequest;
 import software.amazon.awssdk.services.s3.model.PutObjectRequest;
 import software.amazon.awssdk.services.s3.presigner.S3Presigner;
@@ -19,9 +21,24 @@ import java.time.Duration;
 @Slf4j
 @RequiredArgsConstructor
 public class S3FileService {
-    private final S3Operations amazonS3;
+    private final S3Client amazonS3;
     @Value("${cloud.aws.s3.bucket}")
     private String bucket;
+
+    public void deleteImage(String prefix, String fileName) {
+        String filePath = String.format("%s/%s", prefix, fileName);
+        try {
+            DeleteObjectRequest objectRequest = DeleteObjectRequest.builder()
+                    .bucket(bucket)
+                    .key(filePath)
+                    .build();
+            amazonS3.deleteObject(objectRequest);
+            log.info("[S3FileService] deleteObject: {}", filePath);
+
+        } catch (S3Exception exception) {
+            throw new S3Exception("Failed to delete s3 object", exception);
+        }
+    }
 
     public String getPutPreSignedUrl(String prefix, String fileName) {
         String filePath = String.format("%s/%s", prefix, fileName);

--- a/src/main/java/com/habitpay/habitpay/global/config/aws/S3FileService.java
+++ b/src/main/java/com/habitpay/habitpay/global/config/aws/S3FileService.java
@@ -18,7 +18,7 @@ public class S3FileService {
     @Value("${cloud.aws.s3.bucket}")
     private String bucket;
 
-    public String getPreSignedUrl(String prefix, String fileName) {
+    public String getPutPreSignedUrl(String prefix, String fileName) {
         String filePath = String.format("%s/%s", prefix, fileName);
         try (S3Presigner presigner = S3Presigner.create()) {
             PutObjectRequest objectRequest = PutObjectRequest.builder()

--- a/src/main/java/com/habitpay/habitpay/global/config/aws/S3FileService.java
+++ b/src/main/java/com/habitpay/habitpay/global/config/aws/S3FileService.java
@@ -1,0 +1,38 @@
+package com.habitpay.habitpay.global.config.aws;
+
+import io.awspring.cloud.s3.S3Operations;
+import lombok.RequiredArgsConstructor;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Service;
+import software.amazon.awssdk.services.s3.model.PutObjectRequest;
+import software.amazon.awssdk.services.s3.presigner.S3Presigner;
+import software.amazon.awssdk.services.s3.presigner.model.PresignedPutObjectRequest;
+import software.amazon.awssdk.services.s3.presigner.model.PutObjectPresignRequest;
+
+import java.time.Duration;
+
+@Service
+@RequiredArgsConstructor
+public class S3FileService {
+    private final S3Operations amazonS3;
+    @Value("${cloud.aws.s3.bucket}")
+    private String bucket;
+
+    public String getPreSignedUrl(String prefix, String fileName) {
+        String filePath = String.format("%s/%s", prefix, fileName);
+        try (S3Presigner presigner = S3Presigner.create()) {
+            PutObjectRequest objectRequest = PutObjectRequest.builder()
+                    .bucket(bucket)
+                    .key(filePath)
+                    .build();
+
+            PutObjectPresignRequest presignRequest = PutObjectPresignRequest.builder()
+                    .signatureDuration(Duration.ofMinutes(2))
+                    .putObjectRequest(objectRequest)
+                    .build();
+
+            PresignedPutObjectRequest presignedRequest = presigner.presignPutObject(presignRequest);
+            return presignedRequest.url().toString();
+        }
+    }
+}

--- a/src/main/java/com/habitpay/habitpay/global/config/aws/S3FileService.java
+++ b/src/main/java/com/habitpay/habitpay/global/config/aws/S3FileService.java
@@ -2,16 +2,21 @@ package com.habitpay.habitpay.global.config.aws;
 
 import io.awspring.cloud.s3.S3Operations;
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Service;
+import software.amazon.awssdk.services.s3.model.GetObjectRequest;
 import software.amazon.awssdk.services.s3.model.PutObjectRequest;
 import software.amazon.awssdk.services.s3.presigner.S3Presigner;
+import software.amazon.awssdk.services.s3.presigner.model.GetObjectPresignRequest;
+import software.amazon.awssdk.services.s3.presigner.model.PresignedGetObjectRequest;
 import software.amazon.awssdk.services.s3.presigner.model.PresignedPutObjectRequest;
 import software.amazon.awssdk.services.s3.presigner.model.PutObjectPresignRequest;
 
 import java.time.Duration;
 
 @Service
+@Slf4j
 @RequiredArgsConstructor
 public class S3FileService {
     private final S3Operations amazonS3;
@@ -32,7 +37,27 @@ public class S3FileService {
                     .build();
 
             PresignedPutObjectRequest presignedRequest = presigner.presignPutObject(presignRequest);
+            log.info("[S3FileService] getPutPreSignedUrl: {}", presignedRequest.url().toString());
             return presignedRequest.url().toString();
+        }
+    }
+
+    public String getGetPreSignedUrl(String prefix, String fileName) {
+        String filePath = String.format("%s/%s", prefix, fileName);
+        try (S3Presigner presigner = S3Presigner.create()) {
+            GetObjectRequest objectRequest = GetObjectRequest.builder()
+                    .bucket(bucket)
+                    .key(filePath)
+                    .build();
+
+            GetObjectPresignRequest presignRequest = GetObjectPresignRequest.builder()
+                    .signatureDuration(Duration.ofMinutes(2))
+                    .getObjectRequest(objectRequest)
+                    .build();
+
+            PresignedGetObjectRequest presignedRequest = presigner.presignGetObject(presignRequest);
+            log.info("[S3FileService] getGetPreSignedUrl: {}", presignedRequest.url().toString());
+            return presignedRequest.url().toExternalForm();
         }
     }
 }

--- a/src/main/java/com/habitpay/habitpay/global/config/aws/S3FileService.java
+++ b/src/main/java/com/habitpay/habitpay/global/config/aws/S3FileService.java
@@ -40,12 +40,15 @@ public class S3FileService {
         }
     }
 
-    public String getPutPreSignedUrl(String prefix, String fileName) {
+    public String getPutPreSignedUrl(String prefix, String fileName, String extension, Long contentLength) {
         String filePath = String.format("%s/%s", prefix, fileName);
+        String contentType = String.format("image/%s", extension);
         try (S3Presigner presigner = S3Presigner.create()) {
             PutObjectRequest objectRequest = PutObjectRequest.builder()
                     .bucket(bucket)
                     .key(filePath)
+                    .contentType(contentType)
+                    .contentLength(contentLength)
                     .build();
 
             PutObjectPresignRequest presignRequest = PutObjectPresignRequest.builder()

--- a/src/main/java/com/habitpay/habitpay/global/config/jwt/TokenProvider.java
+++ b/src/main/java/com/habitpay/habitpay/global/config/jwt/TokenProvider.java
@@ -30,6 +30,7 @@ public class TokenProvider {
                 .setIssuedAt(now)
                 .setExpiration(expiry)
                 .setSubject(member.getEmail())
+                .claim("nickname", String.valueOf(member.getNickname()))
                 .claim("isActive", String.valueOf(member.isActive()))
                 .signWith(SignatureAlgorithm.HS256, jwtProperties.getSecret())
                 .compact();

--- a/src/main/java/com/habitpay/habitpay/global/config/jwt/TokenService.java
+++ b/src/main/java/com/habitpay/habitpay/global/config/jwt/TokenService.java
@@ -15,6 +15,7 @@ import java.time.Duration;
 import java.util.Collections;
 import java.util.Optional;
 import java.util.Set;
+import java.util.StringTokenizer;
 
 @RequiredArgsConstructor
 @Service
@@ -59,5 +60,13 @@ public class TokenService {
     public boolean getIsActive(String token) {
         Claims claims = getClaims(token);
         return claims.get("isActive", Boolean.class);
+    }
+
+    public Optional<String> getTokenFromHeader(String header) {
+        StringTokenizer tokenizer = new StringTokenizer(header);
+        if (tokenizer.countTokens() != 2 || tokenizer.nextToken().equals("Bearer") == false) {
+            return Optional.empty();
+        }
+        return Optional.of(tokenizer.nextToken());
     }
 }

--- a/src/main/java/com/habitpay/habitpay/global/error/ErrorResponse.java
+++ b/src/main/java/com/habitpay/habitpay/global/error/ErrorResponse.java
@@ -1,0 +1,13 @@
+package com.habitpay.habitpay.global.error;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+@Getter
+@AllArgsConstructor
+public enum ErrorResponse {
+    UNSUPPORTED_IMAGE_EXTENSION("지원하지 않는 이미지 확장자입니다."),
+    UNAUTHORIZED("유효한 토큰이 아닙니다. 다시 로그인 해주세요.");
+
+    private final String message;
+}

--- a/src/main/java/com/habitpay/habitpay/global/error/ErrorResponse.java
+++ b/src/main/java/com/habitpay/habitpay/global/error/ErrorResponse.java
@@ -7,6 +7,7 @@ import lombok.Getter;
 @AllArgsConstructor
 public enum ErrorResponse {
     UNSUPPORTED_IMAGE_EXTENSION("지원하지 않는 이미지 확장자입니다."),
+    IMAGE_CONTENT_TOO_LARGE("이미지 파일의 크기가 제한을 초과했습니다."),
     UNAUTHORIZED("유효한 토큰이 아닙니다. 다시 로그인 해주세요.");
 
     private final String message;

--- a/src/main/java/com/habitpay/habitpay/global/error/ErrorResponse.java
+++ b/src/main/java/com/habitpay/habitpay/global/error/ErrorResponse.java
@@ -7,6 +7,7 @@ import lombok.Getter;
 @AllArgsConstructor
 public enum ErrorResponse {
     UNSUPPORTED_IMAGE_EXTENSION("지원하지 않는 이미지 확장자입니다."),
+    INVALID_NICKNAME_RULE("닉네임 규칙에 맞지 않습니다."),
     IMAGE_CONTENT_TOO_LARGE("이미지 파일의 크기가 제한을 초과했습니다."),
     UNAUTHORIZED("유효한 토큰이 아닙니다. 다시 로그인 해주세요.");
 

--- a/src/main/java/com/habitpay/habitpay/global/util/ImageUtil.java
+++ b/src/main/java/com/habitpay/habitpay/global/util/ImageUtil.java
@@ -1,0 +1,9 @@
+package com.habitpay.habitpay.global.util;
+
+import com.habitpay.habitpay.domain.model.Image;
+
+public class ImageUtil {
+    public static boolean isValidImageExtension(String extension) {
+        return Image.VALID_EXTENSION.contains(extension.toUpperCase());
+    }
+}

--- a/src/main/java/com/habitpay/habitpay/global/util/ImageUtil.java
+++ b/src/main/java/com/habitpay/habitpay/global/util/ImageUtil.java
@@ -3,7 +3,14 @@ package com.habitpay.habitpay.global.util;
 import com.habitpay.habitpay.domain.model.Image;
 
 public class ImageUtil {
+    public static final long MB = 1024 * 1024;
+    public static final long PROFILE_IMAGE_SIZE_LIMIT = 1 * MB;
+
     public static boolean isValidImageExtension(String extension) {
         return Image.VALID_EXTENSION.contains(extension.toUpperCase());
+    }
+
+    public static boolean isValidFileSize(Long size) {
+        return 0 < size && size <= PROFILE_IMAGE_SIZE_LIMIT;
     }
 }

--- a/src/main/resources/application-local.yaml
+++ b/src/main/resources/application-local.yaml
@@ -4,7 +4,7 @@ spring:
       on-profile: local
   jpa:
     hibernate:
-      ddl-auto: create
+      ddl-auto: update
   datasource:
     url: jdbc:postgresql://${POSTGRES_HOST}:${POSTGRES_PORT}/${POSTGRES_DB}
     username: ${POSTGRES_USER}

--- a/src/main/resources/application.yaml
+++ b/src/main/resources/application.yaml
@@ -12,6 +12,18 @@ spring:
   jpa:
     database: postgresql
 ---
+cloud:
+  aws:
+    s3:
+      bucket: ${BUCKET_NAME}
+    stack:
+      auto: false
+    region:
+      static: ap-northeast-2
+    credentials:
+      access-key: ${AWS_ACCESS_KEY}
+      secret-key: ${AWS_SECRET_KEY}
+---
 spring:
   profiles:
     active: local


### PR DESCRIPTION
# 개요
- 프론트에서 프로필 이미지 업로드 시 AWS S3 에 업로드 할 수 있는 presigned url 을 발급 받아서 프론트에 응답합니다.

# 작업 내용
1. 프론트에서 이미지에 대한 정보인 용량과 파일 확장자를 받아서 S3 presigned url 을 발급 받습니다. 
  - 프론트에서 올리려고 했던 이미지가 아닌 다른 파일을 올리는 것을 방지하기 위한 처리입니다.
2. 프로필 이미지 이름은 UUID v4 로 랜덤으로 생성해서 Member 테이블의 `imageFileName` 컬럼에 저장합니다.
3. 사용자가 프로필 이미지를 이미 업로드 했었다면 기존에 업로드한 파일을 S3 에서 삭제합니다.