### PR TITLE
[Feat] host만이 공지 포스트를 등록하고 삭제할 수 있게 함 #79

### DIFF
--- a/src/main/java/com/habitpay/habitpay/domain/challengepost/application/ChallengePostService.java
+++ b/src/main/java/com/habitpay/habitpay/domain/challengepost/application/ChallengePostService.java
@@ -77,16 +77,16 @@ public class ChallengePostService {
         return challengePost;
     }
 
-    public Member getWriter(Long challengeEnrollmentId) {
-        ChallengeEnrollment enrollment = challengeEnrollmentRepository.findById(challengeEnrollmentId)
-                .orElseThrow(() -> new NoSuchElementException("No such enrollment " + challengeEnrollmentId));
+    public Member getWriter(ChallengePost post) {
+        ChallengeEnrollment enrollment = challengeEnrollmentRepository.findById(post.getChallengeEnrollmentId())
+                .orElseThrow(() -> new NoSuchElementException("No such enrollment " + post.getChallengeEnrollmentId()));
         return enrollment.getMember();
     }
 
     public void authorizePostWriter(ChallengePost challengePost) {
         String email = SecurityContextHolder.getContext().getAuthentication().getName();
         log.info("email : " + email);
-        if (!getWriter(challengePost.getChallengeEnrollmentId()).getEmail().equals(email)) {
+        if (!getWriter(challengePost).getEmail().equals(email)) {
             throw new CustomJwtException(HttpStatus.UNAUTHORIZED, CustomJwtErrorInfo.UNAUTHORIZED, "Not a Member who posted.");
         }
     }

--- a/src/main/java/com/habitpay/habitpay/domain/challengepost/application/ChallengePostService.java
+++ b/src/main/java/com/habitpay/habitpay/domain/challengepost/application/ChallengePostService.java
@@ -1,13 +1,20 @@
 package com.habitpay.habitpay.domain.challengepost.application;
 
+import com.habitpay.habitpay.domain.challengeenrollment.application.ChallengeEnrollmentSearchService;
+import com.habitpay.habitpay.domain.challengeenrollment.dao.ChallengeEnrollmentRepository;
+import com.habitpay.habitpay.domain.challengeenrollment.domain.ChallengeEnrollment;
 import com.habitpay.habitpay.domain.challengepost.dao.ChallengePostRepository;
 import com.habitpay.habitpay.domain.challengepost.domain.ChallengePost;
 import com.habitpay.habitpay.domain.challengepost.dto.AddPostRequest;
 import com.habitpay.habitpay.domain.challengepost.dto.ModifyPostRequest;
+import com.habitpay.habitpay.domain.member.domain.Member;
 import com.habitpay.habitpay.domain.postphoto.application.PostPhotoService;
+import com.habitpay.habitpay.domain.refreshtoken.exception.CustomJwtException;
+import com.habitpay.habitpay.global.error.CustomJwtErrorInfo;
 import jakarta.transaction.Transactional;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import org.springframework.http.HttpStatus;
 import org.springframework.security.core.context.SecurityContextHolder;
 import org.springframework.stereotype.Service;
 
@@ -21,6 +28,8 @@ public class ChallengePostService {
 
     private final ChallengePostRepository challengePostRepository;
     private final PostPhotoService postPhotoService;
+    private final ChallengeEnrollmentRepository challengeEnrollmentRepository;
+    private final ChallengeEnrollmentSearchService challengeEnrollmentSearchService;
 
     public ChallengePost save(AddPostRequest request, Long challengeEnrollmentId) {
         return challengePostRepository.save(request.toEntity(challengeEnrollmentId));
@@ -55,7 +64,7 @@ public class ChallengePostService {
     @Transactional
     public ChallengePost update(Long id, ModifyPostRequest request) {
         ChallengePost challengePost = challengePostRepository.findById(id)
-                .orElseThrow(() ->  new IllegalArgumentException("(for debugging) not found : " + id));
+                .orElseThrow(() -> new IllegalArgumentException("(for debugging) not found : " + id));
 
         authorizePostWriter(challengePost);
         if (request.getContent() != null) {
@@ -68,12 +77,17 @@ public class ChallengePostService {
         return challengePost;
     }
 
-    // todo : 확인하기
-    private static void authorizePostWriter(ChallengePost challengePost) {
+    public Member getWriter(Long challengeEnrollmentId) {
+        ChallengeEnrollment enrollment = challengeEnrollmentRepository.findById(challengeEnrollmentId)
+                .orElseThrow(() -> new NoSuchElementException("No such enrollment " + challengeEnrollmentId));
+        return enrollment.getMember();
+    }
+
+    public void authorizePostWriter(ChallengePost challengePost) {
         String email = SecurityContextHolder.getContext().getAuthentication().getName();
         log.info("email : " + email);
-//        if (!challengePost.getWriter().getEmail().equals(email)) {
-//            throw new IllegalArgumentException("(for debug) not authorized");
-//        }
+        if (!getWriter(challengePost.getChallengeEnrollmentId()).getEmail().equals(email)) {
+            throw new CustomJwtException(HttpStatus.UNAUTHORIZED, CustomJwtErrorInfo.UNAUTHORIZED, "Not a Member who posted.");
+        }
     }
 }

--- a/src/main/java/com/habitpay/habitpay/domain/challengepost/dao/ChallengePostRepository.java
+++ b/src/main/java/com/habitpay/habitpay/domain/challengepost/dao/ChallengePostRepository.java
@@ -1,5 +1,7 @@
 package com.habitpay.habitpay.domain.challengepost.dao;
 
+import com.habitpay.habitpay.domain.challenge.domain.Challenge;
+import com.habitpay.habitpay.domain.challengeenrollment.domain.ChallengeEnrollment;
 import com.habitpay.habitpay.domain.challengepost.domain.ChallengePost;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.repository.query.Param;

--- a/src/main/java/com/habitpay/habitpay/domain/challengepost/domain/ChallengePost.java
+++ b/src/main/java/com/habitpay/habitpay/domain/challengepost/domain/ChallengePost.java
@@ -43,9 +43,4 @@ public class ChallengePost extends BaseTime {
     public void modifyPostIsAnnouncement(boolean isAnnouncement) {
         this.isAnnouncement = isAnnouncement;
     }
-
-    // todo : challengeEnrollment에서 id로 멤버 찾기 -> 포스트 작성자 정보
-//    public Member getWriter() {
-//        return challengeEnrollmentRepository.findMemberById(this.challengeEnrollmentId);
-//    }
 }

--- a/src/main/java/com/habitpay/habitpay/domain/challengepost/dto/AddPostRequest.java
+++ b/src/main/java/com/habitpay/habitpay/domain/challengepost/dto/AddPostRequest.java
@@ -13,7 +13,7 @@ import java.util.List;
 @AllArgsConstructor
 public class AddPostRequest {
     private String content;
-    private boolean isAnnouncement;
+    private Boolean isAnnouncement;
     private List<AddPostPhotoData> photos;
 
     public ChallengePost toEntity(Long challengeEnrollmentId) {


### PR DESCRIPTION
* 포스트 등록 시 `isAnnouncement`가 `true`라면, `요청 토큰의 주인`이 `해당 챌린지의 호스트`인 경우에만 등록 가능하도록 수정
```java
@PostMapping("/api/challenges/{id}/post")
    public ResponseEntity<List<String>> addPost(@RequestBody AddPostRequest request, @PathVariable Long id, @AuthenticationPrincipal String email) {

        // 디버깅 용도
         log.info("Authentication Principal Email: {}", email);

        // @AuthenticationPrincipal email 데이터와 챌린지 id를 이용해, enrollment 파악
        // (현재는 findByMember()가 List<>가 아닌 enrollment 단일 객체만 반환하므로, 아직 챌린지 id는 안 쓰였음)
        // (멤버가 여러 챌린지에 등록하면, 멤버 한 명에 연결된 enrollment도 n개가 됨 -> List<>로 받아야 될 상황 생김)
        // (나중에 List<ChallengeEnrollment>가 반환되면, 그 중에 챌린지 id 동일한 것을 골라 쓰면 됨)
        Member member = memberService.findByEmail(email);
        ChallengeEnrollment enrollment = challengeEnrollmentSearchService.findByMember(member)
                .orElseThrow(() -> new NoSuchElementException("(for debugging) no enrollment for : " + email));

        // 공지 포스트면서, 요청 토큰의 email이 챌린지 호스트의 email과 동일하면 등록 가능!
        // 공지 포스트인데, 요청 토큰의 email이 챌린지 호스트의 것과 다르다면 권한 부족으로 예외 던짐
        if (request.getIsAnnouncement()) {
            Challenge challenge = challengeSearchService.findById(id);
            if (!challenge.getHost().equals(member)) {
                throw new CustomJwtException(HttpStatus.FORBIDDEN, CustomJwtErrorInfo.FORBIDDEN, "Only Host is able to upload an Announcement Post.");
            }
        }

        // 챌린지 포스트와 포스트 포토를 각각 저장하는 로직
        ChallengePost challengePost = challengePostService.save(request, enrollment.getId());
        List<String> preSignedUrlList = postPhotoService.save(challengePost, request.getPhotos());

        return ResponseEntity.status(HttpStatus.CREATED).body(preSignedUrlList);
    }
```

-> 초기에는 중간 연결고리인 `enrollment`의 `id`를 기준으로 저장하는 로직과 메서드를 작성해서 그거에 맞추다보니 길어졌는데,
이제 와서 보면 그냥 `challenge id`만 넘기고 나머지는 다 서비스 메서드에서 알아서 처리하도록 리팩토링하면 될 듯함.

---

* 포스트 삭제 요청 시, `isAnnouncement`가 `true`이고 && `요청 토큰의 주인`이 `해당 챌린지의 호스트`인 경우에만 삭제 가능하도록 수정
```java
@DeleteMapping("/api/posts/{id}")
    public ResponseEntity<Void> deletePost(@PathVariable Long id, @AuthenticationPrincipal String email) {
        ChallengePost post = challengePostService.findById(id);

        // 공지 포스트인데,
        if (post.getIsAnnouncement()) {
            ChallengeEnrollment enrollment = challengeEnrollmentRepository
                    .findById(post.getChallengeEnrollmentId())
                    .orElseThrow(() -> new NoSuchElementException("No such enrollment " + post.getChallengeEnrollmentId()));

            // 공지 포스트가 소속된 챌린지의 호스트 email이 요청 토큰의 email과 다르다면 권한 부족 예외 던짐
            if (!enrollment.getChallenge().getHost().getEmail().equals(email)) {
                throw new CustomJwtException(HttpStatus.FORBIDDEN, CustomJwtErrorInfo.FORBIDDEN, "Only Host is able to delete an Announcement Post.");
            }
        }
        // 공지 포스트가 아니라면 삭제 불가하므로 그냥 예외 던짐
        // 나중에 관리자 계정을 만들면 일반 포스트도 삭제 가능하게 될 수 있으니까, 일단 '권한' 부족 예외로 설정함
        else {
            throw new CustomJwtException(HttpStatus.FORBIDDEN, CustomJwtErrorInfo.FORBIDDEN, "Post cannot be deleted.");
        }

        challengePostService.delete(id);

        return ResponseEntity.ok()
                .build();
    }
```
-> 이것도 다 넘겨서 리팩토링하면 될 듯함

---

* 기타 - `public Member getWriter(ChallengePost post)` 메서드 제작
: 챌린지 포스트를 작성한 멤버가 누구인지 알아내는 메서드
: 글 수정 시 동일한 작성자인지 확인할 때 사용 예정

* 발견 못했던 `boolean` 검거해서 데이터 타입 수정: `boolean` -> `Boolean`
```java
public class AddPostRequest {
...
    private Boolean isAnnouncement;
... }

```