### PR TITLE
[feat] ChallengePost : 특정 챌린지 내에서 내가 쓴 포스트만 모아보기 기능 #46

### DIFF
--- a/src/main/java/com/habitpay/habitpay/domain/challengePost/api/ChallengePostApi.java
+++ b/src/main/java/com/habitpay/habitpay/domain/challengePost/api/ChallengePostApi.java
@@ -19,6 +19,7 @@ import org.springframework.web.bind.annotation.*;
 import java.security.Principal;
 import java.util.ArrayList;
 import java.util.List;
+import java.util.stream.Collectors;
 
 @RestController
 @RequiredArgsConstructor
@@ -31,31 +32,14 @@ public class ChallengePostApi {
     @GetMapping("/posts/{id}")
     //    @GetMapping("/api/posts/{id}")
     public ResponseEntity<PostViewResponse> findPost(@PathVariable Long id) {
+
         ChallengePost challengePost = challengePostService.findById(id);
         List<PostPhoto> photoList = postPhotoService.findAllByPost(id);
-
-        List<PostPhotoView> photoViewList = new ArrayList<>();
-
-        for (PostPhoto photo : photoList) {
-            photoViewList.add(new PostPhotoView(photo.getViewOrder(), postPhotoService.getImageUrl(photo)));
-        }
+        List<PostPhotoView> photoViewList = postPhotoService.makePhotoViewList(photoList);
 
         return ResponseEntity.ok()
                 .body(new PostViewResponse(challengePost, photoViewList));
     }
-    // todo : test 용도 (auth 필요 없는 컨트롤러)
-//    @GetMapping("/posts/{id}")
-//    public ResponseEntity<String> findPost(@PathVariable("id")String id) {
-//        return ResponseEntity.ok()
-//                .body("Post id : " + id);
-//    }
-//    @GetMapping("/posts")
-//    public ResponseEntity<PostViewResponse> findPost(@RequestParam(value = "id")Long id) {
-//        ChallengePost challengePost = challengePostService.findById(id);
-//
-//        return ResponseEntity.ok()
-//                .body(new PostViewResponse(challengePost));
-//    }
 
     // todo : 한 챌린지 내의 모든 포스트 보기
 //    @GetMapping("/api/challenge/{id}/posts")
@@ -70,43 +54,31 @@ public class ChallengePostApi {
 //    }
 
     // todo : 한 챌린지 내에서 내가 등록한 포스트만 모아보기
+    @GetMapping("/challenge_enrollment/{id}/posts")
 //    @GetMapping("/api/challenge_enrollment/{id}/posts")
-//    public ResponseEntity<List<PostViewResponse>> findChallengeEnrollmentPosts(@PathVariable Long id) {
-//        List<PostViewResponse> posts = challengePostService.findAllByChallengeEnrollment(id)
-//                .stream()
-//                .map(PostViewResponse::new)
-//                .toList();
-//
-//        return ResponseEntity.ok()
-//                .body(posts);
-//    }
+    public ResponseEntity<List<PostViewResponse>> findChallengeEnrollmentPosts(@PathVariable Long id) {
+        List<PostViewResponse> posts = challengePostService.findAllByChallengeEnrollment(id)
+                .stream()
+                // .filter() // todo : isAnnouncement == true 인 건 제외하기
+                .map(post -> new PostViewResponse(post, postPhotoService.makePhotoViewList(postPhotoService.findAllByPost(post.getId()))))
+                .toList();
 
-//    @PostMapping("/api/challenge_enrollment/{id}/post")
-//    public ResponseEntity<ChallengePost> addPost(@RequestBody AddPostRequest request, @PathVariable Long id, Principal principal) {
-//        ChallengePost challengePost = challengePostService.save(request, id);
-//        // todo : principal.getName() 정보 확인 필요 없으면 인자 지우기
-//        System.out.println("Principal: " + principal.getName());
-//
-//        return ResponseEntity.status(HttpStatus.CREATED)
-//                .body(challengePost);
-//    }
+        return ResponseEntity.ok()
+                .body(posts);
+    }
 
-    // todo : 인터셉터 거치치 않는 테스트 용도 컨트롤러 (/api/challenge_enrollment/{id} 경로 없앤 버전)
-    @PostMapping("/post")
-    // public ResponseEntity<ChallengePost> addPost(@RequestBody AddPostRequest request, Principal principal) {
-    public ResponseEntity<List<String>> addPost(@RequestBody AddPostRequest request, Principal principal) {
+    @PostMapping("/challenge_enrollment/{id}/post")
+    //@PostMapping("/api/challenge_enrollment/{id}/post")
+    public ResponseEntity<List<String>> addPost(@RequestBody AddPostRequest request, @PathVariable Long id, Principal principal) {
 
-            // todo : enrollmentId 만들고 난 후 수정하기
-        ChallengePost challengePost = challengePostService.save(request, 1L);
+        ChallengePost challengePost = challengePostService.save(request, id);
 
         // todo : principal.getName() 정보 확인 필요 없으면 인자 지우기
-//        System.out.println("Principal: " + principal.getName());
+        // System.out.println("Principal: " + principal.getName());
 
         List<String> preSignedUrlList = postPhotoService.save(request.getPhotos());
 
-//        return ResponseEntity.status(HttpStatus.CREATED)
-//                .body(challengePost);
-        // todo : postPhoto 저장할 url 링크 보내주기 -> front에서 어떻게 처리되는지?
+        // todo : postPhoto 저장할 url 링크 -> front에서 어떻게 처리되는지?
         return ResponseEntity.status(HttpStatus.CREATED).body(preSignedUrlList);
     }
 

--- a/src/main/java/com/habitpay/habitpay/domain/challengePost/application/ChallengePostService.java
+++ b/src/main/java/com/habitpay/habitpay/domain/challengePost/application/ChallengePostService.java
@@ -11,6 +11,7 @@ import org.springframework.security.core.context.SecurityContextHolder;
 import org.springframework.stereotype.Service;
 
 import java.util.List;
+import java.util.NoSuchElementException;
 
 @Service
 @RequiredArgsConstructor
@@ -23,14 +24,15 @@ public class ChallengePostService {
         return challengePostRepository.save(request.toEntity(challengeEnrollmentId));
     }
 
-    // todo : 각 챌린지 별로 findAll 해주는 메서드 (진행 중)
+    // todo : 각 챌린지 별로 findAll 해주는 메서드 (ChallengeEnrollment 도메인 만들고 거기서 ChallengeId 가져온 뒤에 할 수 있을 듯)
     public List<ChallengePost> findAllByChallenge(Long challengeId) {
         return challengePostRepository.findAll();
     }
 
-    // todo : 각 챌린지 내에서 내가 쓴 포스트만 찾아주는 메서드 (진행 중)
+    // todo : 없는 id를 입력했을 때 예외 던지지 않고 빈 값으로 나와서 뭔가 처리되는 듯. -> 예외 던지기로 고쳐야 함
     public List<ChallengePost> findAllByChallengeEnrollment(Long challengeEnrollmentId) {
-        return challengePostRepository.findAll();
+        return challengePostRepository.findAllByChallengeEnrollmentId(challengeEnrollmentId)
+                .orElseThrow(() -> new NoSuchElementException("(for debugging) not found challengeEnrollmentId : " + challengeEnrollmentId));
     }
 
     public ChallengePost findById(Long id) {

--- a/src/main/java/com/habitpay/habitpay/domain/challengePost/dao/ChallengePostRepository.java
+++ b/src/main/java/com/habitpay/habitpay/domain/challengePost/dao/ChallengePostRepository.java
@@ -2,9 +2,11 @@ package com.habitpay.habitpay.domain.challengePost.dao;
 
 import com.habitpay.habitpay.domain.challengePost.domain.ChallengePost;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.repository.query.Param;
 
+import java.util.List;
 import java.util.Optional;
 
 public interface ChallengePostRepository extends JpaRepository<ChallengePost, Long> {
-    Optional<ChallengePost> findByChallengeEnrollmentId(Long challengeEnrollmentId);
+    Optional<List<ChallengePost>> findAllByChallengeEnrollmentId(Long challengeEnrollmentId);
 }

--- a/src/main/java/com/habitpay/habitpay/domain/challengePost/dto/PostViewResponse.java
+++ b/src/main/java/com/habitpay/habitpay/domain/challengePost/dto/PostViewResponse.java
@@ -7,6 +7,7 @@ import lombok.Getter;
 import lombok.NoArgsConstructor;
 
 import java.time.LocalDateTime;
+import java.util.ArrayList;
 import java.util.List;
 
 @NoArgsConstructor

--- a/src/main/java/com/habitpay/habitpay/domain/postPhoto/application/PostPhotoService.java
+++ b/src/main/java/com/habitpay/habitpay/domain/postPhoto/application/PostPhotoService.java
@@ -1,5 +1,6 @@
 package com.habitpay.habitpay.domain.postPhoto.application;
 
+import com.habitpay.habitpay.domain.challengePost.dto.PostPhotoView;
 import com.habitpay.habitpay.domain.postPhoto.dao.PostPhotoRepository;
 import com.habitpay.habitpay.domain.postPhoto.domain.PostPhoto;
 import com.habitpay.habitpay.domain.postPhoto.dto.PostPhotoData;
@@ -19,6 +20,7 @@ import java.util.ArrayList;
 import java.util.List;
 import java.util.UUID;
 import java.util.function.Consumer;
+import java.util.stream.Collectors;
 
 @RequiredArgsConstructor
 @Service
@@ -32,6 +34,11 @@ public class PostPhotoService {
 
     // todo : @Transaction 적절한지 확인하고 추가 (for 중간에 잘못됐을 경우 모든 걸 없던 걸로 되돌리는?) / 필요 없을지도?
     public List<String> save(List<PostPhotoData> photos) {
+
+        if (photos == null) {
+            return null;
+        }
+
         List<String> urlList = new ArrayList<>();
 
         for (PostPhotoData photo : photos) {
@@ -83,7 +90,24 @@ public class PostPhotoService {
         postPhotoRepository.delete(postPhoto);
     }
 
-    public String getImageUrl(PostPhoto postPhoto) {
+    public List<PostPhotoView> makePhotoViewList(List<PostPhoto> photoList) {
+        List<PostPhotoView> photoViewList = new ArrayList<>();
+
+        // todo : 되나?
+        photoList
+                .stream()
+                .map(photo -> photoViewList.add(new PostPhotoView(photo.getViewOrder(), getImageUrl(photo))))
+                .toList();
+
+        // todo : 위의 stream() 잘 되면 지우기
+//        for (PostPhoto photo : photoList) {
+//            photoViewList.add(new PostPhotoView(photo.getViewOrder(), getImageUrl(photo)));
+//        }
+
+        return photoViewList;
+    }
+
+    private String getImageUrl(PostPhoto postPhoto) {
         return s3FileService.getGetPreSignedUrl(POST_PHOTOS_PREFIX, postPhoto.getImageFileName());
     }
 


### PR DESCRIPTION
* `ChallengePost` 컨트롤러 및 서비스 로직 리팩토링
-----
* `GET /challenge_enrollment/{id}/posts` 메서드 생성

```java
@GetMapping("/challenge_enrollment/{id}/posts")
public ResponseEntity<List<PostViewResponse>> findChallengeEnrollmentPosts(@PathVariable Long id) {
        List<PostViewResponse> posts = challengePostService.findAllByChallengeEnrollment(id)
                .stream()
                .map(post -> new PostViewResponse(post, postPhotoService.makePhotoViewList(postPhotoService.findAllByPost(post.getId()))))
                .toList();

        return ResponseEntity.ok()
                .body(posts);
    }

```
* `challenge_enrollment`는, 특정 챌린지에 등록했을 때 생성되는 entity
-> `challengeEnrollmentId`를 통해, 한 챌린지 내의 나의 행적을 파악할 수 있음
-> 한 챌린지 내에서 내가 쓴 포스트만 모아서 추적 가능

* 위의 메서드는 한 챌린지 내에서 '내 글 모아보기' 기능을 지원
* `challengeEnrollmentId`를 통해 내가 쓴 `포스트 list`를 얻음
   -> 각 `포스트` 별로 해당 포스트에 포함된 `photo list`를 얻음
        (`포스트 + 사진 목록`이 한 묶음으로 `PostViewResponse`가 됨)
   -> 이 `PostViewResponse들`을 `list`화해서 응답 DTO에 담음
   -> 완료!

-----

repository : 쿼리 메서드
```java
Optional<List<ChallengePost>> findAllByChallengeEnrollmentId(Long challengeEnrollmentId);

```
* **쿼리 메서드**
: `find` ... `by` ... => 메서드 이름에 맞춰서 쿼리를 알아서 생성해 실행해준다!
  (고마워 따봉JPA야)

* 인자로 들어온 `challengeEnrollmentId`에 해당하는 모든 데이터 열을 찾아 List로 반환해줌

-----

* 한 챌린지 내의 모든 글을 모아보는 `GET` 컨트롤러는 완성 X
-> 실제로 `ChallengeEnrollment`도메인을 만들어야 가능할 듯
    : 도메인 내의 `ChallengeId`가 필요하기 때문
     => 다음 이슈에서 투 비 컨티뉴,,