### PR TITLE
:sparkles: feat: 챌린지 참여 도메인 생성 및 챌린지 참여 컨트롤러 구현  #58

### DIFF
--- a/src/main/java/com/habitpay/habitpay/domain/challengeenrollment/api/ChallengeEnrollmentApi.java
+++ b/src/main/java/com/habitpay/habitpay/domain/challengeenrollment/api/ChallengeEnrollmentApi.java
@@ -1,0 +1,42 @@
+package com.habitpay.habitpay.domain.challengeenrollment.api;
+
+import com.habitpay.habitpay.domain.challengeenrollment.application.ChallengeEnrollmentService;
+import com.habitpay.habitpay.domain.member.application.MemberService;
+import com.habitpay.habitpay.domain.member.domain.Member;
+import com.habitpay.habitpay.global.config.jwt.TokenService;
+import com.habitpay.habitpay.global.error.ErrorResponse;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
+
+import java.util.Optional;
+
+@Slf4j
+@RestController
+@RequiredArgsConstructor
+public class ChallengeEnrollmentApi {
+    private final MemberService memberService;
+    private final TokenService tokenService;
+    private final ChallengeEnrollmentService challengeEnrollmentService;
+
+    @PostMapping("/challenges/{id}/enroll")
+    @ResponseStatus(HttpStatus.OK)
+    public ResponseEntity<?> enrollChallenge(@PathVariable("id") Long id, @RequestHeader("Authorization") String authorizationHeader) {
+
+        // TODO: Interceptor 나 Filter 에서 먼저 처리해주기 때문에 나중에 삭제하기
+        Optional<String> optionalToken = tokenService.getTokenFromHeader(authorizationHeader);
+        if (optionalToken.isEmpty()) {
+            String message = ErrorResponse.UNAUTHORIZED.getMessage();
+            return ResponseEntity.status(HttpStatus.UNAUTHORIZED).body(message);
+        }
+
+        String token = optionalToken.get();
+        String email = tokenService.getEmail(token);
+        Member member = memberService.findByEmail(email);
+        log.info("[POST /challenges/{}/enroll] email: {}", id, email);
+        return challengeEnrollmentService.enroll(id, member);
+    }
+
+}

--- a/src/main/java/com/habitpay/habitpay/domain/challengeenrollment/application/ChallengeEnrollmentService.java
+++ b/src/main/java/com/habitpay/habitpay/domain/challengeenrollment/application/ChallengeEnrollmentService.java
@@ -1,0 +1,51 @@
+package com.habitpay.habitpay.domain.challengeenrollment.application;
+
+import com.habitpay.habitpay.domain.challenge.application.ChallengeSearchService;
+import com.habitpay.habitpay.domain.challenge.domain.Challenge;
+import com.habitpay.habitpay.domain.challengeenrollment.dao.ChallengeEnrollmentRepository;
+import com.habitpay.habitpay.domain.challengeenrollment.domain.ChallengeEnrollment;
+import com.habitpay.habitpay.domain.member.domain.Member;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.stereotype.Service;
+
+import java.time.ZonedDateTime;
+import java.util.Optional;
+
+@Slf4j
+@Service
+@RequiredArgsConstructor
+public class ChallengeEnrollmentService {
+    private final ChallengeEnrollmentRepository challengeEnrollmentRepository;
+    private final ChallengeSearchService challengeSearchService;
+
+    public ResponseEntity<String> enroll(Long id, Member member) {
+        Challenge challenge = challengeSearchService.findById(id);
+        ZonedDateTime now = ZonedDateTime.now();
+
+
+        if (now.isAfter(challenge.getEndDate())) {
+            log.error("챌린지 등록 기간 초과");
+            return ResponseEntity.status(HttpStatus.BAD_REQUEST).body("챌린지 등록 기간이 지났습니다.");
+        }
+
+        Optional<ChallengeEnrollment> optionalChallengeEnrollment = challengeEnrollmentRepository.findByMember(member);
+
+        if (optionalChallengeEnrollment.isPresent()) {
+            log.error("이미 참여한 챌린지");
+            return ResponseEntity.status(HttpStatus.BAD_REQUEST).body("이미 참여한 챌린지입니다.");
+        }
+
+        ChallengeEnrollment challengeEnrollment = ChallengeEnrollment.builder()
+                .member(member)
+                .challenge(challenge)
+                .enrolledDate(now)
+                .build();
+
+        challengeEnrollmentRepository.save(challengeEnrollment);
+        log.info("챌린지 참여 완료");
+        return ResponseEntity.status(HttpStatus.OK).body("챌린지에 정상적으로 참여했습니다.");
+    }
+}

--- a/src/main/java/com/habitpay/habitpay/domain/challengeenrollment/dao/ChallengeEnrollmentRepository.java
+++ b/src/main/java/com/habitpay/habitpay/domain/challengeenrollment/dao/ChallengeEnrollmentRepository.java
@@ -1,0 +1,11 @@
+package com.habitpay.habitpay.domain.challengeenrollment.dao;
+
+import com.habitpay.habitpay.domain.challengeenrollment.domain.ChallengeEnrollment;
+import com.habitpay.habitpay.domain.member.domain.Member;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.Optional;
+
+public interface ChallengeEnrollmentRepository extends JpaRepository<ChallengeEnrollment, Long> {
+    Optional<ChallengeEnrollment> findByMember(Member member);
+}

--- a/src/main/java/com/habitpay/habitpay/domain/challengeenrollment/domain/ChallengeEnrollment.java
+++ b/src/main/java/com/habitpay/habitpay/domain/challengeenrollment/domain/ChallengeEnrollment.java
@@ -1,0 +1,57 @@
+package com.habitpay.habitpay.domain.challengeenrollment.domain;
+
+import com.habitpay.habitpay.domain.challenge.domain.Challenge;
+import com.habitpay.habitpay.domain.member.domain.Member;
+import jakarta.persistence.*;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.time.ZonedDateTime;
+
+@Getter
+@NoArgsConstructor
+@Entity
+@Table(name = "challenge_enrollment")
+public class ChallengeEnrollment {
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @ManyToOne
+    @JoinColumn(name = "challenge_id")
+    private Challenge challenge;
+
+    @ManyToOne
+    @JoinColumn(name = "member_id")
+    private Member member;
+
+    @Column(nullable = false)
+    private boolean isGivenUp;
+
+    @Column(nullable = false)
+    private ZonedDateTime enrolledDate;
+
+    @Column()
+    private ZonedDateTime givenUpDate;
+
+    @Column(nullable = false)
+    private int successCount;
+
+    @Column(nullable = false)
+    private int failureCount;
+
+    @Column(nullable = false)
+    private int totalFee;
+
+    @Builder
+    public ChallengeEnrollment(Challenge challenge, Member member, ZonedDateTime enrolledDate) {
+        this.challenge = challenge;
+        this.member = member;
+        this.isGivenUp = false;
+        this.enrolledDate = enrolledDate;
+        this.successCount = 0;
+        this.failureCount = 0;
+        this.totalFee = 0;
+    }
+}


### PR DESCRIPTION
# 작업 내용
- 사용자의 챌린지 참여를 위한 `challengeEnrollment` 도메인을 생성했습니다.
- POST `/challenges/{id}/enroll` 컨트롤러에서 사용자의 챌린지 참여를 받을 수 있도록 구현했습니다.

# 기타

## Q1. 사용자의 정보를 request header 가 아닌 다른 방법을 통해 가져올 수 있을까?

현재는 컨트롤러에서 `@RequestHeader` 어노테이션을 통해 authorization header 에 포함된 jwt 토큰에서 사용자의 이메일을 획득합니다.
하지만 모든 컨트롤러에서 동일한 코드를 반복하는 것은 비효율적인 것 같아서 filter 나 interceptor 에서 사용자 정보를 먼저 등록하고, 컨트롤러나 서비스에서는 등록한 정보를 가져오는 방식으로 구현하는 것이 가능할 지 찾아보고 있습니다.

## Q2. 컨트롤러의 반환 값을 ResponseEntity<?> 가 아닌 명확한 자료형을 쓰는 게 좋지 않을까?

컨트롤러의 반환 값을 무엇이든 돌려줄 수 있도록 `<?>` 을 이용했습니다.
하지만 명확한 반환 값을 정의하는 것이 코드를 한 번에 이해하기 좋고, 유지보수 측면에서도 좋을 것 같다는 생각이 들었습니다.
그래서 `ApiResponse` 와 같은 클래스를 이용해서 공통된 response 규격을 정의하고, 각 도메인에서 필요한 응답은 `ApiResponse` 클래스를 상속 받아서 새롭게 생성하는 것은 어떨지 생각하고 있습니다. 