### PR TITLE
[Feat] 패키지 이름 변경 오류 수정 & proof 도메인 패키지 만들기 #64

### DIFF
--- a/src/main/java/com/habitpay/habitpay/domain/challengepost/api/ChallengePostApi.java
+++ b/src/main/java/com/habitpay/habitpay/domain/challengepost/api/ChallengePostApi.java
@@ -1,11 +1,11 @@
-package com.habitpay.habitpay.domain.challengePost.api;
+package com.habitpay.habitpay.domain.challengepost.api;
 
-import com.habitpay.habitpay.domain.challengePost.application.ChallengePostService;
-import com.habitpay.habitpay.domain.challengePost.domain.ChallengePost;
-import com.habitpay.habitpay.domain.challengePost.dto.AddPostRequest;
-import com.habitpay.habitpay.domain.challengePost.dto.ModifyPostRequest;
+import com.habitpay.habitpay.domain.challengepost.application.ChallengePostService;
+import com.habitpay.habitpay.domain.challengepost.domain.ChallengePost;
+import com.habitpay.habitpay.domain.challengepost.dto.AddPostRequest;
+import com.habitpay.habitpay.domain.challengepost.dto.ModifyPostRequest;
 import com.habitpay.habitpay.domain.postphoto.dto.PostPhotoView;
-import com.habitpay.habitpay.domain.challengePost.dto.PostViewResponse;
+import com.habitpay.habitpay.domain.challengepost.dto.PostViewResponse;
 import com.habitpay.habitpay.domain.postphoto.application.PostPhotoService;
 import com.habitpay.habitpay.domain.postphoto.domain.PostPhoto;
 import lombok.RequiredArgsConstructor;

--- a/src/main/java/com/habitpay/habitpay/domain/challengepost/application/ChallengePostService.java
+++ b/src/main/java/com/habitpay/habitpay/domain/challengepost/application/ChallengePostService.java
@@ -1,9 +1,9 @@
-package com.habitpay.habitpay.domain.challengePost.application;
+package com.habitpay.habitpay.domain.challengepost.application;
 
-import com.habitpay.habitpay.domain.challengePost.dao.ChallengePostRepository;
-import com.habitpay.habitpay.domain.challengePost.domain.ChallengePost;
-import com.habitpay.habitpay.domain.challengePost.dto.AddPostRequest;
-import com.habitpay.habitpay.domain.challengePost.dto.ModifyPostRequest;
+import com.habitpay.habitpay.domain.challengepost.dao.ChallengePostRepository;
+import com.habitpay.habitpay.domain.challengepost.domain.ChallengePost;
+import com.habitpay.habitpay.domain.challengepost.dto.AddPostRequest;
+import com.habitpay.habitpay.domain.challengepost.dto.ModifyPostRequest;
 import jakarta.transaction.Transactional;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;

--- a/src/main/java/com/habitpay/habitpay/domain/challengepost/dao/ChallengePostRepository.java
+++ b/src/main/java/com/habitpay/habitpay/domain/challengepost/dao/ChallengePostRepository.java
@@ -1,6 +1,6 @@
-package com.habitpay.habitpay.domain.challengePost.dao;
+package com.habitpay.habitpay.domain.challengepost.dao;
 
-import com.habitpay.habitpay.domain.challengePost.domain.ChallengePost;
+import com.habitpay.habitpay.domain.challengepost.domain.ChallengePost;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.repository.query.Param;
 

--- a/src/main/java/com/habitpay/habitpay/domain/challengepost/domain/ChallengePost.java
+++ b/src/main/java/com/habitpay/habitpay/domain/challengepost/domain/ChallengePost.java
@@ -1,4 +1,4 @@
-package com.habitpay.habitpay.domain.challengePost.domain;
+package com.habitpay.habitpay.domain.challengepost.domain;
 
 import com.habitpay.habitpay.domain.member.domain.Member;
 import com.habitpay.habitpay.domain.model.BaseTime;

--- a/src/main/java/com/habitpay/habitpay/domain/challengepost/dto/AddPostRequest.java
+++ b/src/main/java/com/habitpay/habitpay/domain/challengepost/dto/AddPostRequest.java
@@ -1,6 +1,6 @@
-package com.habitpay.habitpay.domain.challengePost.dto;
+package com.habitpay.habitpay.domain.challengepost.dto;
 
-import com.habitpay.habitpay.domain.challengePost.domain.ChallengePost;
+import com.habitpay.habitpay.domain.challengepost.domain.ChallengePost;
 import com.habitpay.habitpay.domain.postphoto.dto.AddPostPhotoData;
 import lombok.AllArgsConstructor;
 import lombok.Getter;

--- a/src/main/java/com/habitpay/habitpay/domain/challengepost/dto/ModifyPostRequest.java
+++ b/src/main/java/com/habitpay/habitpay/domain/challengepost/dto/ModifyPostRequest.java
@@ -1,4 +1,4 @@
-package com.habitpay.habitpay.domain.challengePost.dto;
+package com.habitpay.habitpay.domain.challengepost.dto;
 
 import com.habitpay.habitpay.domain.postphoto.dto.AddPostPhotoData;
 import com.habitpay.habitpay.domain.postphoto.dto.ModifyPostPhotoData;

--- a/src/main/java/com/habitpay/habitpay/domain/challengepost/dto/PostViewResponse.java
+++ b/src/main/java/com/habitpay/habitpay/domain/challengepost/dto/PostViewResponse.java
@@ -1,6 +1,6 @@
-package com.habitpay.habitpay.domain.challengePost.dto;
+package com.habitpay.habitpay.domain.challengepost.dto;
 
-import com.habitpay.habitpay.domain.challengePost.domain.ChallengePost;
+import com.habitpay.habitpay.domain.challengepost.domain.ChallengePost;
 import com.habitpay.habitpay.domain.postphoto.dto.PostPhotoView;
 import lombok.Getter;
 import lombok.NoArgsConstructor;

--- a/src/main/java/com/habitpay/habitpay/domain/postphoto/application/PostPhotoService.java
+++ b/src/main/java/com/habitpay/habitpay/domain/postphoto/application/PostPhotoService.java
@@ -1,13 +1,13 @@
-package com.habitpay.habitpay.domain.postPhoto.application;
+package com.habitpay.habitpay.domain.postphoto.application;
 
-import com.habitpay.habitpay.domain.challengePost.domain.ChallengePost;
-import com.habitpay.habitpay.domain.postPhoto.dto.PostPhotoView;
-import com.habitpay.habitpay.domain.postPhoto.dao.PostPhotoRepository;
-import com.habitpay.habitpay.domain.postPhoto.domain.PostPhoto;
-import com.habitpay.habitpay.domain.postPhoto.dto.AddPostPhotoData;
+import com.habitpay.habitpay.domain.challengepost.domain.ChallengePost;
+import com.habitpay.habitpay.domain.postphoto.dto.PostPhotoView;
+import com.habitpay.habitpay.domain.postphoto.dao.PostPhotoRepository;
+import com.habitpay.habitpay.domain.postphoto.domain.PostPhoto;
+import com.habitpay.habitpay.domain.postphoto.dto.AddPostPhotoData;
 import com.habitpay.habitpay.global.config.aws.S3FileService;
 import com.habitpay.habitpay.global.error.ErrorResponse;
-import com.habitpay.habitpay.domain.postPhoto.exception.CustomPhotoException;
+import com.habitpay.habitpay.domain.postphoto.exception.CustomPhotoException;
 import com.habitpay.habitpay.global.util.ImageUtil;
 import jakarta.transaction.Transactional;
 import lombok.RequiredArgsConstructor;

--- a/src/main/java/com/habitpay/habitpay/domain/postphoto/dao/PostPhotoRepository.java
+++ b/src/main/java/com/habitpay/habitpay/domain/postphoto/dao/PostPhotoRepository.java
@@ -1,7 +1,7 @@
-package com.habitpay.habitpay.domain.postPhoto.dao;
+package com.habitpay.habitpay.domain.postphoto.dao;
 
-import com.habitpay.habitpay.domain.challengePost.domain.ChallengePost;
-import com.habitpay.habitpay.domain.postPhoto.domain.PostPhoto;
+import com.habitpay.habitpay.domain.challengepost.domain.ChallengePost;
+import com.habitpay.habitpay.domain.postphoto.domain.PostPhoto;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 import java.util.List;

--- a/src/main/java/com/habitpay/habitpay/domain/postphoto/domain/PostPhoto.java
+++ b/src/main/java/com/habitpay/habitpay/domain/postphoto/domain/PostPhoto.java
@@ -1,6 +1,6 @@
-package com.habitpay.habitpay.domain.postPhoto.domain;
+package com.habitpay.habitpay.domain.postphoto.domain;
 
-import com.habitpay.habitpay.domain.challengePost.domain.ChallengePost;
+import com.habitpay.habitpay.domain.challengepost.domain.ChallengePost;
 import com.habitpay.habitpay.domain.model.BaseTime;
 import jakarta.persistence.*;
 import lombok.AccessLevel;

--- a/src/main/java/com/habitpay/habitpay/domain/postphoto/dto/AddPostPhotoData.java
+++ b/src/main/java/com/habitpay/habitpay/domain/postphoto/dto/AddPostPhotoData.java
@@ -1,4 +1,4 @@
-package com.habitpay.habitpay.domain.postPhoto.dto;
+package com.habitpay.habitpay.domain.postphoto.dto;
 
 import lombok.AllArgsConstructor;
 import lombok.Getter;

--- a/src/main/java/com/habitpay/habitpay/domain/postphoto/dto/ModifyPostPhotoData.java
+++ b/src/main/java/com/habitpay/habitpay/domain/postphoto/dto/ModifyPostPhotoData.java
@@ -1,4 +1,4 @@
-package com.habitpay.habitpay.domain.postPhoto.dto;
+package com.habitpay.habitpay.domain.postphoto.dto;
 
 import lombok.AllArgsConstructor;
 import lombok.Getter;

--- a/src/main/java/com/habitpay/habitpay/domain/postphoto/dto/PostPhotoView.java
+++ b/src/main/java/com/habitpay/habitpay/domain/postphoto/dto/PostPhotoView.java
@@ -1,7 +1,7 @@
-package com.habitpay.habitpay.domain.postPhoto.dto;
+package com.habitpay.habitpay.domain.postphoto.dto;
 
-import com.habitpay.habitpay.domain.postPhoto.application.PostPhotoService;
-import com.habitpay.habitpay.domain.postPhoto.domain.PostPhoto;
+import com.habitpay.habitpay.domain.postphoto.application.PostPhotoService;
+import com.habitpay.habitpay.domain.postphoto.domain.PostPhoto;
 import com.habitpay.habitpay.global.config.aws.S3FileService;
 import lombok.AllArgsConstructor;
 import lombok.Getter;

--- a/src/main/java/com/habitpay/habitpay/domain/postphoto/exception/CustomPhotoException.java
+++ b/src/main/java/com/habitpay/habitpay/domain/postphoto/exception/CustomPhotoException.java
@@ -1,4 +1,4 @@
-package com.habitpay.habitpay.domain.postPhoto.exception;
+package com.habitpay.habitpay.domain.postphoto.exception;
 
 import com.habitpay.habitpay.global.error.ErrorResponse;
 import lombok.Getter;

--- a/src/main/java/com/habitpay/habitpay/domain/proof/dao/ProofRepository.java
+++ b/src/main/java/com/habitpay/habitpay/domain/proof/dao/ProofRepository.java
@@ -1,0 +1,8 @@
+package com.habitpay.habitpay.domain.proof.dao;
+
+import com.habitpay.habitpay.domain.proof.domain.Proof;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface ProofRepository extends JpaRepository<Proof, Long> {
+
+}

--- a/src/main/java/com/habitpay/habitpay/domain/proof/domain/Proof.java
+++ b/src/main/java/com/habitpay/habitpay/domain/proof/domain/Proof.java
@@ -1,0 +1,38 @@
+package com.habitpay.habitpay.domain.proof.domain;
+
+import com.habitpay.habitpay.domain.challengepost.domain.ChallengePost;
+import jakarta.persistence.*;
+import lombok.AccessLevel;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import org.springframework.data.annotation.CreatedDate;
+import org.springframework.data.jpa.domain.support.AuditingEntityListener;
+
+import java.time.LocalDateTime;
+
+@EntityListeners(AuditingEntityListener.class)
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@Getter
+@Entity
+@Table(name = "proof")
+public class Proof {
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    // todo : enrollment 도메인 적용하기
+//    @ManyToOne
+//    @JoinColumn
+//    private ChallengeEnrollment enrollment;
+
+    @OneToOne
+    @JoinColumn
+    private ChallengePost post;
+
+    @CreatedDate
+    private LocalDateTime createdAt;
+
+//    @Builder
+//    public Proof() {}
+}

--- a/src/main/java/com/habitpay/habitpay/domain/refreshtoken/api/TokenApiController.java
+++ b/src/main/java/com/habitpay/habitpay/domain/refreshtoken/api/TokenApiController.java
@@ -1,12 +1,12 @@
-package com.habitpay.habitpay.domain.refreshToken.api;
+package com.habitpay.habitpay.domain.refreshtoken.api;
 
-import com.habitpay.habitpay.domain.refreshToken.application.NewTokenService;
-import com.habitpay.habitpay.domain.refreshToken.application.RefreshTokenService;
-import com.habitpay.habitpay.domain.refreshToken.dto.CreateAccessTokenRequest;
-import com.habitpay.habitpay.domain.refreshToken.dto.CreateAccessTokenResponse;
+import com.habitpay.habitpay.domain.refreshtoken.application.NewTokenService;
+import com.habitpay.habitpay.domain.refreshtoken.application.RefreshTokenService;
+import com.habitpay.habitpay.domain.refreshtoken.dto.CreateAccessTokenRequest;
+import com.habitpay.habitpay.domain.refreshtoken.dto.CreateAccessTokenResponse;
 import com.habitpay.habitpay.global.config.jwt.TokenService;
 import com.habitpay.habitpay.global.error.CustomJwtErrorInfo;
-import com.habitpay.habitpay.domain.refreshToken.exception.CustomJwtException;
+import com.habitpay.habitpay.domain.refreshtoken.exception.CustomJwtException;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.http.HttpStatus;

--- a/src/main/java/com/habitpay/habitpay/domain/refreshtoken/application/NewTokenService.java
+++ b/src/main/java/com/habitpay/habitpay/domain/refreshtoken/application/NewTokenService.java
@@ -1,10 +1,10 @@
-package com.habitpay.habitpay.domain.refreshToken.application;
+package com.habitpay.habitpay.domain.refreshtoken.application;
 
 import com.habitpay.habitpay.domain.member.application.MemberService;
 import com.habitpay.habitpay.domain.member.domain.Member;
 import com.habitpay.habitpay.global.config.jwt.TokenProvider;
 import com.habitpay.habitpay.global.error.CustomJwtErrorInfo;
-import com.habitpay.habitpay.domain.refreshToken.exception.CustomJwtException;
+import com.habitpay.habitpay.domain.refreshtoken.exception.CustomJwtException;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.http.HttpStatus;

--- a/src/main/java/com/habitpay/habitpay/domain/refreshtoken/application/RefreshTokenService.java
+++ b/src/main/java/com/habitpay/habitpay/domain/refreshtoken/application/RefreshTokenService.java
@@ -1,9 +1,9 @@
-package com.habitpay.habitpay.domain.refreshToken.application;
+package com.habitpay.habitpay.domain.refreshtoken.application;
 
 import com.habitpay.habitpay.domain.member.application.MemberService;
 import com.habitpay.habitpay.domain.member.domain.Member;
-import com.habitpay.habitpay.domain.refreshToken.dao.RefreshTokenRepository;
-import com.habitpay.habitpay.domain.refreshToken.domain.RefreshToken;
+import com.habitpay.habitpay.domain.refreshtoken.dao.RefreshTokenRepository;
+import com.habitpay.habitpay.domain.refreshtoken.domain.RefreshToken;
 import com.habitpay.habitpay.global.config.jwt.TokenService;
 import com.habitpay.habitpay.global.util.CookieUtil;
 import jakarta.servlet.http.HttpServletRequest;

--- a/src/main/java/com/habitpay/habitpay/domain/refreshtoken/dao/RefreshTokenRepository.java
+++ b/src/main/java/com/habitpay/habitpay/domain/refreshtoken/dao/RefreshTokenRepository.java
@@ -1,6 +1,6 @@
-package com.habitpay.habitpay.domain.refreshToken.dao;
+package com.habitpay.habitpay.domain.refreshtoken.dao;
 
-import com.habitpay.habitpay.domain.refreshToken.domain.RefreshToken;
+import com.habitpay.habitpay.domain.refreshtoken.domain.RefreshToken;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 import java.util.Optional;

--- a/src/main/java/com/habitpay/habitpay/domain/refreshtoken/domain/RefreshToken.java
+++ b/src/main/java/com/habitpay/habitpay/domain/refreshtoken/domain/RefreshToken.java
@@ -1,4 +1,4 @@
-package com.habitpay.habitpay.domain.refreshToken.domain;
+package com.habitpay.habitpay.domain.refreshtoken.domain;
 
 import com.habitpay.habitpay.domain.model.BaseTime;
 import jakarta.persistence.*;

--- a/src/main/java/com/habitpay/habitpay/domain/refreshtoken/dto/CreateAccessTokenRequest.java
+++ b/src/main/java/com/habitpay/habitpay/domain/refreshtoken/dto/CreateAccessTokenRequest.java
@@ -1,4 +1,4 @@
-package com.habitpay.habitpay.domain.refreshToken.dto;
+package com.habitpay.habitpay.domain.refreshtoken.dto;
 
 import lombok.Getter;
 import lombok.Setter;

--- a/src/main/java/com/habitpay/habitpay/domain/refreshtoken/dto/CreateAccessTokenResponse.java
+++ b/src/main/java/com/habitpay/habitpay/domain/refreshtoken/dto/CreateAccessTokenResponse.java
@@ -1,4 +1,4 @@
-package com.habitpay.habitpay.domain.refreshToken.dto;
+package com.habitpay.habitpay.domain.refreshtoken.dto;
 
 import lombok.AllArgsConstructor;
 import lombok.Getter;

--- a/src/main/java/com/habitpay/habitpay/domain/refreshtoken/exception/CustomJwtException.java
+++ b/src/main/java/com/habitpay/habitpay/domain/refreshtoken/exception/CustomJwtException.java
@@ -1,4 +1,4 @@
-package com.habitpay.habitpay.domain.refreshToken.exception;
+package com.habitpay.habitpay.domain.refreshtoken.exception;
 
 import com.habitpay.habitpay.global.error.CustomJwtErrorInfo;
 import lombok.Getter;


### PR DESCRIPTION
* #63 이슈에서 패키지 이름을 모두 소문자로 변경했으나, 각 파일 상단의 `package 경로`와 `import 경로`는 수정되지 않은 것을 발견해 고침

* 패키지 이름 변경 : intelliJ의 `refactor -> rename` 기능 사용
* `rename` 시 설정 : [`comments`와 `strings`에서도 찾아 바꾸겠다]는 옵션을 선택하지 않았음 (일반 변수명도 바뀌면 안 되니까,,)
* import 등의 경로도 알아서 바꿔주는 줄 알았으나 아니었음
* Proof 도메인 만들며 클래스 참조가 제대로 안 되는 현상을 뒤늦게 발견하고 고침,,

-----

* `Proof` 도메인을 위한 패키지를 만들고, `entity` 및 `repository` 기본 틀로만 파일 만듦
* 일단 도메인 이름을 `Proof`로 한 이유
: 원안인 `Participation`은 챌린지 자체에 참여한다는 의미로도 읽힐 수 있음
  -> 그 경우 `Enrollment`와 겹쳐 혼동될 수 있음
  -> 챌린지 내 과제에 참여했고 미션 성공으로 인정 받았다는 '증거'의 의미로 `proof` 채택

* 그러나 언제나 더 적절하고 좋은 이름이 있다면 바꿀 의향이 있습니다,,!