### PR TITLE
Refactor/챌린지 컨트롤러 서비스 로직 분리#77

### DIFF
--- a/src/main/java/com/habitpay/habitpay/domain/challenge/api/ChallengeApi.java
+++ b/src/main/java/com/habitpay/habitpay/domain/challenge/api/ChallengeApi.java
@@ -2,15 +2,11 @@ package com.habitpay.habitpay.domain.challenge.api;
 
 import com.habitpay.habitpay.domain.challenge.application.ChallengeCreationService;
 import com.habitpay.habitpay.domain.challenge.application.ChallengeDetailService;
-import com.habitpay.habitpay.domain.challenge.application.ChallengeSearchService;
-import com.habitpay.habitpay.domain.challenge.domain.Challenge;
+import com.habitpay.habitpay.domain.challenge.application.ChallengeUpdateService;
 import com.habitpay.habitpay.domain.challenge.dto.ChallengeCreationRequest;
 import com.habitpay.habitpay.domain.challenge.dto.ChallengePatchRequest;
 import com.habitpay.habitpay.domain.challenge.dto.ChallengeResponse;
-import com.habitpay.habitpay.domain.member.application.MemberService;
-import com.habitpay.habitpay.domain.member.domain.Member;
 import com.habitpay.habitpay.global.common.response.ApiResponse;
-import com.habitpay.habitpay.global.config.jwt.TokenService;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.http.HttpStatus;
@@ -18,17 +14,13 @@ import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.*;
 
-import java.util.Optional;
-
 @RestController
 @RequiredArgsConstructor
 @Slf4j
 public class ChallengeApi {
     private final ChallengeCreationService challengeCreationService;
-    private final ChallengeSearchService challengeSearchService;
+    private final ChallengeUpdateService challengeUpdateService;
     private final ChallengeDetailService challengeDetailService;
-    private final MemberService memberService;
-    private final TokenService tokenService;
 
     @GetMapping("/challenges/{id}")
     @ResponseStatus(HttpStatus.OK)
@@ -48,24 +40,9 @@ public class ChallengeApi {
 
     @PatchMapping("/challenges/{id}")
     @ResponseStatus(HttpStatus.OK)
-    public ResponseEntity<?> patchChallengeDetails(@PathVariable("id") Long id, @RequestBody ChallengePatchRequest challengePatchRequest,
-                                                   @RequestHeader("Authorization") String authorizationHeader) {
-        log.info("[PATCH /challenges/{}]", id);
-
-        Optional<String> optionalToken = tokenService.getTokenFromHeader(authorizationHeader);
-        String token = optionalToken.get();
-        String email = tokenService.getEmail(token);
-        Member member = memberService.findByEmail(email);
-        Challenge challenge = challengeSearchService.findById(id);
-
-        if (member.getEmail().equals(challenge.getHost().getEmail()) == false) {
-            return ResponseEntity.status(HttpStatus.UNAUTHORIZED).body("챌린지 수정 권한이 없습니다.");
-        }
-
-        challenge.updateChallengeDescription(challengePatchRequest.getDescription());
-        // TODO: update 로 변경하기
-//        challengeCreationService.save(challenge);
-
-        return ResponseEntity.status(HttpStatus.OK).body("챌린지 정보 수정이 반영되었습니다.");
+    public ResponseEntity<ApiResponse> patchChallengeDetails(@PathVariable("id") Long id, @RequestBody ChallengePatchRequest challengePatchRequest,
+                                                             @AuthenticationPrincipal String email) {
+        log.info("[PATCH /challenges/{}]: email {}", id, email);
+        return challengeUpdateService.update(id, challengePatchRequest, email);
     }
 }

--- a/src/main/java/com/habitpay/habitpay/domain/challenge/api/ChallengeApi.java
+++ b/src/main/java/com/habitpay/habitpay/domain/challenge/api/ChallengeApi.java
@@ -54,7 +54,7 @@ public class ChallengeApi {
         return ResponseEntity.status(HttpStatus.OK).body(challengeResponse);
     }
 
-    @PostMapping("/challenge")
+    @PostMapping("/challenges")
     @ResponseStatus(HttpStatus.CREATED)
     public ResponseEntity<?> createChallenge(@RequestBody ChallengeCreationRequest challengeCreationRequest,
                                              @RequestHeader("Authorization") String authorizationHeader) {
@@ -69,7 +69,7 @@ public class ChallengeApi {
         String token = optionalToken.get();
         String email = tokenService.getEmail(token);
         Member host = memberService.findByEmail(email);
-        log.info("[POST /challenge] email: {}", email);
+        log.info("[POST /challenges] email: {}", email);
 
         Challenge challenge = Challenge.builder()
                 .member(host)
@@ -86,11 +86,11 @@ public class ChallengeApi {
         return ResponseEntity.status(HttpStatus.CREATED).body(challenge.getId());
     }
 
-    @PatchMapping("/challenge/{id}")
+    @PatchMapping("/challenges/{id}")
     @ResponseStatus(HttpStatus.OK)
     public ResponseEntity<?> patchChallengeDetails(@PathVariable("id") Long id, @RequestBody ChallengePatchRequest challengePatchRequest,
                                                    @RequestHeader("Authorization") String authorizationHeader) {
-        log.info("[PATCH /challenge/{}]", id);
+        log.info("[PATCH /challenges/{}]", id);
 
         Optional<String> optionalToken = tokenService.getTokenFromHeader(authorizationHeader);
         String token = optionalToken.get();

--- a/src/main/java/com/habitpay/habitpay/domain/challenge/api/ChallengeApi.java
+++ b/src/main/java/com/habitpay/habitpay/domain/challenge/api/ChallengeApi.java
@@ -1,14 +1,12 @@
 package com.habitpay.habitpay.domain.challenge.api;
 
 import com.habitpay.habitpay.domain.challenge.application.ChallengeCreationService;
+import com.habitpay.habitpay.domain.challenge.application.ChallengeDetailService;
 import com.habitpay.habitpay.domain.challenge.application.ChallengeSearchService;
 import com.habitpay.habitpay.domain.challenge.domain.Challenge;
 import com.habitpay.habitpay.domain.challenge.dto.ChallengeCreationRequest;
 import com.habitpay.habitpay.domain.challenge.dto.ChallengePatchRequest;
 import com.habitpay.habitpay.domain.challenge.dto.ChallengeResponse;
-import com.habitpay.habitpay.domain.challengeenrollment.application.ChallengeEnrollmentSearchService;
-import com.habitpay.habitpay.domain.challengeenrollment.application.ChallengeEnrollmentService;
-import com.habitpay.habitpay.domain.challengeenrollment.domain.ChallengeEnrollment;
 import com.habitpay.habitpay.domain.member.application.MemberService;
 import com.habitpay.habitpay.domain.member.domain.Member;
 import com.habitpay.habitpay.global.config.jwt.TokenService;
@@ -17,6 +15,7 @@ import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.*;
 
 import java.util.Optional;
@@ -27,31 +26,16 @@ import java.util.Optional;
 public class ChallengeApi {
     private final ChallengeCreationService challengeCreationService;
     private final ChallengeSearchService challengeSearchService;
-    private final ChallengeEnrollmentService challengeEnrollmentService;
-    private final ChallengeEnrollmentSearchService challengeEnrollmentSearchService;
+    private final ChallengeDetailService challengeDetailService;
     private final MemberService memberService;
     private final TokenService tokenService;
 
     @GetMapping("/challenges/{id}")
     @ResponseStatus(HttpStatus.OK)
-    public ResponseEntity<?> getChallenge(@PathVariable("id") Long id,
-                                          @RequestHeader("Authorization") String authorizationHeader) {
-
+    public ResponseEntity<ChallengeResponse> getChallengeDetail(@PathVariable("id") Long id,
+                                                                @AuthenticationPrincipal String email) {
         log.info("[GET /challenges/{}]", id);
-
-        // TODO: Interceptor 나 Filter 에서 먼저 처리해주기 때문에 나중에 삭제하기
-        Optional<String> optionalToken = tokenService.getTokenFromHeader(authorizationHeader);
-        String token = optionalToken.get();
-        String email = tokenService.getEmail(token);
-        Member member = memberService.findByEmail(email);
-
-        // TODO: 사용자의 Challenge 등록 여부를 확인한 후 return 하기
-
-        Challenge challenge = challengeSearchService.findById(id);
-        Optional<ChallengeEnrollment> optionalChallengeEnrollment = challengeEnrollmentSearchService.findByMember(member);
-        ChallengeResponse challengeResponse = new ChallengeResponse(member, challenge, optionalChallengeEnrollment);
-
-        return ResponseEntity.status(HttpStatus.OK).body(challengeResponse);
+        return challengeDetailService.getChallengeDetailById(id, email);
     }
 
     @PostMapping("/challenges")

--- a/src/main/java/com/habitpay/habitpay/domain/challenge/application/ChallengeCreationService.java
+++ b/src/main/java/com/habitpay/habitpay/domain/challenge/application/ChallengeCreationService.java
@@ -2,17 +2,38 @@ package com.habitpay.habitpay.domain.challenge.application;
 
 import com.habitpay.habitpay.domain.challenge.dao.ChallengeRepository;
 import com.habitpay.habitpay.domain.challenge.domain.Challenge;
+import com.habitpay.habitpay.domain.challenge.dto.ChallengeCreationRequest;
+import com.habitpay.habitpay.domain.member.application.MemberService;
+import com.habitpay.habitpay.domain.member.domain.Member;
+import com.habitpay.habitpay.global.common.response.ApiResponse;
 import lombok.AllArgsConstructor;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
 @Service
 @AllArgsConstructor
 public class ChallengeCreationService {
+    private final MemberService memberService;
     private final ChallengeRepository challengeRepository;
 
     @Transactional
-    public void save(Challenge challenge) {
+    public ResponseEntity<ApiResponse> save(ChallengeCreationRequest challengeCreationRequest, String email) {
+        Member host = memberService.findByEmail(email);
+        Challenge challenge = Challenge.builder()
+                .member(host)
+                .title(challengeCreationRequest.getTitle())
+                .description(challengeCreationRequest.getDescription())
+                .startDate(challengeCreationRequest.getStartDate())
+                .endDate(challengeCreationRequest.getEndDate())
+                .participatingDays(challengeCreationRequest.getParticipatingDays())
+                .feePerAbsence(challengeCreationRequest.getFeePerAbsence())
+                .build();
         challengeRepository.save(challenge);
+        
+        // TODO: 챌린지 id 도 함께 전달하기
+        ApiResponse apiResponse = ApiResponse.create("챌린지가 생성되었습니다.");
+        return ResponseEntity.status(HttpStatus.CREATED).body(apiResponse);
     }
 }

--- a/src/main/java/com/habitpay/habitpay/domain/challenge/application/ChallengeDetailService.java
+++ b/src/main/java/com/habitpay/habitpay/domain/challenge/application/ChallengeDetailService.java
@@ -1,0 +1,31 @@
+package com.habitpay.habitpay.domain.challenge.application;
+
+import com.habitpay.habitpay.domain.challenge.domain.Challenge;
+import com.habitpay.habitpay.domain.challenge.dto.ChallengeResponse;
+import com.habitpay.habitpay.domain.challengeenrollment.application.ChallengeEnrollmentSearchService;
+import com.habitpay.habitpay.domain.challengeenrollment.domain.ChallengeEnrollment;
+import com.habitpay.habitpay.domain.member.application.MemberService;
+import com.habitpay.habitpay.domain.member.domain.Member;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.stereotype.Service;
+
+import java.util.Optional;
+
+@Service
+@RequiredArgsConstructor
+public class ChallengeDetailService {
+    private final MemberService memberService;
+    private final ChallengeSearchService challengeSearchService;
+    private final ChallengeEnrollmentSearchService challengeEnrollmentSearchService;
+
+    public ResponseEntity<ChallengeResponse> getChallengeDetailById(Long id, String email) {
+        Member member = memberService.findByEmail(email);
+        Challenge challenge = challengeSearchService.findById(id);
+        Optional<ChallengeEnrollment> optionalChallengeEnrollment = challengeEnrollmentSearchService.findByMember(member);
+        ChallengeResponse challengeResponse = new ChallengeResponse(member, challenge, optionalChallengeEnrollment);
+        
+        return ResponseEntity.status(HttpStatus.OK).body(challengeResponse);
+    }
+}

--- a/src/main/java/com/habitpay/habitpay/domain/challenge/application/ChallengeUpdateService.java
+++ b/src/main/java/com/habitpay/habitpay/domain/challenge/application/ChallengeUpdateService.java
@@ -1,0 +1,44 @@
+package com.habitpay.habitpay.domain.challenge.application;
+
+import com.habitpay.habitpay.domain.challenge.dao.ChallengeRepository;
+import com.habitpay.habitpay.domain.challenge.domain.Challenge;
+import com.habitpay.habitpay.domain.challenge.dto.ChallengePatchRequest;
+import com.habitpay.habitpay.domain.member.application.MemberService;
+import com.habitpay.habitpay.domain.member.domain.Member;
+import com.habitpay.habitpay.global.common.response.ApiResponse;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@RequiredArgsConstructor
+public class ChallengeUpdateService {
+    private final MemberService memberService;
+    private final ChallengeRepository challengeRepository;
+    private final ChallengeSearchService challengeSearchService;
+
+    @Transactional
+    public ResponseEntity<ApiResponse> update(Long id, ChallengePatchRequest challengePatchRequest, String email) {
+        ApiResponse apiResponse;
+        Member member = memberService.findByEmail(email);
+        Challenge challenge = challengeSearchService.findById(id);
+
+        if (isChallengeHost(member, challenge) == false) {
+            // TODO: throw 로 예외 처리 가능한지 확인하기
+            apiResponse = ApiResponse.create("챌린지 수정 권한이 없습니다.");
+            return ResponseEntity.status(HttpStatus.UNAUTHORIZED).body(apiResponse);
+        }
+
+        challenge.updateDescription(challengePatchRequest.getDescription());
+        challengeRepository.save(challenge);
+
+        apiResponse = ApiResponse.create("챌린지 정보 수정이 반영되었습니다.");
+        return ResponseEntity.status(HttpStatus.OK).body(apiResponse);
+    }
+
+    private boolean isChallengeHost(Member member, Challenge challenge) {
+        return member.getEmail().equals(challenge.getHost().getEmail());
+    }
+}

--- a/src/main/java/com/habitpay/habitpay/domain/challenge/domain/Challenge.java
+++ b/src/main/java/com/habitpay/habitpay/domain/challenge/domain/Challenge.java
@@ -66,7 +66,7 @@ public class Challenge extends BaseTime {
         this.feePerAbsence = feePerAbsence;
     }
 
-    public void updateChallengeDescription(String description) {
+    public void updateDescription(String description) {
         this.description = description;
     }
 }


### PR DESCRIPTION
# 작업 내용 

## 1. 챌린지 도메인 컨트롤러 서비스 로직 분리

대상 컨트롤러는 아래와 같이 3가지입니다.

GET /challenges/{id}
POST /challenge
PATCH /challenge/{id}

## 2. 컨트롤러 단수형(challenge)에서 복수형(challenges)으로 변경

POST /challenge -> /challenges
PATCH /challenge/{id} -> /challenges/{id}

# 알게 된 사실

도메인 객체(Challenge)의 일부 정보만 변경하고 싶을 때 `repository.save()` 를 실행해도 update 가 이루어진다고 합니다.
JPA 에는 update 메서드가 존재하지 않는데, save 메서드가 DB 의 primary key 를 참고해서 새롭게 생성하는 객체인지, 업데이트하는 객체인지 추적한다고 합니다. (자세한 원리는 아직 이해하지 못함)

- 참고자료: [Save는 Insert와 Update를 어떻게 구분할까](https://brunch.co.kr/@anonymdevoo/37) [브런치]