### PR TITLE
[feat] 챌린지 포스트 컨트롤러 수정 and 포스트 수정 요청 시 필요한 null 예외 처리 추가 #60

### DIFF
--- a/src/main/java/com/habitpay/habitpay/domain/challengePost/api/ChallengePostApi.java
+++ b/src/main/java/com/habitpay/habitpay/domain/challengePost/api/ChallengePostApi.java
@@ -43,29 +43,54 @@ public class ChallengePostApi {
     }
 
     @GetMapping("/api/challenges/{id}/posts")
-    public ResponseEntity<List<PostViewResponse>> findChallengePosts(
-            @PathVariable Long id, @RequestParam(required = false) Optional<Long> challengeEnrollmentId) {
-
-        Long enrollmentId = challengeEnrollmentId.orElse(-1L);
-        List<ChallengePost> challengePosts = new ArrayList<>();
-        List<PostViewResponse> viewPosts = new ArrayList<>();
-
-        if (enrollmentId.equals(-1L)) {
-             challengePosts = challengePostService.findAllByChallenge(id);
-        } else {
-            challengePosts = challengePostService.findAllByChallengeEnrollment(enrollmentId);
-        }
-
-        viewPosts = challengePosts
+    public ResponseEntity<List<PostViewResponse>> findChallengePosts(@PathVariable Long id) {
+        List<PostViewResponse> challengePostsView = challengePostService.findAllByChallenge(id)
                 .stream()
                 .filter(post -> !post.getIsAnnouncement())
-                // .sorted() // todo : id 순이 아닌 다른 순서로 정렬하고 싶을 경우
+                // .sorted() // todo : 순서 설정하고 싶을 때
                 .map(post -> new PostViewResponse(post, postPhotoService.makePhotoViewList(postPhotoService.findAllByPost(post))))
                 .toList();
 
         return ResponseEntity.ok()
-                .body(viewPosts);
+                .body(challengePostsView);
     }
+
+    @GetMapping("/api/challenges/{id}/posts/me")
+    public ResponseEntity<List<PostViewResponse>> findChallengePostsByMe(
+            @PathVariable Long id, Principal principal) {
+        // todo : principal.getName() : token의 email 주소
+        //      : [email && challenge id] 정보를 합쳐 enrollment id 찾기
+        Long challengeEnrollmentId = 1L; // todo : 임시값
+
+        List<PostViewResponse> challengePostsView = challengePostService.findAllByChallengeEnrollment(challengeEnrollmentId)
+                .stream()
+                .filter(post -> !post.getIsAnnouncement())
+                // .sorted() // todo : 순서 설정하고 싶을 때
+                .map(post -> new PostViewResponse(post, postPhotoService.makePhotoViewList(postPhotoService.findAllByPost(post))))
+                .toList();
+
+        return ResponseEntity.ok()
+                .body(challengePostsView);
+    }
+
+    // todo : 경로 및 필요한 requestParam 설정 완료 후 다시 고치기
+    //      : 'challengeEnrollmentId' or 'memberId' 등 멤버 식별할 수 있는 데이터를 받으면 됨
+//    @GetMapping("/api/challenges/{id}/posts/member")
+//    public ResponseEntity<List<PostViewResponse>> findChallengePostsByMember(
+//            @PathVariable Long id, @RequestParam Optional<Long> challengeEnrollmentId) {
+//
+//        Long challengeEnrollmentId = 1L;
+//
+//        List<PostViewResponse> challengePostsView = challengePostService.findAllByChallengeEnrollment(challengeEnrollmentId)
+//                .stream()
+//                .filter(post -> !post.getIsAnnouncement())
+//                // .sorted() // todo : 순서 설정하고 싶을 때
+//                .map(post -> new PostViewResponse(post, postPhotoService.makePhotoViewList(postPhotoService.findAllByPost(post))))
+//                .toList();
+//
+//        return ResponseEntity.ok()
+//                .body(challengePostsView);
+//    }
 
     @PostMapping("/api/challenge_enrollment/{id}/post")
     public ResponseEntity<List<String>> addPost(@RequestBody AddPostRequest request, @PathVariable Long id, Principal principal) {

--- a/src/main/java/com/habitpay/habitpay/domain/challengePost/application/ChallengePostService.java
+++ b/src/main/java/com/habitpay/habitpay/domain/challengePost/application/ChallengePostService.java
@@ -55,7 +55,12 @@ public class ChallengePostService {
                 .orElseThrow(() ->  new IllegalArgumentException("(for debugging) not found : " + id));
 
         authorizePostWriter(challengePost);
-        challengePost.modifyPost(request.getContent(), request.getIsAnnouncement());
+        if (request.getContent() != null) {
+            challengePost.modifyPostContent(request.getContent());
+        }
+        if (request.getIsAnnouncement() != null) {
+            challengePost.modifyPostIsAnnouncement(request.getIsAnnouncement());
+        }
 
         return challengePost;
     }

--- a/src/main/java/com/habitpay/habitpay/domain/challengePost/domain/ChallengePost.java
+++ b/src/main/java/com/habitpay/habitpay/domain/challengePost/domain/ChallengePost.java
@@ -36,9 +36,11 @@ public class ChallengePost extends BaseTime {
         this.isAnnouncement = isAnnouncement;
     }
 
-    public void modifyPost(String modifiedContent, boolean isAnnouncement) {
-        // todo : 내용이 바뀌지 않은 경우, 그 사실을 알 수 있다면 밑에 과정 안 해도 되지 않나
+    public void modifyPostContent(String modifiedContent) {
         this.content = modifiedContent;
+    }
+
+    public void modifyPostIsAnnouncement(boolean isAnnouncement) {
         this.isAnnouncement = isAnnouncement;
     }
 


### PR DESCRIPTION
* 챌린지 포스트 모아보는 GET 컨트롤러 메서드 수정

```java
// 이전 코드

@GetMapping("/api/challenges/{id}/posts")
    public ResponseEntity<List<PostViewResponse>> findChallengePosts(
            @PathVariable Long id, @RequestParam(required = false) Optional<Long> challengeEnrollmentId) {

// "/api/challenges/{id}/posts"로 들어오면 챌린지 내 모든 포스트 모아보기
// "/api/challenges/{id}/posts?challengeEnrollmentId="로 들어오면, 챌린지 내 해당 멤버의 모든 포스트 모아보기
//                                                  -> enrollment id 통해 '내 글 보기', '특정 멤버 글 보기' 모두 처리
}
```

```java
// 바뀐 코드

@GetMapping("/api/challenges/{id}/posts")
    public ResponseEntity<List<PostViewResponse>> findChallengePosts(@PathVariable Long id) {
// 챌린지 내 모든 글 모아보기
}

...

@GetMapping("/api/challenges/{id}/posts/me")
    public ResponseEntity<List<PostViewResponse>> findChallengePostsByMe(
            @PathVariable Long id, Principal principal) {
// 챌린지 내 내 글 모아보기
}
```

```java
// 추후 추가 작업할 예정인 코드

@GetMapping("/api/challenges/{id}/posts/member")
    public ResponseEntity<List<PostViewResponse>> findChallengePostsByMember { }
// -> 챌린지 내 특정 멤버의 글만 모아보기
// : 특정 멤버의 정보를 어떻게 얻을 것인지 전략 짠 후 작업하기 (member id? enrollment id? 등)
```

* 추후 추가 작업 예정 : `/api/challenges/{id}/posts/me` 경로 메서드에서,
`challengeId`와 `principal` 인증 정보의 `토큰 이메일 정보`를 이용해 `enrollmentId`를 추출하는 코드 추가할 계획
(`enrollmentId`를 통해 토큰 주인의 글만 불러올 수 있음 -> 현재는 임시값을 넣어둔 상태)

-----

* 챌린지 포스트 도메인의 메서드 수정

```java
// 이전 코드

public void modifyPost(String modifiedContent, boolean isAnnouncement) {
        this.content = modifiedContent;
        this.isAnnouncement = isAnnouncement;
    }
// -> 내용과 공지 여부를 한꺼번에 받아 모두 처리
```

```java
// 바뀐 코드

    public void modifyPostContent(String modifiedContent) {
        this.content = modifiedContent;
    }

    public void modifyPostIsAnnouncement(boolean isAnnouncement) {
        this.isAnnouncement = isAnnouncement;
    }
// -> 내용 수정과 공지 여부 수정 메서드로 분리함
```

-----

* 포스트 수정 요청 시 null 예외 처리 추가

```java
// 이전 코드

        challengePost.modifyPost(request.getContent(), request.getIsAnnouncement());

```

```java
// 바뀐 코드

        if (request.getContent() != null) {
            challengePost.modifyPostContent(request.getContent());
        }
        if (request.getIsAnnouncement() != null) {
            challengePost.modifyPostIsAnnouncement(request.getIsAnnouncement());
        }

// -> 내용이나 공지 여부의 수정이 없을 경우 null값이 들어오므로, 해당 예외 처리 추가
```