### PR TITLE
Feat/챌린지 정보 수정 기능 구현#40

### DIFF
--- a/src/main/java/com/habitpay/habitpay/domain/challenge/domain/Challenge.java
+++ b/src/main/java/com/habitpay/habitpay/domain/challenge/domain/Challenge.java
@@ -65,4 +65,8 @@ public class Challenge extends BaseTime {
         this.participatingDays = participatingDays;
         this.feePerAbsence = feePerAbsence;
     }
+
+    public void updateChallengeDescription(String description) {
+        this.description = description;
+    }
 }

--- a/src/main/java/com/habitpay/habitpay/domain/challenge/dto/ChallengePatchRequest.java
+++ b/src/main/java/com/habitpay/habitpay/domain/challenge/dto/ChallengePatchRequest.java
@@ -1,0 +1,8 @@
+package com.habitpay.habitpay.domain.challenge.dto;
+
+import lombok.Getter;
+
+@Getter
+public class ChallengePatchRequest {
+    private String description;
+}

--- a/src/main/java/com/habitpay/habitpay/global/config/auth/SecurityConfig.java
+++ b/src/main/java/com/habitpay/habitpay/global/config/auth/SecurityConfig.java
@@ -46,7 +46,7 @@ public class SecurityConfig {
                         .sessionCreationPolicy(SessionCreationPolicy.STATELESS))
                 .authorizeHttpRequests((authorizeRequests ->
                         authorizeRequests
-                                .requestMatchers("/*").permitAll() // todo: 보안 상 취약할 수 있으니 범위 제한하기
+                                .requestMatchers("/**").permitAll() // todo: 보안 상 취약할 수 있으니 범위 제한하기
 //                            .requestMatchers("/api/v1/**").hasRole(Role.USER.name()) // todo: 로그인 후 사용하는 api 에서만 적용하기
                                 .anyRequest().authenticated()
                 ))


### PR DESCRIPTION
# 작업 내용
- PATCH /challenge/{id} 컨트롤러를 구현했습니다.
- 챌린지 정보를 수정하기 위한 데이터를 담는 `ChallengePatchRequest` 클래스를 생성했습니다.
  - 현재는 챌린지 설명(description)만 수정 가능하도록 했습니다. 
- `SecurityConfig` 파일에서 Request 의 모든 하위 경로를 받을 수 있도록 * 에서 ** 로 수정했습니다.