### PR TITLE
[refact] REST API 네이밍 컨벤션에 맞추어 ChallengePost 컨트롤러 수정하기 #53

### DIFF
--- a/src/main/java/com/habitpay/habitpay/domain/challengePost/api/ChallengePostApi.java
+++ b/src/main/java/com/habitpay/habitpay/domain/challengePost/api/ChallengePostApi.java
@@ -44,7 +44,7 @@ public class ChallengePostApi {
 
     @GetMapping("/api/challenges/{id}/posts")
     public ResponseEntity<List<PostViewResponse>> findChallengePosts(
-            @PathVariable Long id, @RequestParam(required = false, name = "challenge-enrollment-id") Optional<Long> challengeEnrollmentId) {
+            @PathVariable Long id, @RequestParam(required = false) Optional<Long> challengeEnrollmentId) {
 
         Long enrollmentId = challengeEnrollmentId.orElse(-1L);
         List<ChallengePost> challengePosts = new ArrayList<>();

--- a/src/main/java/com/habitpay/habitpay/domain/challengePost/api/ChallengePostApi.java
+++ b/src/main/java/com/habitpay/habitpay/domain/challengePost/api/ChallengePostApi.java
@@ -59,7 +59,7 @@ public class ChallengePostApi {
         viewPosts = challengePosts
                 .stream()
                 .filter(post -> !post.getIsAnnouncement())
-                // .sorted()
+                // .sorted() // todo : id 순이 아닌 다른 순서로 정렬하고 싶을 경우
                 .map(post -> new PostViewResponse(post, postPhotoService.makePhotoViewList(postPhotoService.findAllByPost(post))))
                 .toList();
 
@@ -67,22 +67,21 @@ public class ChallengePostApi {
                 .body(viewPosts);
     }
 
-    @PostMapping("/challenge_enrollment/{id}/post")
-    //@PostMapping("/api/challenge_enrollment/{id}/post")
+    @PostMapping("/api/challenge_enrollment/{id}/post")
     public ResponseEntity<List<String>> addPost(@RequestBody AddPostRequest request, @PathVariable Long id, Principal principal) {
 
+         log.info("Principal Name: {}", principal.getName());
+        // todo : principal.getName() : token의 email 주소
+        //      : API를 '/api/challenges/{id}/post'로 변경하여, 메서드 간 일관성을 유지하고 직관성을 높일 예정
+        //      : [email && challenge id] 정보를 합쳐 enrollment id 찾기만 하면 됨
+
         ChallengePost challengePost = challengePostService.save(request, id);
-
-        // todo : principal.getName() 정보 확인 필요 없으면 인자 지우기
-        // System.out.println("Principal: " + principal.getName());
-
         List<String> preSignedUrlList = postPhotoService.save(challengePost, request.getPhotos());
 
         return ResponseEntity.status(HttpStatus.CREATED).body(preSignedUrlList);
     }
 
-    @PutMapping("/posts/{id}")
-//    @PutMapping("/api/posts/{id}")
+    @PutMapping("/api/posts/{id}")
     public ResponseEntity<List<String>> modifyPost(@PathVariable Long id,
                                                     @RequestBody ModifyPostRequest request) {
 

--- a/src/main/java/com/habitpay/habitpay/domain/challengePost/domain/ChallengePost.java
+++ b/src/main/java/com/habitpay/habitpay/domain/challengePost/domain/ChallengePost.java
@@ -27,7 +27,7 @@ public class ChallengePost extends BaseTime {
     private String content;
 
     @Column(nullable = false)
-    private boolean isAnnouncement;
+    private Boolean isAnnouncement;
 
     @Builder
     public ChallengePost(Long challengeEnrollmentId, String content, boolean isAnnouncement) {

--- a/src/main/java/com/habitpay/habitpay/domain/challengePost/dto/PostViewResponse.java
+++ b/src/main/java/com/habitpay/habitpay/domain/challengePost/dto/PostViewResponse.java
@@ -16,7 +16,7 @@ public class PostViewResponse {
     private Long challengeEnrollmentId;
     private String content;
     private String writer;
-    private boolean isAnnouncement;
+    private Boolean isAnnouncement;
     private LocalDateTime createdAt;
     private List<PostPhotoView> photoViewList;
 
@@ -25,7 +25,7 @@ public class PostViewResponse {
         this.challengeEnrollmentId = post.getChallengeEnrollmentId();
         this.content = post.getContent();
         //todo: this.writer = post.getWriter(post.getChallengeEnrollmentId());
-        this.isAnnouncement = post.isAnnouncement();
+        this.isAnnouncement = post.getIsAnnouncement();
         this.createdAt = post.getCreatedAt();
         this.photoViewList = photoViewList;
     }

--- a/src/main/resources/application-local.yaml
+++ b/src/main/resources/application-local.yaml
@@ -6,12 +6,9 @@ spring:
     hibernate:
       ddl-auto: update
   datasource:
-#    url: jdbc:postgresql://${POSTGRES_HOST}:${POSTGRES_PORT}/${POSTGRES_DB}
-#    username: ${POSTGRES_USER}
-#    password: ${POSTGRES_PASSWORD}
-    url: jdbc:postgresql://localhost:5432/postgres
-    username: postgres
-    password:
+    url: jdbc:postgresql://${POSTGRES_HOST}:${POSTGRES_PORT}/${POSTGRES_DB}
+    username: ${POSTGRES_USER}
+    password: ${POSTGRES_PASSWORD}
   devtools:
     livereload:
       enabled: true

--- a/src/main/resources/application-local.yaml
+++ b/src/main/resources/application-local.yaml
@@ -6,9 +6,12 @@ spring:
     hibernate:
       ddl-auto: update
   datasource:
-    url: jdbc:postgresql://${POSTGRES_HOST}:${POSTGRES_PORT}/${POSTGRES_DB}
-    username: ${POSTGRES_USER}
-    password: ${POSTGRES_PASSWORD}
+#    url: jdbc:postgresql://${POSTGRES_HOST}:${POSTGRES_PORT}/${POSTGRES_DB}
+#    username: ${POSTGRES_USER}
+#    password: ${POSTGRES_PASSWORD}
+    url: jdbc:postgresql://localhost:5432/postgres
+    username: postgres
+    password:
   devtools:
     livereload:
       enabled: true


### PR DESCRIPTION
* 컨벤션 정해지기 전에 작업한 도메인 : `ChallengePost`, `PostPhoto`, `RefreshToken`
* 그 중 API가 있는 도메인 : `ChallengePost`, `RefreshToken`

* `RefreshToken`의 컨트롤러
```java
@PostMapping("/token")
```
뿐이어서 다행히 수정할 게 없었음

-> 결론 : `ChallengePost`만 수정하면 됨

-----

### `ChallengePost` 컨트롤러의 REST API 수정

* 주석처리했던 `/api`를 다시 살림
-> 이제 요청 시 `JWT`를 `Bearer Token`으로 추가해서 보내야 처리됨

```java
//  특정 id의 포스트 불러오기
@GetMapping("/api/posts/{id}")
public ResponseEntity<PostViewResponse> findPost(@PathVariable Long id)

// 특정 챌린지 내 모든 포스트 불러오기
// `?challengeEnrollmentId=` 쿼리 스트링이 있다면, 해당 등록 멤버의 포스트만 불러오기
@GetMapping("/api/challenges/{id}/posts")
public ResponseEntity<List<PostViewResponse>> findChallengePosts(
            @PathVariable Long id,
            @RequestParam(required = false) Optional<Long> challengeEnrollmentId)

// 특정 id의 포스트 수정하기
@PutMapping("/api/posts/{id}")

// 특정 id의 포스트 삭제하기
@DeleteMapping("/api/posts/{id}")
```

* 단독 포스트에 관련된 API는 메서드만 다르고 모두 `/api/posts/{id}`를 사용해서 일관성 높임
* 챌린지 내 모든 포스트 불러오는 기능
    * `/api/challenges/{id}/posts`로 접근 시 챌린지 내 모든 포스트 불러오기
    * `/api/challenges/{id}/posts?challengeEnrollmentId=` 쿼리 스트링 추가해서 접근 시 특정 멤버의 포스트만 불러오기
    (`/api/challenge_enrollment/{id}/posts` 가 없어지고, 위의 메서드가 그 역할까지 담당하게 됨)
=> 바꾼 이유 : `challenge enrollment` 도메인을 `challenge`의 하위 리소스로 보기 애매한 점이 있음.
      오히려 `challenge`에서 `enrollment id` 기준으로 필터링했다는 게 의미상 더 적합한 듯 하여 이렇게 수정함
      고치고 나니 가독성과 일관성이 더 좋아진 듯하여 일단 만족
      (그러나 피드백은 언제든 환영!)
      + `?challengeEnrollmentId=` 쿼리 스트링 말고,
          `/api/challenges/{id}/posts/self` 이런 식으로 자기 것만 불러오기도 가능
                                                                                  (토큰 통해 요청 주체 알 수 있기 때문)
          아니면 `?memberId=` 등으로 특정 멤버의 아이디 받아서 검색도 가능할 듯
             -> 장점 : API 주소에 `challengeEnrollmentId` 데이터를 굳이 안 보여줘도 됨
                                     : 나중에 `enrollment` 도메인 만들고 쓰임새 보면서 다시 정해도 될 듯?
     + `/api/challenge_enrollment/{id}/posts`로 만들어도 되긴 하는데, 그럴 경우 ChallengePost 컨트롤러가 아닌 추후 ChallengeEnrollment 컨트롤러로 옮겨야 모양이 맞을 듯

```java
@PostMapping("/api/challenge_enrollment/{id}/post")
```
포스트 등록 메서드의 경우, 추후 `/api/challenges/{id}/post`로 변경하여 역시 일관성을 높일 예정
현재는 아직 `enrollment 도메인`이 없는데, 생기면 `challenge id`와 `인증 정보`를 이용해 `enrollment id`를 유추할 수 있으므로 그때 수정하고자 함.

-----

* 기타 수정
```java
boolean isAnnouncement; -> Boolean isAnnouncement;
```