### PR TITLE
Feat/챌린지 조회 컨트롤러 구현#35

### DIFF
--- a/src/main/java/com/habitpay/habitpay/domain/challenge/api/ChallengeApi.java
+++ b/src/main/java/com/habitpay/habitpay/domain/challenge/api/ChallengeApi.java
@@ -1,8 +1,10 @@
 package com.habitpay.habitpay.domain.challenge.api;
 
 import com.habitpay.habitpay.domain.challenge.application.ChallengeCreationService;
+import com.habitpay.habitpay.domain.challenge.application.ChallengeSearchService;
 import com.habitpay.habitpay.domain.challenge.domain.Challenge;
 import com.habitpay.habitpay.domain.challenge.dto.ChallengeCreationRequest;
+import com.habitpay.habitpay.domain.challenge.dto.ChallengeResponse;
 import com.habitpay.habitpay.domain.member.application.MemberService;
 import com.habitpay.habitpay.domain.member.domain.Member;
 import com.habitpay.habitpay.global.config.jwt.TokenService;
@@ -20,6 +22,7 @@ import java.util.Optional;
 @Slf4j
 public class ChallengeApi {
     private final ChallengeCreationService challengeCreationService;
+    private final ChallengeSearchService challengeSearchService;
     private final MemberService memberService;
     private final TokenService tokenService;
 
@@ -37,11 +40,11 @@ public class ChallengeApi {
 
         String token = optionalToken.get();
         String email = tokenService.getEmail(token);
-        Member member = memberService.findByEmail(email);
+        Member host = memberService.findByEmail(email);
         log.info("[POST /challenge] email: {}", email);
 
         Challenge challenge = Challenge.builder()
-                .member(member)
+                .member(host)
                 .title(challengeCreationRequest.getTitle())
                 .description(challengeCreationRequest.getDescription())
                 .startDate(challengeCreationRequest.getStartDate())
@@ -53,5 +56,26 @@ public class ChallengeApi {
         challengeCreationService.save(challenge);
 
         return ResponseEntity.status(HttpStatus.CREATED).body(challenge.getId());
+    }
+
+    @GetMapping("/challenge/{id}")
+    @ResponseStatus(HttpStatus.OK)
+    public ResponseEntity<?> getChallenge(@PathVariable("id") Long id,
+                                          @RequestHeader("Authorization") String authorizationHeader) {
+
+        log.info("[GET /challenge] id: {}", id);
+
+        // TODO: Interceptor 나 Filter 에서 먼저 처리해주기 때문에 나중에 삭제하기
+        Optional<String> optionalToken = tokenService.getTokenFromHeader(authorizationHeader);
+        String token = optionalToken.get();
+        String email = tokenService.getEmail(token);
+        Member host = memberService.findByEmail(email);
+
+        // TODO: 사용자의 Challenge 등록 여부를 확인한 후 return 하기
+
+        Challenge challenge = challengeSearchService.findById(id);
+        ChallengeResponse challengeResponse = new ChallengeResponse(host, challenge);
+
+        return ResponseEntity.status(HttpStatus.OK).body(challengeResponse);
     }
 }

--- a/src/main/java/com/habitpay/habitpay/domain/challenge/api/ChallengeApi.java
+++ b/src/main/java/com/habitpay/habitpay/domain/challenge/api/ChallengeApi.java
@@ -2,7 +2,7 @@ package com.habitpay.habitpay.domain.challenge.api;
 
 import com.habitpay.habitpay.domain.challenge.application.ChallengeCreateService;
 import com.habitpay.habitpay.domain.challenge.domain.Challenge;
-import com.habitpay.habitpay.domain.challenge.dto.ChallengeRequest;
+import com.habitpay.habitpay.domain.challenge.dto.ChallengeCreationRequest;
 import com.habitpay.habitpay.domain.member.application.MemberService;
 import com.habitpay.habitpay.domain.member.domain.Member;
 import com.habitpay.habitpay.global.config.jwt.TokenService;
@@ -25,7 +25,7 @@ public class ChallengeApi {
 
     @PostMapping("/challenge")
     @ResponseStatus(HttpStatus.CREATED)
-    public ResponseEntity<?> createChallenge(@RequestBody ChallengeRequest challengeRequest,
+    public ResponseEntity<?> createChallenge(@RequestBody ChallengeCreationRequest challengeCreationRequest,
                                              @RequestHeader("Authorization") String authorizationHeader) {
 
         // TODO: Interceptor 나 Filter 에서 먼저 처리해주기 때문에 나중에 삭제하기
@@ -42,12 +42,12 @@ public class ChallengeApi {
 
         Challenge challenge = Challenge.builder()
                 .member(member)
-                .title(challengeRequest.getTitle())
-                .description(challengeRequest.getDescription())
-                .startDate(challengeRequest.getStartDate())
-                .endDate(challengeRequest.getEndDate())
-                .participatingDays(challengeRequest.getParticipatingDays())
-                .feePerAbsence(challengeRequest.getFeePerAbsence())
+                .title(challengeCreationRequest.getTitle())
+                .description(challengeCreationRequest.getDescription())
+                .startDate(challengeCreationRequest.getStartDate())
+                .endDate(challengeCreationRequest.getEndDate())
+                .participatingDays(challengeCreationRequest.getParticipatingDays())
+                .feePerAbsence(challengeCreationRequest.getFeePerAbsence())
                 .build();
 
         challengeCreateService.save(challenge);

--- a/src/main/java/com/habitpay/habitpay/domain/challenge/api/ChallengeApi.java
+++ b/src/main/java/com/habitpay/habitpay/domain/challenge/api/ChallengeApi.java
@@ -1,6 +1,6 @@
 package com.habitpay.habitpay.domain.challenge.api;
 
-import com.habitpay.habitpay.domain.challenge.application.ChallengeCreateService;
+import com.habitpay.habitpay.domain.challenge.application.ChallengeCreationService;
 import com.habitpay.habitpay.domain.challenge.domain.Challenge;
 import com.habitpay.habitpay.domain.challenge.dto.ChallengeCreationRequest;
 import com.habitpay.habitpay.domain.member.application.MemberService;
@@ -19,7 +19,7 @@ import java.util.Optional;
 @RequiredArgsConstructor
 @Slf4j
 public class ChallengeApi {
-    private final ChallengeCreateService challengeCreateService;
+    private final ChallengeCreationService challengeCreationService;
     private final MemberService memberService;
     private final TokenService tokenService;
 
@@ -50,7 +50,7 @@ public class ChallengeApi {
                 .feePerAbsence(challengeCreationRequest.getFeePerAbsence())
                 .build();
 
-        challengeCreateService.save(challenge);
+        challengeCreationService.save(challenge);
 
         return ResponseEntity.status(HttpStatus.CREATED).body(challenge.getId());
     }

--- a/src/main/java/com/habitpay/habitpay/domain/challenge/application/ChallengeCreationService.java
+++ b/src/main/java/com/habitpay/habitpay/domain/challenge/application/ChallengeCreationService.java
@@ -8,7 +8,7 @@ import org.springframework.transaction.annotation.Transactional;
 
 @Service
 @AllArgsConstructor
-public class ChallengeCreateService {
+public class ChallengeCreationService {
     private final ChallengeRepository challengeRepository;
 
     @Transactional

--- a/src/main/java/com/habitpay/habitpay/domain/challenge/application/ChallengeSearchService.java
+++ b/src/main/java/com/habitpay/habitpay/domain/challenge/application/ChallengeSearchService.java
@@ -1,0 +1,23 @@
+package com.habitpay.habitpay.domain.challenge.application;
+
+import com.habitpay.habitpay.domain.challenge.dao.ChallengeRepository;
+import com.habitpay.habitpay.domain.challenge.domain.Challenge;
+import lombok.AllArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.Optional;
+
+@Service
+@AllArgsConstructor
+public class ChallengeSearchService {
+    private final ChallengeRepository challengeRepository;
+
+    @Transactional
+    public Challenge findById(Long id) {
+        Optional<Challenge> optionalChallenge = Optional.ofNullable(challengeRepository.findById(id)
+                .orElseThrow(() -> new IllegalArgumentException("존재하는 챌린지가 아닙니다.")));
+
+        return optionalChallenge.get();
+    }
+}

--- a/src/main/java/com/habitpay/habitpay/domain/challenge/domain/Challenge.java
+++ b/src/main/java/com/habitpay/habitpay/domain/challenge/domain/Challenge.java
@@ -22,7 +22,7 @@ public class Challenge extends BaseTime {
 
     @ManyToOne
     @JoinColumn(name = "member_id")
-    private Member member;
+    private Member host;
 
     @Column(nullable = false)
     private String title;
@@ -57,7 +57,7 @@ public class Challenge extends BaseTime {
     @Builder
     public Challenge(Member member, String title, String description, ZonedDateTime startDate, ZonedDateTime endDate,
                      byte participatingDays, int feePerAbsence) {
-        this.member = member;
+        this.host = member;
         this.title = title;
         this.description = description;
         this.startDate = startDate;

--- a/src/main/java/com/habitpay/habitpay/domain/challenge/dto/ChallengeCreationRequest.java
+++ b/src/main/java/com/habitpay/habitpay/domain/challenge/dto/ChallengeCreationRequest.java
@@ -5,7 +5,7 @@ import lombok.Getter;
 import java.time.ZonedDateTime;
 
 @Getter
-public class ChallengeRequest {
+public class ChallengeCreationRequest {
     private String title;
     private String description;
     private ZonedDateTime startDate;

--- a/src/main/java/com/habitpay/habitpay/domain/challenge/dto/ChallengeResponse.java
+++ b/src/main/java/com/habitpay/habitpay/domain/challenge/dto/ChallengeResponse.java
@@ -1,0 +1,30 @@
+package com.habitpay.habitpay.domain.challenge.dto;
+
+import com.habitpay.habitpay.domain.challenge.domain.Challenge;
+import com.habitpay.habitpay.domain.member.domain.Member;
+import lombok.Getter;
+
+import java.time.ZonedDateTime;
+
+@Getter
+public class ChallengeResponse {
+    private String title;
+    private String description;
+    private ZonedDateTime startDate;
+    private ZonedDateTime endDate;
+    private byte participatingDays;
+    private int feePerAbsence;
+    private String hostNickname;
+    private String hostProfileImage;
+
+    public ChallengeResponse(Member host, Challenge challenge) {
+        this.title = challenge.getTitle();
+        this.description = challenge.getDescription();
+        this.startDate = challenge.getStartDate();
+        this.endDate = challenge.getEndDate();
+        this.participatingDays = challenge.getParticipatingDays();
+        this.feePerAbsence = challenge.getFeePerAbsence();
+        this.hostNickname = host.getNickname();
+        this.hostProfileImage = host.getImageFileName();
+    }
+}


### PR DESCRIPTION
# 작업 내용
- GET /challenge/{id} 요청을 보내면 챌린지 정보를 응답하는 컨트롤러를 생성했습니다.
- 응답에 담는 데이터를`ChallengeResponse` 클래스로 생성했습니다.

# 작업 예정
- 챌린지에 참여한 사람만 챌린지에 대한 정보를 확인할 수 있도록 challenge_enrollment 테이블을 확인 후 응답을 보냅니다.
- 챌린지에 참여하는 인원, 챌린지에 참여하는 사용자의 이미지 파일 3개를 추가로 보낼 예정입니다.
- 위의 작업 모두 challenge_enrollment 도메인 생성 후 진행 예정입니다.