### PR TITLE
Feat/챌린지 정보 조회 컨트롤러 수정#75

### DIFF
--- a/src/main/java/com/habitpay/habitpay/domain/challenge/api/ChallengeApi.java
+++ b/src/main/java/com/habitpay/habitpay/domain/challenge/api/ChallengeApi.java
@@ -6,6 +6,9 @@ import com.habitpay.habitpay.domain.challenge.domain.Challenge;
 import com.habitpay.habitpay.domain.challenge.dto.ChallengeCreationRequest;
 import com.habitpay.habitpay.domain.challenge.dto.ChallengePatchRequest;
 import com.habitpay.habitpay.domain.challenge.dto.ChallengeResponse;
+import com.habitpay.habitpay.domain.challengeenrollment.application.ChallengeEnrollmentSearchService;
+import com.habitpay.habitpay.domain.challengeenrollment.application.ChallengeEnrollmentService;
+import com.habitpay.habitpay.domain.challengeenrollment.domain.ChallengeEnrollment;
 import com.habitpay.habitpay.domain.member.application.MemberService;
 import com.habitpay.habitpay.domain.member.domain.Member;
 import com.habitpay.habitpay.global.config.jwt.TokenService;
@@ -24,26 +27,29 @@ import java.util.Optional;
 public class ChallengeApi {
     private final ChallengeCreationService challengeCreationService;
     private final ChallengeSearchService challengeSearchService;
+    private final ChallengeEnrollmentService challengeEnrollmentService;
+    private final ChallengeEnrollmentSearchService challengeEnrollmentSearchService;
     private final MemberService memberService;
     private final TokenService tokenService;
 
-    @GetMapping("/challenge/{id}")
+    @GetMapping("/challenges/{id}")
     @ResponseStatus(HttpStatus.OK)
     public ResponseEntity<?> getChallenge(@PathVariable("id") Long id,
                                           @RequestHeader("Authorization") String authorizationHeader) {
 
-        log.info("[GET /challenge/{}]", id);
+        log.info("[GET /challenges/{}]", id);
 
         // TODO: Interceptor 나 Filter 에서 먼저 처리해주기 때문에 나중에 삭제하기
         Optional<String> optionalToken = tokenService.getTokenFromHeader(authorizationHeader);
         String token = optionalToken.get();
         String email = tokenService.getEmail(token);
-        Member host = memberService.findByEmail(email);
+        Member member = memberService.findByEmail(email);
 
         // TODO: 사용자의 Challenge 등록 여부를 확인한 후 return 하기
 
         Challenge challenge = challengeSearchService.findById(id);
-        ChallengeResponse challengeResponse = new ChallengeResponse(host, challenge);
+        Optional<ChallengeEnrollment> optionalChallengeEnrollment = challengeEnrollmentSearchService.findByMember(member);
+        ChallengeResponse challengeResponse = new ChallengeResponse(member, challenge, optionalChallengeEnrollment);
 
         return ResponseEntity.status(HttpStatus.OK).body(challengeResponse);
     }

--- a/src/main/java/com/habitpay/habitpay/domain/challenge/dto/ChallengeResponse.java
+++ b/src/main/java/com/habitpay/habitpay/domain/challenge/dto/ChallengeResponse.java
@@ -1,10 +1,12 @@
 package com.habitpay.habitpay.domain.challenge.dto;
 
 import com.habitpay.habitpay.domain.challenge.domain.Challenge;
+import com.habitpay.habitpay.domain.challengeenrollment.domain.ChallengeEnrollment;
 import com.habitpay.habitpay.domain.member.domain.Member;
 import lombok.Getter;
 
 import java.time.ZonedDateTime;
+import java.util.Optional;
 
 @Getter
 public class ChallengeResponse {
@@ -17,16 +19,23 @@ public class ChallengeResponse {
     private String hostNickname;
     private String hostProfileImage;
     private Boolean isHost;
+    private Boolean isEnrolledMember;
 
-    public ChallengeResponse(Member host, Challenge challenge) {
+    public ChallengeResponse(Member member, Challenge challenge, Optional<ChallengeEnrollment> optionalChallengeEnrollment) {
         this.title = challenge.getTitle();
         this.description = challenge.getDescription();
         this.startDate = challenge.getStartDate();
         this.endDate = challenge.getEndDate();
         this.participatingDays = challenge.getParticipatingDays();
         this.feePerAbsence = challenge.getFeePerAbsence();
-        this.hostNickname = host.getNickname();
-        this.hostProfileImage = host.getImageFileName();
-        this.isHost = challenge.getHost().getEmail().equals(host.getEmail());
+        this.hostNickname = member.getNickname();
+        this.hostProfileImage = member.getImageFileName();
+        this.isHost = challenge.getHost().getEmail().equals(member.getEmail());
+        if (optionalChallengeEnrollment.isEmpty()) {
+            this.isEnrolledMember = false;
+        } else {
+            ChallengeEnrollment challengeEnrollment = optionalChallengeEnrollment.get();
+            this.isEnrolledMember = challengeEnrollment.getChallenge().getId().equals(challenge.getId());
+        }
     }
 }

--- a/src/main/java/com/habitpay/habitpay/domain/challengeenrollment/application/ChallengeEnrollmentSearchService.java
+++ b/src/main/java/com/habitpay/habitpay/domain/challengeenrollment/application/ChallengeEnrollmentSearchService.java
@@ -1,0 +1,19 @@
+package com.habitpay.habitpay.domain.challengeenrollment.application;
+
+import com.habitpay.habitpay.domain.challengeenrollment.dao.ChallengeEnrollmentRepository;
+import com.habitpay.habitpay.domain.challengeenrollment.domain.ChallengeEnrollment;
+import com.habitpay.habitpay.domain.member.domain.Member;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+import java.util.Optional;
+
+@Service
+@RequiredArgsConstructor
+public class ChallengeEnrollmentSearchService {
+    private final ChallengeEnrollmentRepository challengeEnrollmentRepository;
+
+    public Optional<ChallengeEnrollment> findByMember(Member member) {
+        return challengeEnrollmentRepository.findByMember(member);
+    }
+}


### PR DESCRIPTION
# 작업 내용

## 1. 챌린지 정보 조회 컨트롤러 수정

프론트에서 사용자가 챌린지 참여했는지 판단하기 위해 `isEnrolledMember` 멤버변수를 `ChallengeResponse` DTO 에 추가했습니다.

```diff
@Getter
public class ChallengeResponse {
    private String title;
    private String description;
    private ZonedDateTime startDate;
    private ZonedDateTime endDate;
    private byte participatingDays;
    private int feePerAbsence;
    private String hostNickname;
    private String hostProfileImage;
    private Boolean isHost;
+   private Boolean isEnrolledMember;
}
```

해당 변수는 Challenge 에 참여한 여부인 ChallengeEnrollment 가 존재하는지 확인한 후 값을 결정합니다.

```java
if (optionalChallengeEnrollment.isEmpty()) {
    this.isEnrolledMember = false;
} else {
    ChallengeEnrollment challengeEnrollment = optionalChallengeEnrollment.get();
    this.isEnrolledMember = challengeEnrollment.getChallenge().getId().equals(challenge.getId());
}
```

### 고려했던 부분 

ChallengeEnrollment 객체를 찾기 위해 `ChallengeEnrollmentRepository` 를 의존성 주입할 때 별도의 서비스를 생성해서 찾도록 했습니다.

```java
@Service
@RequiredArgsConstructor
public class ChallengeEnrollmentSearchService {
    private final ChallengeEnrollmentRepository challengeEnrollmentRepository;

    public Optional<ChallengeEnrollment> findByMember(Member member) {
        return challengeEnrollmentRepository.findByMember(member);
    }
}
```

현재는 컨트롤러와 서비스 로직이 분리되지 않은 상태인데, 컨트롤러에서 Repository 를 직접 사용하는 것보다 서비스 계층을 분리하는 것이 역할을 구분하기 좋을 것 같다고 생각했습니다.

## 2. 컨트롤러 이름 복수형 변경

기존에 단수형으로 작성했던 GET `/challenge/{id}` 을 GET `/challenges/{id}` 로 변경했습니다.
```diff
-  @GetMapping("/challenge/{id}")
+  @GetMapping("/challenges/{id}")
```