### PR TITLE
[feat] 도메인 수정 : Proof -> ChallengeParticipationRecord #73

### DIFF
--- a/src/main/java/com/habitpay/habitpay/domain/challengeparticipationrecord/dao/ChallengeParticipationRecordRepository.java
+++ b/src/main/java/com/habitpay/habitpay/domain/challengeparticipationrecord/dao/ChallengeParticipationRecordRepository.java
@@ -1,0 +1,8 @@
+package com.habitpay.habitpay.domain.challengeparticipationrecord.dao;
+
+import com.habitpay.habitpay.domain.challengeparticipationrecord.domain.ChallengeParticipationRecord;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface ChallengeParticipationRecordRepository extends JpaRepository<ChallengeParticipationRecord, Long> {
+
+}

--- a/src/main/java/com/habitpay/habitpay/domain/challengeparticipationrecord/domain/ChallengeParticipationRecord.java
+++ b/src/main/java/com/habitpay/habitpay/domain/challengeparticipationrecord/domain/ChallengeParticipationRecord.java
@@ -1,22 +1,19 @@
-package com.habitpay.habitpay.domain.proof.domain;
+package com.habitpay.habitpay.domain.challengeparticipationrecord.domain;
 
 import com.habitpay.habitpay.domain.challengepost.domain.ChallengePost;
+import com.habitpay.habitpay.domain.model.BaseTime;
 import jakarta.persistence.*;
 import lombok.AccessLevel;
-import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
-import org.springframework.data.annotation.CreatedDate;
 import org.springframework.data.jpa.domain.support.AuditingEntityListener;
-
-import java.time.LocalDateTime;
 
 @EntityListeners(AuditingEntityListener.class)
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 @Getter
 @Entity
-@Table(name = "proof")
-public class Proof {
+@Table(name = "challenge_participation_record")
+public class ChallengeParticipationRecord extends BaseTime {
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;
@@ -30,9 +27,6 @@ public class Proof {
     @JoinColumn
     private ChallengePost post;
 
-    @CreatedDate
-    private LocalDateTime createdAt;
-
 //    @Builder
-//    public Proof() {}
+//    public ChallengeParticipationRecord() {}
 }

--- a/src/main/java/com/habitpay/habitpay/domain/proof/dao/ProofRepository.java
+++ b/src/main/java/com/habitpay/habitpay/domain/proof/dao/ProofRepository.java
@@ -1,8 +1,0 @@
-package com.habitpay.habitpay.domain.proof.dao;
-
-import com.habitpay.habitpay.domain.proof.domain.Proof;
-import org.springframework.data.jpa.repository.JpaRepository;
-
-public interface ProofRepository extends JpaRepository<Proof, Long> {
-
-}


### PR DESCRIPTION
* 도메인 이름 변경
: 의미가 더 명확한 이름으로 변경되었습니다.
```java
Proof -> ChallengeParticipationRecord
```

* `ChallengeParticipationRecord`가 자체 지역 변수 `createdAt`을 사용하는 대신, `BaseTime`을 상속 받아 `createdAt` 요소를 사용합니다.
```java
public class ChallengeParticipationRecord extends BaseTime { }
```

-----

* 이야기해보고 싶은 것
* `ChallengeParticipationRecord`은 도메인 특성 상, 생성만 가능하고 변경이나 삭제는 불가능하다는 원칙을 세웠습니다.
그래서 `createdAt` 요소만 필요하다고 판단, 처음에는 생성 일시만 도메인 내 지역 변수로 설정했습니다.
그러나 코멘트 해주신 것에 따라 이미 만든 걸 재사용하는 게 일리가 있다고 판단해 이번 풀리퀘에서 `BaseTime`을 상속받는 방식으로 수정했는데요,
막상 고치고 보니, 사용하지 않을 `BaseTime`의 `modifiedAt`, `deletedAt`이 마음에 걸립니다ㅠㅠ.
상속 받은 부모 클래스의 특정 요소를 사용하지 못하도록 막는 기능이 있나 검색해봤으나 짧은 시간 내에 찾지는 못했고,,
이게 상속을 제대로 사용하고 있는 것인지 확신이 안 들고,, (이건 제가 정말 잘 모르기 때문에)
그럼에도 `BaseTime`을 상속 받아서 사용하는 게 더 유용할 것인지 한 번 더 고견을 여쭙고 싶습니다.
(이번에도 동일한 코멘트 받으면 바로 머지하려고 합니다.)