### PR TITLE
feat: 챌린지 생성 컨트롤러 생성 #26

### DIFF
--- a/src/main/java/com/habitpay/habitpay/domain/challenge/api/ChallengeApi.java
+++ b/src/main/java/com/habitpay/habitpay/domain/challenge/api/ChallengeApi.java
@@ -1,0 +1,57 @@
+package com.habitpay.habitpay.domain.challenge.api;
+
+import com.habitpay.habitpay.domain.challenge.application.ChallengeCreateService;
+import com.habitpay.habitpay.domain.challenge.domain.Challenge;
+import com.habitpay.habitpay.domain.challenge.dto.ChallengeRequest;
+import com.habitpay.habitpay.domain.member.application.MemberService;
+import com.habitpay.habitpay.domain.member.domain.Member;
+import com.habitpay.habitpay.global.config.jwt.TokenService;
+import com.habitpay.habitpay.global.error.ErrorResponse;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
+
+import java.util.Optional;
+
+@RestController
+@RequiredArgsConstructor
+@Slf4j
+public class ChallengeApi {
+    private final ChallengeCreateService challengeCreateService;
+    private final MemberService memberService;
+    private final TokenService tokenService;
+
+    @PostMapping("/challenge")
+    @ResponseStatus(HttpStatus.CREATED)
+    public ResponseEntity<?> createChallenge(@RequestBody ChallengeRequest challengeRequest,
+                                             @RequestHeader("Authorization") String authorizationHeader) {
+
+        // TODO: Interceptor 나 Filter 에서 먼저 처리해주기 때문에 나중에 삭제하기
+        Optional<String> optionalToken = tokenService.getTokenFromHeader(authorizationHeader);
+        if (optionalToken.isEmpty()) {
+            String message = ErrorResponse.UNAUTHORIZED.getMessage();
+            return ResponseEntity.status(HttpStatus.UNAUTHORIZED).body(message);
+        }
+
+        String token = optionalToken.get();
+        String email = tokenService.getEmail(token);
+        Member member = memberService.findByEmail(email);
+        log.info("[POST /challenge] email: {}", email);
+
+        Challenge challenge = Challenge.builder()
+                .member(member)
+                .title(challengeRequest.getTitle())
+                .description(challengeRequest.getDescription())
+                .startDate(challengeRequest.getStartDate())
+                .endDate(challengeRequest.getEndDate())
+                .participatingDays(challengeRequest.getParticipatingDays())
+                .feePerAbsence(challengeRequest.getFeePerAbsence())
+                .build();
+
+        challengeCreateService.save(challenge);
+
+        return ResponseEntity.status(HttpStatus.CREATED).body(challenge.getId());
+    }
+}

--- a/src/main/java/com/habitpay/habitpay/domain/challenge/application/ChallengeCreateService.java
+++ b/src/main/java/com/habitpay/habitpay/domain/challenge/application/ChallengeCreateService.java
@@ -1,0 +1,18 @@
+package com.habitpay.habitpay.domain.challenge.application;
+
+import com.habitpay.habitpay.domain.challenge.dao.ChallengeRepository;
+import com.habitpay.habitpay.domain.challenge.domain.Challenge;
+import lombok.AllArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@AllArgsConstructor
+public class ChallengeCreateService {
+    private final ChallengeRepository challengeRepository;
+
+    @Transactional
+    public void save(Challenge challenge) {
+        challengeRepository.save(challenge);
+    }
+}

--- a/src/main/java/com/habitpay/habitpay/domain/challenge/dao/ChallengeRepository.java
+++ b/src/main/java/com/habitpay/habitpay/domain/challenge/dao/ChallengeRepository.java
@@ -1,0 +1,8 @@
+package com.habitpay.habitpay.domain.challenge.dao;
+
+import com.habitpay.habitpay.domain.challenge.domain.Challenge;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface ChallengeRepository extends JpaRepository<Challenge, Long> {
+    
+}

--- a/src/main/java/com/habitpay/habitpay/domain/challenge/domain/Challenge.java
+++ b/src/main/java/com/habitpay/habitpay/domain/challenge/domain/Challenge.java
@@ -1,0 +1,68 @@
+package com.habitpay.habitpay.domain.challenge.domain;
+
+import com.habitpay.habitpay.domain.member.domain.Member;
+import com.habitpay.habitpay.domain.model.BaseTime;
+import jakarta.persistence.*;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+
+import java.time.ZonedDateTime;
+
+@Getter
+@NoArgsConstructor
+@Entity
+@Slf4j
+@Table(name = "challenge")
+public class Challenge extends BaseTime {
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @ManyToOne
+    @JoinColumn(name = "member_id")
+    private Member member;
+
+    @Column(nullable = false)
+    private String title;
+
+    @Column()
+    private String description;
+
+    @Column(nullable = false)
+    private ZonedDateTime startDate;
+
+    @Column(nullable = false)
+    private ZonedDateTime endDate;
+
+    @Column()
+    private ZonedDateTime stopDate;
+
+    @Column(nullable = false)
+    private int numberOfParticipants;
+
+    @Column(nullable = false)
+    private byte participatingDays;
+
+    @Column(nullable = false)
+    private int feePerAbsence;
+
+    @Column(nullable = false)
+    private int totalAbsenceFee;
+
+    @Column(nullable = false)
+    private boolean isPaidAll;
+
+    @Builder
+    public Challenge(Member member, String title, String description, ZonedDateTime startDate, ZonedDateTime endDate,
+                     byte participatingDays, int feePerAbsence) {
+        this.member = member;
+        this.title = title;
+        this.description = description;
+        this.startDate = startDate;
+        this.endDate = endDate;
+        this.participatingDays = participatingDays;
+        this.feePerAbsence = feePerAbsence;
+    }
+}

--- a/src/main/java/com/habitpay/habitpay/domain/challenge/dto/ChallengeRequest.java
+++ b/src/main/java/com/habitpay/habitpay/domain/challenge/dto/ChallengeRequest.java
@@ -1,0 +1,15 @@
+package com.habitpay.habitpay.domain.challenge.dto;
+
+import lombok.Getter;
+
+import java.time.ZonedDateTime;
+
+@Getter
+public class ChallengeRequest {
+    private String title;
+    private String description;
+    private ZonedDateTime startDate;
+    private ZonedDateTime endDate;
+    private byte participatingDays;
+    private int feePerAbsence;
+}


### PR DESCRIPTION
# 작업내용
- 챌린지 생성 컨트롤러를 만들었습니다. (POST /challenge)
- 챌린지 생성 후 프론트에 챌린지의 ID 를 보냅니다. ID 를 이용해서 챌린지 화면으로 이동할 수 있도록 할 예정입니다.