### PR TITLE
:sparkles: feat: Implement DELETE /member controller #22

### DIFF
--- a/src/main/java/com/habitpay/habitpay/domain/member/api/MemberApi.java
+++ b/src/main/java/com/habitpay/habitpay/domain/member/api/MemberApi.java
@@ -161,5 +161,23 @@ public class MemberApi {
         return ResponseEntity.status(HttpStatus.OK).body(preSignedUrl);
     }
 
+    @DeleteMapping("/member")
+    @ResponseStatus(HttpStatus.OK)
+    public ResponseEntity<String> deleteMember(@RequestHeader("Authorization") String authorizationHeader) {
+        Optional<String> optionalToken = tokenService.getTokenFromHeader(authorizationHeader);
+        if (optionalToken.isEmpty()) {
+            String message = ErrorResponse.UNAUTHORIZED.getMessage();
+            return ResponseEntity.status(HttpStatus.UNAUTHORIZED).body(message);
+        }
 
+        String token = optionalToken.get();
+        String email = tokenService.getEmail(token);
+        Member member = memberService.findByEmail(email);
+
+        String imageFileName = member.getImageFileName();
+        log.info("[DELETE /member] imageFileName: {}", imageFileName);
+        s3FileService.deleteImage("profiles", imageFileName);
+        memberService.delete(member);
+        return ResponseEntity.status(HttpStatus.OK).body("정상적으로 탈퇴되었습니다.");
+    }
 }

--- a/src/main/java/com/habitpay/habitpay/domain/member/application/MemberService.java
+++ b/src/main/java/com/habitpay/habitpay/domain/member/application/MemberService.java
@@ -24,4 +24,9 @@ public class MemberService {
     public void save(Member member) {
         memberRepository.save(member);
     }
+
+    @Transactional
+    public void delete(Member member) {
+        memberRepository.delete(member);
+    }
 }


### PR DESCRIPTION
# 작업 내용
- DELETE /member 컨트롤러 생성
- 탈퇴하려는 유저가 이미 프로필 이미지를 S3 에 업로드 했다면 삭제하도록 처리