### PR TITLE
[feat] 포스트 삭제 시 내부 이미지 파일도 완전히 삭제하기 #67

### DIFF
--- a/src/main/java/com/habitpay/habitpay/domain/challengepost/application/ChallengePostService.java
+++ b/src/main/java/com/habitpay/habitpay/domain/challengepost/application/ChallengePostService.java
@@ -4,6 +4,7 @@ import com.habitpay.habitpay.domain.challengepost.dao.ChallengePostRepository;
 import com.habitpay.habitpay.domain.challengepost.domain.ChallengePost;
 import com.habitpay.habitpay.domain.challengepost.dto.AddPostRequest;
 import com.habitpay.habitpay.domain.challengepost.dto.ModifyPostRequest;
+import com.habitpay.habitpay.domain.postphoto.application.PostPhotoService;
 import jakarta.transaction.Transactional;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
@@ -19,6 +20,7 @@ import java.util.NoSuchElementException;
 public class ChallengePostService {
 
     private final ChallengePostRepository challengePostRepository;
+    private final PostPhotoService postPhotoService;
 
     public ChallengePost save(AddPostRequest request, Long challengeEnrollmentId) {
         return challengePostRepository.save(request.toEntity(challengeEnrollmentId));
@@ -46,6 +48,7 @@ public class ChallengePostService {
                 .orElseThrow(() -> new IllegalArgumentException("(for debugging) not found : " + id));
 
         authorizePostWriter(challengePost); // todo : method 미완
+        postPhotoService.deleteAllByPost(challengePost);
         challengePostRepository.delete(challengePost);
     }
 

--- a/src/main/java/com/habitpay/habitpay/domain/postphoto/application/PostPhotoService.java
+++ b/src/main/java/com/habitpay/habitpay/domain/postphoto/application/PostPhotoService.java
@@ -70,6 +70,13 @@ public class PostPhotoService {
         postPhotoRepository.delete(postPhoto);
     }
 
+    public void deleteAllByPost(ChallengePost post) {
+        List<PostPhoto> photoList = postPhotoRepository.findAllByPost(post)
+                .orElseThrow(() -> new NoSuchElementException("(for debugging) not found post : " + post.getId()));
+
+        photoList.forEach(photo -> {delete(photo.getId());});
+    }
+
     public List<PostPhotoView> makePhotoViewList(List<PostPhoto> photoList) {
         List<PostPhotoView> photoViewList = new ArrayList<>();
 


### PR DESCRIPTION
* 이전 코드 : 포스트 삭제 시, 포스트의 이미지 파일이 `DB`에서는 삭제되나 `AWS S3` 상에는 남아있는 상태
* (이미지 파일 **개별** 삭제 메서드는 `DB`, `S3`에 삭제 여부를 모두 반영했음
* but 포스트 삭제 시 포스트에 포함되는 이미지 파일 삭제는 `DB`에만 반영되있던 상태)

-----

* 바뀐 코드 : 포스트 삭제 시, 내부 이미지 파일이 `DB`에서뿐만 아니라 `AWS S3`에서도 삭제 되도록 코드 수정

```java
public void deleteAllByPost(ChallengePost post) {
        List<PostPhoto> photoList = postPhotoRepository.findAllByPost(post)
                .orElseThrow(() -> new NoSuchElementException("(for debugging) not found post : " + post.getId()));

        photoList.forEach(photo -> {delete(photo.getId());});
    }
```
* 포스트 기준으로 모든 이미지 파일 목록을 `List<PostPhoto>`로 받고, 해당 `List`를 순회하며 한 장씩 `개별 삭제 메서드` 적용함