### PR TITLE
[feat] getWriter() 메서드를 사용하는 로직들 수정 및 리팩토링 #81

### DIFF
--- a/src/main/java/com/habitpay/habitpay/domain/challengepost/api/ChallengePostApi.java
+++ b/src/main/java/com/habitpay/habitpay/domain/challengepost/api/ChallengePostApi.java
@@ -118,7 +118,7 @@ public class ChallengePostApi {
 
         if (request.getIsAnnouncement()) {
             Challenge challenge = challengeSearchService.findById(id);
-            if (!challenge.getHost().equals(member)) {
+            if (!challengePostService.isHost(challenge, member)) {
                 throw new CustomJwtException(HttpStatus.FORBIDDEN, CustomJwtErrorInfo.FORBIDDEN, "Only Host is able to upload an Announcement Post.");
             }
         }
@@ -147,11 +147,7 @@ public class ChallengePostApi {
         ChallengePost post = challengePostService.findById(id);
 
         if (post.getIsAnnouncement()) {
-            ChallengeEnrollment enrollment = challengeEnrollmentRepository
-                    .findById(post.getChallengeEnrollmentId())
-                    .orElseThrow(() -> new NoSuchElementException("No such enrollment " + post.getChallengeEnrollmentId()));
-
-            if (!enrollment.getChallenge().getHost().getEmail().equals(email)) {
+            if (!challengePostService.isHost(challengePostService.findChallengeByPostId(id), email)) {
                 throw new CustomJwtException(HttpStatus.FORBIDDEN, CustomJwtErrorInfo.FORBIDDEN, "Only Host is able to delete an Announcement Post.");
             }
         }

--- a/src/main/java/com/habitpay/habitpay/domain/challengepost/application/ChallengePostService.java
+++ b/src/main/java/com/habitpay/habitpay/domain/challengepost/application/ChallengePostService.java
@@ -1,5 +1,6 @@
 package com.habitpay.habitpay.domain.challengepost.application;
 
+import com.habitpay.habitpay.domain.challenge.domain.Challenge;
 import com.habitpay.habitpay.domain.challengeenrollment.application.ChallengeEnrollmentSearchService;
 import com.habitpay.habitpay.domain.challengeenrollment.dao.ChallengeEnrollmentRepository;
 import com.habitpay.habitpay.domain.challengeenrollment.domain.ChallengeEnrollment;
@@ -13,6 +14,7 @@ import com.habitpay.habitpay.domain.refreshtoken.exception.CustomJwtException;
 import com.habitpay.habitpay.global.error.CustomJwtErrorInfo;
 import jakarta.transaction.Transactional;
 import lombok.RequiredArgsConstructor;
+import lombok.extern.java.Log;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.http.HttpStatus;
 import org.springframework.security.core.context.SecurityContextHolder;
@@ -51,26 +53,34 @@ public class ChallengePostService {
                 .orElseThrow(() -> new IllegalArgumentException("(for debugging) not found : " + id));
     }
 
-    // todo : 공지글만 삭제 가능하도록
-    public void delete(Long id) {
-        ChallengePost challengePost = challengePostRepository.findById(id)
-                .orElseThrow(() -> new IllegalArgumentException("(for debugging) not found : " + id));
+    public Challenge findChallengeByPostId(Long postId) {
+        ChallengePost post = findById(postId);
+        // todo : enrollment service에 findById() 메서드 만들기
+        ChallengeEnrollment enrollment = challengeEnrollmentRepository
+                .findById(post.getChallengeEnrollmentId())
+                .orElseThrow(() -> new NoSuchElementException("No such enrollment " + post.getChallengeEnrollmentId()));
+        return enrollment.getChallenge();
+    }
 
-        authorizePostWriter(challengePost); // todo : method 미완
+    public void delete(Long id) {
+        ChallengePost challengePost = findById(id);
+
         postPhotoService.deleteAllByPost(challengePost);
         challengePostRepository.delete(challengePost);
     }
 
     @Transactional
     public ChallengePost update(Long id, ModifyPostRequest request) {
-        ChallengePost challengePost = challengePostRepository.findById(id)
-                .orElseThrow(() -> new IllegalArgumentException("(for debugging) not found : " + id));
+        ChallengePost challengePost = findById(id);
 
         authorizePostWriter(challengePost);
         if (request.getContent() != null) {
             challengePost.modifyPostContent(request.getContent());
         }
         if (request.getIsAnnouncement() != null) {
+            if (request.getIsAnnouncement() && !isHost(id, getWriter(challengePost))) {
+                throw new CustomJwtException(HttpStatus.FORBIDDEN, CustomJwtErrorInfo.FORBIDDEN, "Only Host is able to upload an Announcement Post.");
+            }
             challengePost.modifyPostIsAnnouncement(request.getIsAnnouncement());
         }
 
@@ -89,5 +99,18 @@ public class ChallengePostService {
         if (!getWriter(challengePost).getEmail().equals(email)) {
             throw new CustomJwtException(HttpStatus.UNAUTHORIZED, CustomJwtErrorInfo.UNAUTHORIZED, "Not a Member who posted.");
         }
+    }
+
+    public boolean isHost(Challenge challenge, Member member) {
+        return challenge.getHost().equals(member);
+    }
+
+    public boolean isHost(Challenge challenge, String email) {
+        return challenge.getHost().getEmail().equals(email);
+    }
+
+    public boolean isHost(Long postId, Member member) {
+        Challenge challenge = findChallengeByPostId(postId);
+        return challenge.getHost().equals(member);
     }
 }


### PR DESCRIPTION
* `getWriter()`는 포스트의 작성자를 찾기 위한 메서드
```java
public Member getWriter(ChallengePost post) { }
```
---
* `authorizePostWriter()`는 포스트의 작성자가 맞는지 검증하는 메서드
```java
public void authorizePostWriter(ChallengePost challengePost) {
        String email = SecurityContextHolder.getContext().getAuthentication().getName();

        if (!getWriter(challengePost).getEmail().equals(email)) {
            throw new CustomJwtException(HttpStatus.UNAUTHORIZED, CustomJwtErrorInfo.UNAUTHORIZED, "Not a Member who posted.");
        }
    }
```
포스트 수정 및 삭제 시, 작성자 본인이 맞는지 검증이 필요하기 때문에 제작.
컨트롤러를 통해 얻은 `포스트 id`를 `SecurityContextHolder`의 `토큰 email` 정보와 결합해서 확인함.
-> 이때 `getWriter()` 이용

---

* 포스트 수정 및 삭제 메서드 리팩토링 중, 작성자 인증 뿐만 아니라 챌린지의 호스트인지 판단도 필요하다는 걸 알게 됨.
* `isHost()` 메서드 오버로딩 시리즈를 만들게 됨.
```java
    public boolean isHost(Challenge challenge, Member member) { }

    public boolean isHost(Challenge challenge, String email) { }

    public boolean isHost(Long postId, Member member) { }
```

---

* `포스트` `delete` 메서드
```java
public void delete(Long id) {
        ChallengePost challengePost = findById(id);

        postPhotoService.deleteAllByPost(challengePost);
        challengePostRepository.delete(challengePost);
    }
```
컨트롤러 단의 앞선 로직에서 `isHost()` 여부를 확인하기 때문에, `authorizePostWriter()`가 불필요해서 오히려 삭제함.

---

* `포스트` `update` 메서드
```java
public ChallengePost update(Long id, ModifyPostRequest request) {
        ChallengePost challengePost = findById(id);

        authorizePostWriter(challengePost);
        ...
        if (request.getIsAnnouncement() != null) {
            if (request.getIsAnnouncement() && !isHost(id, getWriter(challengePost))) {
                throw new CustomJwtException(HttpStatus.FORBIDDEN, CustomJwtErrorInfo.FORBIDDEN, "Only Host is able to upload an Announcement Post.");
            }
            challengePost.modifyPostIsAnnouncement(request.getIsAnnouncement());
        }
        ...
    }
```
기본적으로 `authorizePostWriter()`로 작성자 검증.
`IsAnnouncement` 값 변경 시 문제가 되는 경우는, `호스트가 아닌 멤버`가 `true`로 변경하려고 시도할 경우 뿐임.
그 경우만 `if문`을 사용하여 예외 처리함.

---

* 기타 : 자주 사용하는 로직이라 메서드를 만들었음
```java
public Challenge findChallengeByPostId(Long postId) { }
```
`포스트 id`를 통해, 해당 포스트가 소속된 챌린지가 무엇인지 얻는 메서드

---

* 기타 리팩토링
* `isHost()`, `findById()` 등 기존에 있는 메서드로 대체할 수 있는 코드들을 없애고 메서드로 대신함.