### PR TITLE
[feat] PostPhoto에 ChallengePost를 외래키로 연결 #48

### DIFF
--- a/src/main/java/com/habitpay/habitpay/domain/challengePost/api/ChallengePostApi.java
+++ b/src/main/java/com/habitpay/habitpay/domain/challengePost/api/ChallengePostApi.java
@@ -76,9 +76,8 @@ public class ChallengePostApi {
         // todo : principal.getName() 정보 확인 필요 없으면 인자 지우기
         // System.out.println("Principal: " + principal.getName());
 
-        List<String> preSignedUrlList = postPhotoService.save(request.getPhotos());
+        List<String> preSignedUrlList = postPhotoService.save(challengePost, request.getPhotos());
 
-        // todo : postPhoto 저장할 url 링크 -> front에서 어떻게 처리되는지?
         return ResponseEntity.status(HttpStatus.CREATED).body(preSignedUrlList);
     }
 

--- a/src/main/java/com/habitpay/habitpay/domain/postPhoto/application/PostPhotoService.java
+++ b/src/main/java/com/habitpay/habitpay/domain/postPhoto/application/PostPhotoService.java
@@ -1,5 +1,6 @@
 package com.habitpay.habitpay.domain.postPhoto.application;
 
+import com.habitpay.habitpay.domain.challengePost.domain.ChallengePost;
 import com.habitpay.habitpay.domain.challengePost.dto.PostPhotoView;
 import com.habitpay.habitpay.domain.postPhoto.dao.PostPhotoRepository;
 import com.habitpay.habitpay.domain.postPhoto.domain.PostPhoto;
@@ -18,6 +19,7 @@ import org.springframework.stereotype.Service;
 
 import java.util.ArrayList;
 import java.util.List;
+import java.util.NoSuchElementException;
 import java.util.UUID;
 import java.util.function.Consumer;
 import java.util.stream.Collectors;
@@ -33,7 +35,7 @@ public class PostPhotoService {
     public final String POST_PHOTOS_PREFIX = "postPhotos";
 
     // todo : @Transaction 적절한지 확인하고 추가 (for 중간에 잘못됐을 경우 모든 걸 없던 걸로 되돌리는?) / 필요 없을지도?
-    public List<String> save(List<PostPhotoData> photos) {
+    public List<String> save(ChallengePost post, List<PostPhotoData> photos) {
 
         if (photos == null) {
             return null;
@@ -58,7 +60,7 @@ public class PostPhotoService {
             log.info("[save] savedFileName: {}", savedFileName);
 
             postPhotoRepository.save(PostPhoto.builder()
-                    .postId(photo.getPostId())
+                    .post(post)
                     .imageFileName(savedFileName)
                     .viewOrder(photo.getViewOrder())
                     .build());
@@ -73,7 +75,7 @@ public class PostPhotoService {
 
     public PostPhoto findById(Long id) {
         return postPhotoRepository.findById(id)
-                .orElseThrow(() -> new IllegalArgumentException("(for debugging) not found : " + id));
+                .orElseThrow(() -> new NoSuchElementException("(for debugging) not found : " + id));
     }
 
     // todo : post 별로 찾아주는 메서드 (진행 중)
@@ -83,7 +85,7 @@ public class PostPhotoService {
 
     public void delete(Long id) {
         PostPhoto postPhoto = postPhotoRepository.findById(id)
-                .orElseThrow(() -> new IllegalArgumentException("(for debugging) not found : " + id));
+                .orElseThrow(() -> new NoSuchElementException("(for debugging) not found : " + id));
 
         authorizePhotoUploader(postPhoto);
         // todo : aws에서도 이미지 파일 삭제하기
@@ -93,16 +95,10 @@ public class PostPhotoService {
     public List<PostPhotoView> makePhotoViewList(List<PostPhoto> photoList) {
         List<PostPhotoView> photoViewList = new ArrayList<>();
 
-        // todo : 되나?
         photoList
                 .stream()
                 .map(photo -> photoViewList.add(new PostPhotoView(photo.getViewOrder(), getImageUrl(photo))))
                 .toList();
-
-        // todo : 위의 stream() 잘 되면 지우기
-//        for (PostPhoto photo : photoList) {
-//            photoViewList.add(new PostPhotoView(photo.getViewOrder(), getImageUrl(photo)));
-//        }
 
         return photoViewList;
     }

--- a/src/main/java/com/habitpay/habitpay/domain/postPhoto/domain/PostPhoto.java
+++ b/src/main/java/com/habitpay/habitpay/domain/postPhoto/domain/PostPhoto.java
@@ -1,5 +1,6 @@
 package com.habitpay.habitpay.domain.postPhoto.domain;
 
+import com.habitpay.habitpay.domain.challengePost.domain.ChallengePost;
 import com.habitpay.habitpay.domain.member.domain.Member;
 import com.habitpay.habitpay.domain.model.BaseTime;
 import com.habitpay.habitpay.domain.postPhoto.dto.PostPhotoData;
@@ -20,9 +21,9 @@ public class PostPhoto extends BaseTime {
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;
 
-    // todo : challengePost와 외래키 연결
-    @Column(nullable = false)
-    private Long postId;
+    @ManyToOne
+    @JoinColumn
+    private ChallengePost post;
 
     @Column
     private String imageFileName;
@@ -31,8 +32,8 @@ public class PostPhoto extends BaseTime {
     private Long viewOrder;
 
     @Builder
-    public PostPhoto(Long postId, String imageFileName, Long viewOrder) {
-        this.postId = postId;
+    public PostPhoto(ChallengePost post, String imageFileName, Long viewOrder) {
+        this.post = post;
         this.imageFileName = imageFileName;
         this.viewOrder = viewOrder;
     }

--- a/src/main/java/com/habitpay/habitpay/domain/postPhoto/dto/PostPhotoData.java
+++ b/src/main/java/com/habitpay/habitpay/domain/postPhoto/dto/PostPhotoData.java
@@ -4,7 +4,6 @@ import lombok.Getter;
 
 @Getter
 public class PostPhotoData {
-    private Long postId;
     private Long viewOrder;
     private String imageExtension;
     private Long contentLength;


### PR DESCRIPTION
* 해당 이슈 및 브랜치 내용은, 금일 스크럼 때 준한님이 (aws 환경 설정을 도와주시면서 겸사) 알려주신 외래키 연결법 및 같이 진행한 코드 수정을 반영한 것입니다.

`PostPhoto` 엔티티에 챌린지 포스트가 외래키로 연결된 모습
```java
@ManyToOne
@JoinColumn
private ChallengePost post;
```
관련되어있는 DTO 및 메서드를 맞게 수정함

-----

* 별개로, `findById 시리즈 메서드`에서 인자로 받은 id에 해당하는 데이터가 없을 시,
`IllegalArgumentException`가 아닌 `NoSuchElementException`를 던지도록 수정