### PR TITLE
[Feat] CustomPhotoException 처리를 위한 핸들러 #43

### DIFF
--- a/src/main/java/com/habitpay/habitpay/domain/postPhoto/application/PostPhotoService.java
+++ b/src/main/java/com/habitpay/habitpay/domain/postPhoto/application/PostPhotoService.java
@@ -39,11 +39,11 @@ public class PostPhotoService {
             Long contentLength = photo.getContentLength();
 
             if (!ImageUtil.isValidFileSize(contentLength)) {
-                throw new CustomPhotoException(HttpStatus.PAYLOAD_TOO_LARGE, ErrorResponse.IMAGE_CONTENT_TOO_LARGE, "image no." + photo.getViewOrder());
+                throw new CustomPhotoException(HttpStatus.PAYLOAD_TOO_LARGE, ErrorResponse.IMAGE_CONTENT_TOO_LARGE, " image no." + photo.getViewOrder());
             }
 
             if (!ImageUtil.isValidImageExtension(imageExtension)) {
-                throw new CustomPhotoException(HttpStatus.UNSUPPORTED_MEDIA_TYPE, ErrorResponse.UNSUPPORTED_IMAGE_EXTENSION, "image no." + photo.getViewOrder());
+                throw new CustomPhotoException(HttpStatus.UNSUPPORTED_MEDIA_TYPE, ErrorResponse.UNSUPPORTED_IMAGE_EXTENSION, " image no." + photo.getViewOrder());
             }
 
             String randomFileName = UUID.randomUUID().toString();

--- a/src/main/java/com/habitpay/habitpay/domain/postPhoto/application/PostPhotoService.java
+++ b/src/main/java/com/habitpay/habitpay/domain/postPhoto/application/PostPhotoService.java
@@ -39,11 +39,11 @@ public class PostPhotoService {
             Long contentLength = photo.getContentLength();
 
             if (!ImageUtil.isValidFileSize(contentLength)) {
-                throw new CustomPhotoException(HttpStatus.PAYLOAD_TOO_LARGE, ErrorResponse.IMAGE_CONTENT_TOO_LARGE, " image no." + photo.getViewOrder());
+                throw new CustomPhotoException(HttpStatus.PAYLOAD_TOO_LARGE, ErrorResponse.IMAGE_CONTENT_TOO_LARGE, "image no." + photo.getViewOrder());
             }
 
             if (!ImageUtil.isValidImageExtension(imageExtension)) {
-                throw new CustomPhotoException(HttpStatus.UNSUPPORTED_MEDIA_TYPE, ErrorResponse.UNSUPPORTED_IMAGE_EXTENSION, " image no." + photo.getViewOrder());
+                throw new CustomPhotoException(HttpStatus.UNSUPPORTED_MEDIA_TYPE, ErrorResponse.UNSUPPORTED_IMAGE_EXTENSION, "image no." + photo.getViewOrder());
             }
 
             String randomFileName = UUID.randomUUID().toString();

--- a/src/main/java/com/habitpay/habitpay/global/error/CustomJwtErrorInfo.java
+++ b/src/main/java/com/habitpay/habitpay/global/error/CustomJwtErrorInfo.java
@@ -9,5 +9,5 @@ public enum CustomJwtErrorInfo {
     UNAUTHORIZED("invalid_token"), // 401
     FORBIDDEN("insufficient_scope"); // 403
 
-    private final String errorMessage;
+    private final String Message;
 }

--- a/src/main/java/com/habitpay/habitpay/global/exception/ErrorMessageResponse.java
+++ b/src/main/java/com/habitpay/habitpay/global/exception/ErrorMessageResponse.java
@@ -1,11 +1,11 @@
-package com.habitpay.habitpay.global.exception.JWT;
+package com.habitpay.habitpay.global.exception;
 
 import lombok.AllArgsConstructor;
 import lombok.Getter;
 
 @AllArgsConstructor
 @Getter
-public class ErrorTokenResponse {
+public class ErrorMessageResponse {
     private String error;
     private String errorDescription;
 //    private String errorUri;

--- a/src/main/java/com/habitpay/habitpay/global/exception/JWT/CustomJwtException.java
+++ b/src/main/java/com/habitpay/habitpay/global/exception/JWT/CustomJwtException.java
@@ -9,12 +9,12 @@ public class CustomJwtException extends RuntimeException {
 
     private final HttpStatus statusCode;
     private final CustomJwtErrorInfo customJwtErrorInfo;
-    private final String errorMessage;
+    private final String Message;
 
-    public CustomJwtException(HttpStatus statusCode, CustomJwtErrorInfo customJwtErrorInfo, String errorMessage) {
-        super((customJwtErrorInfo.getErrorMessage()));
+    public CustomJwtException(HttpStatus statusCode, CustomJwtErrorInfo customJwtErrorInfo, String Message) {
+        super((customJwtErrorInfo.getMessage()));
         this.statusCode = statusCode;
         this.customJwtErrorInfo = customJwtErrorInfo;
-        this.errorMessage = errorMessage;
+        this.Message = Message;
     }
 }

--- a/src/main/java/com/habitpay/habitpay/global/handler/GlobalExceptionHandler.java
+++ b/src/main/java/com/habitpay/habitpay/global/handler/GlobalExceptionHandler.java
@@ -2,6 +2,7 @@ package com.habitpay.habitpay.global.handler;
 
 import com.habitpay.habitpay.global.exception.JWT.ErrorTokenResponse;
 import com.habitpay.habitpay.global.exception.JWT.CustomJwtException;
+import com.habitpay.habitpay.global.exception.PostPhoto.CustomPhotoException;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
@@ -18,6 +19,12 @@ public class GlobalExceptionHandler {
                         exception.getCustomJwtErrorInfo().getErrorMessage(),
                         exception.getErrorMessage()
                 ));
+    }
+
+    @ExceptionHandler(CustomPhotoException.class)
+    protected ResponseEntity<String> customPhotoExceptionError(CustomPhotoException exception) {
+        return ResponseEntity.status(exception.getStatusCode())
+                .body(exception.getErrorResponse() + exception.getMessage());
     }
 
     // todo : getMessage() 숨기기?

--- a/src/main/java/com/habitpay/habitpay/global/handler/GlobalExceptionHandler.java
+++ b/src/main/java/com/habitpay/habitpay/global/handler/GlobalExceptionHandler.java
@@ -1,6 +1,6 @@
 package com.habitpay.habitpay.global.handler;
 
-import com.habitpay.habitpay.global.exception.JWT.ErrorTokenResponse;
+import com.habitpay.habitpay.global.exception.ErrorMessageResponse;
 import com.habitpay.habitpay.global.exception.JWT.CustomJwtException;
 import com.habitpay.habitpay.global.exception.PostPhoto.CustomPhotoException;
 import lombok.extern.slf4j.Slf4j;
@@ -13,18 +13,21 @@ import org.springframework.web.bind.annotation.RestControllerAdvice;
 @Slf4j
 public class GlobalExceptionHandler {
     @ExceptionHandler(CustomJwtException.class)
-    protected ResponseEntity<ErrorTokenResponse> customJwtExceptionError(CustomJwtException exception) {
+    protected ResponseEntity<ErrorMessageResponse> customJwtExceptionError(CustomJwtException exception) {
         return ResponseEntity.status(exception.getStatusCode())
-                .body(new ErrorTokenResponse(
-                        exception.getCustomJwtErrorInfo().getErrorMessage(),
-                        exception.getErrorMessage()
+                .body(new ErrorMessageResponse(
+                        exception.getCustomJwtErrorInfo().getMessage(),
+                        exception.getMessage()
                 ));
     }
 
     @ExceptionHandler(CustomPhotoException.class)
-    protected ResponseEntity<String> customPhotoExceptionError(CustomPhotoException exception) {
+    protected ResponseEntity<ErrorMessageResponse> customPhotoExceptionError(CustomPhotoException exception) {
         return ResponseEntity.status(exception.getStatusCode())
-                .body(exception.getErrorResponse() + exception.getMessage());
+                .body(new ErrorMessageResponse(
+                        exception.getErrorResponse().getMessage(),
+                        exception.getMessage()
+                ));
     }
 
     // todo : getMessage() 숨기기?


### PR DESCRIPTION
### `CustomPhotoException`를 처리하는 핸들러를 global controller에 추가

```java
@ExceptionHandler(CustomPhotoException.class)
    protected ResponseEntity<ErrorMessageResponse> customPhotoExceptionError(CustomPhotoException exception) {
        return ResponseEntity.status(exception.getStatusCode())
                .body(new ErrorMessageResponse(
                        exception.getErrorResponse().getMessage(),
                        exception.getMessage()
                ));
    }
```
-----
### 예외 처리 시 응답 본문을 담는 DTO에 소소한 변화

```java
public class ErrorMessageResponse {
    private String error;
    private String errorDescription;
}
```

* `Custom 예외`가 2개 이상이 됨(JWT, Photo)
-> `ResponseEntity`에 들어갈 `응답 DTO`를 여러 `custom 예외`가 같이 사용할 수 있음
-> 이전 JWT 패키지가 아닌, 상위의 Exception 패키지로 새롭게 위치 변경
     : Exception 패키지 하위 어디에서나 사용할 수 있으며, 폴더 구조에서도 그 형태가 드러남
<img width="274" alt="스크린샷 2024-05-23 오후 7 07 42" src="https://github.com/HabitPay/backend/assets/87570646/d6ee47fb-2b0b-42ae-9b7f-49dcae1803d2">

그러면서 이름도 변경 `ErrorTokenResponse` -> `ErrorMessageResponse`
: `token`만을 위한 DTO가 아닌, 모든 `에러 응답`을 위한 DTO가 되었다!

-----
### 기타 작은 리팩토링

* 예외 처리를 다루는 클래스에서 `ErrorMessge`라는 이름을 가진 property를
-> `Message`로 바꿈 (불필요하게 긴 이름이 헷갈림을 유발했기 때문,,)