### PR TITLE
[feat] 챌린지 포스트 내용을 수정하는 PUT 메서드 제작 #45

### DIFF
--- a/src/main/java/com/habitpay/habitpay/domain/challengePost/application/ChallengePostService.java
+++ b/src/main/java/com/habitpay/habitpay/domain/challengePost/application/ChallengePostService.java
@@ -55,7 +55,7 @@ public class ChallengePostService {
                 .orElseThrow(() ->  new IllegalArgumentException("(for debugging) not found : " + id));
 
         authorizePostWriter(challengePost);
-        challengePost.modifyPost(request.getContent(), request.isAnnouncement());
+        challengePost.modifyPost(request.getContent(), request.getIsAnnouncement());
 
         return challengePost;
     }
@@ -63,7 +63,7 @@ public class ChallengePostService {
     // todo : 확인하기
     private static void authorizePostWriter(ChallengePost challengePost) {
         String email = SecurityContextHolder.getContext().getAuthentication().getName();
-        System.out.println("email : " + email);
+        log.info("email : " + email);
 //        if (!challengePost.getWriter().getEmail().equals(email)) {
 //            throw new IllegalArgumentException("(for debug) not authorized");
 //        }

--- a/src/main/java/com/habitpay/habitpay/domain/challengePost/domain/ChallengePost.java
+++ b/src/main/java/com/habitpay/habitpay/domain/challengePost/domain/ChallengePost.java
@@ -37,6 +37,7 @@ public class ChallengePost extends BaseTime {
     }
 
     public void modifyPost(String modifiedContent, boolean isAnnouncement) {
+        // todo : 내용이 바뀌지 않은 경우, 그 사실을 알 수 있다면 밑에 과정 안 해도 되지 않나
         this.content = modifiedContent;
         this.isAnnouncement = isAnnouncement;
     }

--- a/src/main/java/com/habitpay/habitpay/domain/challengePost/dto/AddPostRequest.java
+++ b/src/main/java/com/habitpay/habitpay/domain/challengePost/dto/AddPostRequest.java
@@ -1,8 +1,7 @@
 package com.habitpay.habitpay.domain.challengePost.dto;
 
 import com.habitpay.habitpay.domain.challengePost.domain.ChallengePost;
-import com.habitpay.habitpay.domain.postPhoto.domain.PostPhoto;
-import com.habitpay.habitpay.domain.postPhoto.dto.PostPhotoData;
+import com.habitpay.habitpay.domain.postPhoto.dto.AddPostPhotoData;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
@@ -15,7 +14,7 @@ import java.util.List;
 public class AddPostRequest {
     private String content;
     private boolean isAnnouncement;
-     private List<PostPhotoData> photos;
+    private List<AddPostPhotoData> photos;
 
     public ChallengePost toEntity(Long challengeEnrollmentId) {
         return ChallengePost.builder()

--- a/src/main/java/com/habitpay/habitpay/domain/challengePost/dto/ModifyPostRequest.java
+++ b/src/main/java/com/habitpay/habitpay/domain/challengePost/dto/ModifyPostRequest.java
@@ -1,13 +1,20 @@
 package com.habitpay.habitpay.domain.challengePost.dto;
 
+import com.habitpay.habitpay.domain.postPhoto.dto.AddPostPhotoData;
+import com.habitpay.habitpay.domain.postPhoto.dto.ModifyPostPhotoData;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
+
+import java.util.List;
 
 @AllArgsConstructor
 @NoArgsConstructor
 @Getter
 public class ModifyPostRequest {
     private String content;
-    private boolean isAnnouncement;
+    private Boolean isAnnouncement;
+    private List<AddPostPhotoData> newPhotos;
+    private List<ModifyPostPhotoData> modifiedPhotos;
+    private List<Long> deletedPhotoIds;
 }

--- a/src/main/java/com/habitpay/habitpay/domain/challengePost/dto/PostViewResponse.java
+++ b/src/main/java/com/habitpay/habitpay/domain/challengePost/dto/PostViewResponse.java
@@ -1,13 +1,11 @@
 package com.habitpay.habitpay.domain.challengePost.dto;
 
 import com.habitpay.habitpay.domain.challengePost.domain.ChallengePost;
-import com.habitpay.habitpay.domain.postPhoto.domain.PostPhoto;
-import com.habitpay.habitpay.domain.postPhoto.dto.PostPhotoData;
+import com.habitpay.habitpay.domain.postPhoto.dto.PostPhotoView;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 
 import java.time.LocalDateTime;
-import java.util.ArrayList;
 import java.util.List;
 
 @NoArgsConstructor

--- a/src/main/java/com/habitpay/habitpay/domain/postPhoto/application/PostPhotoService.java
+++ b/src/main/java/com/habitpay/habitpay/domain/postPhoto/application/PostPhotoService.java
@@ -1,10 +1,10 @@
 package com.habitpay.habitpay.domain.postPhoto.application;
 
 import com.habitpay.habitpay.domain.challengePost.domain.ChallengePost;
-import com.habitpay.habitpay.domain.challengePost.dto.PostPhotoView;
+import com.habitpay.habitpay.domain.postPhoto.dto.PostPhotoView;
 import com.habitpay.habitpay.domain.postPhoto.dao.PostPhotoRepository;
 import com.habitpay.habitpay.domain.postPhoto.domain.PostPhoto;
-import com.habitpay.habitpay.domain.postPhoto.dto.PostPhotoData;
+import com.habitpay.habitpay.domain.postPhoto.dto.AddPostPhotoData;
 import com.habitpay.habitpay.global.config.aws.S3FileService;
 import com.habitpay.habitpay.global.error.ErrorResponse;
 import com.habitpay.habitpay.global.exception.PostPhoto.CustomPhotoException;
@@ -13,7 +13,6 @@ import jakarta.transaction.Transactional;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.http.HttpStatus;
-import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.context.SecurityContextHolder;
 import org.springframework.stereotype.Service;
 
@@ -21,8 +20,6 @@ import java.util.ArrayList;
 import java.util.List;
 import java.util.NoSuchElementException;
 import java.util.UUID;
-import java.util.function.Consumer;
-import java.util.stream.Collectors;
 
 @RequiredArgsConstructor
 @Service
@@ -34,8 +31,8 @@ public class PostPhotoService {
 
     public final String POST_PHOTOS_PREFIX = "postPhotos";
 
-    // todo : @Transaction 적절한지 확인하고 추가 (for 중간에 잘못됐을 경우 모든 걸 없던 걸로 되돌리는?) / 필요 없을지도?
-    public List<String> save(ChallengePost post, List<PostPhotoData> photos) {
+    // todo : @Transactional 적절한지 확인하고 추가
+    public List<String> save(ChallengePost post, List<AddPostPhotoData> photos) {
 
         if (photos == null) {
             return null;
@@ -43,30 +40,8 @@ public class PostPhotoService {
 
         List<String> urlList = new ArrayList<>();
 
-        for (PostPhotoData photo : photos) {
-            String imageExtension = photo.getImageExtension();
-            Long contentLength = photo.getContentLength();
-
-            if (!ImageUtil.isValidFileSize(contentLength)) {
-                throw new CustomPhotoException(HttpStatus.PAYLOAD_TOO_LARGE, ErrorResponse.IMAGE_CONTENT_TOO_LARGE, "image no." + photo.getViewOrder());
-            }
-
-            if (!ImageUtil.isValidImageExtension(imageExtension)) {
-                throw new CustomPhotoException(HttpStatus.UNSUPPORTED_MEDIA_TYPE, ErrorResponse.UNSUPPORTED_IMAGE_EXTENSION, "image no." + photo.getViewOrder());
-            }
-
-            String randomFileName = UUID.randomUUID().toString();
-            String savedFileName = String.format("%s.%s", randomFileName, imageExtension);
-            log.info("[save] savedFileName: {}", savedFileName);
-
-            postPhotoRepository.save(PostPhoto.builder()
-                    .post(post)
-                    .imageFileName(savedFileName)
-                    .viewOrder(photo.getViewOrder())
-                    .build());
-
-            String preSignedUrl = s3FileService.getPutPreSignedUrl(POST_PHOTOS_PREFIX, savedFileName, imageExtension, contentLength);
-
+        for (AddPostPhotoData photo : photos) {
+            String preSignedUrl = savePhoto(post, photo);
             urlList.add(preSignedUrl);
         }
 
@@ -78,9 +53,9 @@ public class PostPhotoService {
                 .orElseThrow(() -> new NoSuchElementException("(for debugging) not found : " + id));
     }
 
-    // todo : post 별로 찾아주는 메서드 (진행 중)
-    public List<PostPhoto> findAllByPost(Long postId) {
-        return postPhotoRepository.findAll();
+    public List<PostPhoto> findAllByPost(ChallengePost post) {
+        return postPhotoRepository.findAllByPost(post)
+                .orElseThrow(() -> new NoSuchElementException("(for debugging) not found challenge post : " + post.getId()));
     }
 
     public void delete(Long id) {
@@ -88,19 +63,43 @@ public class PostPhotoService {
                 .orElseThrow(() -> new NoSuchElementException("(for debugging) not found : " + id));
 
         authorizePhotoUploader(postPhoto);
-        // todo : aws에서도 이미지 파일 삭제하기
+
+        s3FileService.deleteImage(POST_PHOTOS_PREFIX, findById(id).getImageFileName());
         postPhotoRepository.delete(postPhoto);
     }
 
     public List<PostPhotoView> makePhotoViewList(List<PostPhoto> photoList) {
         List<PostPhotoView> photoViewList = new ArrayList<>();
 
-        photoList
-                .stream()
-                .map(photo -> photoViewList.add(new PostPhotoView(photo.getViewOrder(), getImageUrl(photo))))
-                .toList();
+        // getImageUrl 메서드를 써야하므로, PostPhotoView에 생성자 만들기 어려움
+        photoList.forEach(photo -> photoViewList.add(new PostPhotoView(photo.getId(), photo.getViewOrder(), getImageUrl(photo))));
 
         return photoViewList;
+    }
+
+    private String savePhoto(ChallengePost post, AddPostPhotoData photo) {
+        String imageExtension = photo.getImageExtension();
+        Long contentLength = photo.getContentLength();
+
+        if (!ImageUtil.isValidFileSize(contentLength)) {
+            throw new CustomPhotoException(HttpStatus.PAYLOAD_TOO_LARGE, ErrorResponse.IMAGE_CONTENT_TOO_LARGE, "image no." + photo.getViewOrder());
+        }
+
+        if (!ImageUtil.isValidImageExtension(imageExtension)) {
+            throw new CustomPhotoException(HttpStatus.UNSUPPORTED_MEDIA_TYPE, ErrorResponse.UNSUPPORTED_IMAGE_EXTENSION, "image no." + photo.getViewOrder());
+        }
+
+        String randomFileName = UUID.randomUUID().toString();
+        String savedFileName = String.format("%s.%s", randomFileName, imageExtension);
+        log.info("[save] savedFileName: {}", savedFileName);
+
+        postPhotoRepository.save(PostPhoto.builder()
+                .post(post)
+                .imageFileName(savedFileName)
+                .viewOrder(photo.getViewOrder())
+                .build());
+
+        return s3FileService.getPutPreSignedUrl(POST_PHOTOS_PREFIX, savedFileName, imageExtension, contentLength);
     }
 
     private String getImageUrl(PostPhoto postPhoto) {
@@ -108,12 +107,15 @@ public class PostPhotoService {
     }
 
     // todo : 사진 순서 데이터 어떻게 오는지 확인하고 작성하기
-//    @Transactional
-//    public PostPhoto changeViewOrder() {}
+    @Transactional
+    public void changeViewOrder(Long photoId, Long newViewOrder) {
+        PostPhoto photo = findById(photoId);
+        photo.changeViewOrder(newViewOrder);
+    }
 
     private static void authorizePhotoUploader(PostPhoto postPhoto) {
         String email = SecurityContextHolder.getContext().getAuthentication().getName();
-        System.out.println("email : " + email);
+        log.info("email : " + email);
 //        if (!postPhoto.getUploader().getEmail().equals(email)) {
 //            throw new IllegalArgumentException("(for debug) not authorized");
 //        }

--- a/src/main/java/com/habitpay/habitpay/domain/postPhoto/dao/PostPhotoRepository.java
+++ b/src/main/java/com/habitpay/habitpay/domain/postPhoto/dao/PostPhotoRepository.java
@@ -1,10 +1,12 @@
 package com.habitpay.habitpay.domain.postPhoto.dao;
 
+import com.habitpay.habitpay.domain.challengePost.domain.ChallengePost;
 import com.habitpay.habitpay.domain.postPhoto.domain.PostPhoto;
 import org.springframework.data.jpa.repository.JpaRepository;
 
+import java.util.List;
 import java.util.Optional;
 
 public interface PostPhotoRepository extends JpaRepository<PostPhoto, Long> {
-    Optional<PostPhoto> findByPostId(Long postId);
+    Optional<List<PostPhoto>> findAllByPost(ChallengePost post);
 }

--- a/src/main/java/com/habitpay/habitpay/domain/postPhoto/domain/PostPhoto.java
+++ b/src/main/java/com/habitpay/habitpay/domain/postPhoto/domain/PostPhoto.java
@@ -1,9 +1,7 @@
 package com.habitpay.habitpay.domain.postPhoto.domain;
 
 import com.habitpay.habitpay.domain.challengePost.domain.ChallengePost;
-import com.habitpay.habitpay.domain.member.domain.Member;
 import com.habitpay.habitpay.domain.model.BaseTime;
-import com.habitpay.habitpay.domain.postPhoto.dto.PostPhotoData;
 import jakarta.persistence.*;
 import lombok.AccessLevel;
 import lombok.Builder;
@@ -39,8 +37,7 @@ public class PostPhoto extends BaseTime {
     }
 
     public void changeViewOrder(Long newOrder) {
-        // todo : 두 사진 객체의 순서가 바뀌는 게 보장되어야 함.
-        // todo : 순서를 숫자로 받지 않고, postPhoto 객체를 받아서 서로 viewOrder 값을 교환하는 방식도 고려
+        // todo : 두 사진 객체의 순서가 바뀌는 게 보장되어야 함. -> 혹시 겹치면 순서 앞선 것부터 나열한다거나,,
         this.viewOrder = newOrder;
     }
 

--- a/src/main/java/com/habitpay/habitpay/domain/postPhoto/dto/AddPostPhotoData.java
+++ b/src/main/java/com/habitpay/habitpay/domain/postPhoto/dto/AddPostPhotoData.java
@@ -1,9 +1,13 @@
 package com.habitpay.habitpay.domain.postPhoto.dto;
 
+import lombok.AllArgsConstructor;
 import lombok.Getter;
+import lombok.NoArgsConstructor;
 
+@AllArgsConstructor
+@NoArgsConstructor
 @Getter
-public class PostPhotoData {
+public class AddPostPhotoData {
     private Long viewOrder;
     private String imageExtension;
     private Long contentLength;

--- a/src/main/java/com/habitpay/habitpay/domain/postPhoto/dto/ModifyPostPhotoData.java
+++ b/src/main/java/com/habitpay/habitpay/domain/postPhoto/dto/ModifyPostPhotoData.java
@@ -1,0 +1,13 @@
+package com.habitpay.habitpay.domain.postPhoto.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@AllArgsConstructor
+@NoArgsConstructor
+@Getter
+public class ModifyPostPhotoData {
+    private Long photoId;
+    private Long viewOrder;
+}

--- a/src/main/java/com/habitpay/habitpay/domain/postPhoto/dto/PostPhotoView.java
+++ b/src/main/java/com/habitpay/habitpay/domain/postPhoto/dto/PostPhotoView.java
@@ -1,4 +1,4 @@
-package com.habitpay.habitpay.domain.challengePost.dto;
+package com.habitpay.habitpay.domain.postPhoto.dto;
 
 import com.habitpay.habitpay.domain.postPhoto.application.PostPhotoService;
 import com.habitpay.habitpay.domain.postPhoto.domain.PostPhoto;
@@ -12,6 +12,7 @@ import lombok.Setter;
 @NoArgsConstructor
 @Getter
 public class PostPhotoView {
+    private Long postPhotoId;
     private Long viewOrder;
     private String imageUrl;
 }

--- a/src/main/java/com/habitpay/habitpay/global/error/CustomJwtErrorInfo.java
+++ b/src/main/java/com/habitpay/habitpay/global/error/CustomJwtErrorInfo.java
@@ -9,5 +9,5 @@ public enum CustomJwtErrorInfo {
     UNAUTHORIZED("invalid_token"), // 401
     FORBIDDEN("insufficient_scope"); // 403
 
-    private final String Message;
+    private final String message;
 }

--- a/src/main/java/com/habitpay/habitpay/global/exception/JWT/CustomJwtException.java
+++ b/src/main/java/com/habitpay/habitpay/global/exception/JWT/CustomJwtException.java
@@ -9,12 +9,12 @@ public class CustomJwtException extends RuntimeException {
 
     private final HttpStatus statusCode;
     private final CustomJwtErrorInfo customJwtErrorInfo;
-    private final String Message;
+    private final String message;
 
     public CustomJwtException(HttpStatus statusCode, CustomJwtErrorInfo customJwtErrorInfo, String Message) {
         super((customJwtErrorInfo.getMessage()));
         this.statusCode = statusCode;
         this.customJwtErrorInfo = customJwtErrorInfo;
-        this.Message = Message;
+        this.message = Message;
     }
 }


### PR DESCRIPTION
* 소소한 리팩토링
-----
* 클래스 내 변수명을 코드 커스텀에 맞게 카멜 케이싱으로 변경
```java
Message -> message
```
-----
### 챌린지 포스트를 수정하는 PUT 메서드 제작 (내용, 이미지 파일 변경 포함)

```java
@PutMapping("/api/posts/{id}")
    public ResponseEntity<List<String>> modifyPost(@PathVariable Long id,
                                                    @RequestBody ModifyPostRequest request) {

        ChallengePost modifiedPost = challengePostService.update(id, request);
        request.getDeletedPhotoIds().forEach(postPhotoService::delete);
        request.getModifiedPhotos().forEach(photo -> postPhotoService.changeViewOrder(photo.getPhotoId(), photo.getViewOrder()));
        List<String> presignedUrlList =  postPhotoService.save(challengePostService.findById(id), request.getNewPhotos());

        return ResponseEntity.ok()
                .body(presignedUrlList);
    }
```
* 챌린지 포스트 수정에는 크게 4가지 변경이 있다고 상정
: 1. 내용(`content`) 변경
  2. 이미지 파일 삭제
  3. 이미지 파일 순서 변경
  4. 새 이미지 파일 추가

* 리턴 타입은 `presignedUrl`(S3에 이미지 등록 위한 링크)을 위한 `문자열 list`입니다.
* 내용, 공지글 여부 변경을 반영하는 `update`
* 삭제할 `PostPhoto`의 `Id list`를 이용해 차례로 삭제하는 `postPhotoService::delete`
* 이미지 정렬 순서인 `ViewOrder`을 변경하는 `changeViewOrder`
* 새로운 이미지를 등록하는 `save`

-----

### 챌린지 포스트 수정 요청 시 받는 DTO

```java
public class ModifyPostRequest {
    private String content;
    private Boolean isAnnouncement;
    private List<AddPostPhotoData> newPhotos;
    private List<ModifyPostPhotoData> modifiedPhotos;
    private List<Long> deletedPhotoIds;
}
```

* 새 이미지 파일을 추가하기 위한 `AddPostPhotoData`는 이전에 있던 것을 재활용
  (새 이미지를 추가할 때 사용하는 데이터라는 의미를 살리기 위해, 앞에 `Add` 접두사를 추가함)
```java
public class AddPostPhotoData {
    private Long viewOrder;
    private String imageExtension;
    private Long contentLength;
}
```

* 이미지 파일 변경을 위한 `ModifyPostPhotoData` DTO
  : 이때 변경은 `ViewOrder` 정렬 순서가 바뀜을 뜻함.
   그 외의 변경은 이미지 파일 삭제 및 추가로 이루어지기 때문.
```java
public class ModifyPostPhotoData {
    private Long photoId;
    private Long viewOrder;
}

...
// 아래 메서드처럼 `photoId`에 새로운 `viewOrder` 데이터만 넣어서 바꿔줄 예정

public void changeViewOrder(Long photoId, Long newViewOrder) {
        PostPhoto photo = findById(photoId);
        photo.changeViewOrder(newViewOrder);
    }
```

* 이미지 파일 삭제는 `photoId`만으로 가능하므로, 삭제할 `Id`를 받기 위해 `List<Long>`으로 받음
```java
 private List<Long> deletedPhotoIds;
```
-----

### 고민한 지점
* 챌린지 포스트 수정 시, 이미지 파일의 변화를 어떤 방식으로 파악하고 처리할 것인지 고민함
* 현재 코드 : `이미지 파일 순서 변경`, `이미지 파일 추가`, `이미지 파일 삭제`를 각각 분리해서 관리하는 형태(각각의 `list` 존재)
   고민했던 다른 방향 : `이미지 파일 순서 변경`과 `이미지 파일 추가`를 하나의 DTO로 관리하기

* 고민했던 방향으로 구현한다면, 다음과 같은 DTO `list`로 관리할 수 있음
```java
// 샘플
public class PostPhotoData {
    private Long photoId;
    private Long viewOrder;
    private String imageExtension;
    private Long contentLength;
}
```
* 그렇다. 원래부터 있던 `AddPostPhotoData`에 `photoId`만 추가한 것.
이 경우, `imageExtension`이 빈값이면 `이미지 파일 순서 변경`만 이루어졌다고 유추할 수 있다.
반대로 `imageExtension`의 값이 있다면 `이미지 파일 추가` 로직을 밟으면 된다. (이때 `photoId`는 빈값일 것임)

* 현재 코드의 장점 : 추가, 변경, 삭제를 각각 다른 프로퍼티로 관리하여 기능적으로 구분 가능
* 고민했던 방향의 장점 : `PostPhotoData`라는 동일한 DTO로 관리하므로, 한 포스트의 이미지 `list`라는 일관성 안에 담겨 관리됨

* 사실 아직도 어떤 게 더 좋은 방향인지 모르겠음
현재 코드를 선택한 큰 이유는, 이미지 순서 변경의 경우 불필요한 `imageExtension` 프로퍼티를 갖고 있어야 하고,
또 이미지 추가를 할 경우 (아직 정해지지도 않은) `photoId`를 빈값으로 들고 있어야 하는 게 뭔가 어색하다고 판단해서였음.
