### PR TITLE
[feat] 포스트가 저장될 때 챌린지 참여 기록 객체도 생성 및 저장하기 #83

### DIFF
--- a/src/main/java/com/habitpay/habitpay/domain/challengeparticipationrecord/application/ChallengeParticipationRecordSearchService.java
+++ b/src/main/java/com/habitpay/habitpay/domain/challengeparticipationrecord/application/ChallengeParticipationRecordSearchService.java
@@ -1,0 +1,22 @@
+package com.habitpay.habitpay.domain.challengeparticipationrecord.application;
+
+import com.habitpay.habitpay.domain.challengeparticipationrecord.dao.ChallengeParticipationRecordRepository;
+import com.habitpay.habitpay.domain.challengeparticipationrecord.domain.ChallengeParticipationRecord;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Service;
+
+import java.util.NoSuchElementException;
+
+@Service
+@RequiredArgsConstructor
+@Slf4j
+public class ChallengeParticipationRecordSearchService {
+
+    private final ChallengeParticipationRecordRepository challengeParticipationRecordRepository;
+
+    public ChallengeParticipationRecord findById(Long id) {
+        return challengeParticipationRecordRepository.findById(id)
+                .orElseThrow(() -> new NoSuchElementException("No Such Record " + id));
+    }
+}

--- a/src/main/java/com/habitpay/habitpay/domain/challengeparticipationrecord/application/ChallengeParticipationRecordService.java
+++ b/src/main/java/com/habitpay/habitpay/domain/challengeparticipationrecord/application/ChallengeParticipationRecordService.java
@@ -1,0 +1,26 @@
+package com.habitpay.habitpay.domain.challengeparticipationrecord.application;
+
+import com.habitpay.habitpay.domain.challengeenrollment.domain.ChallengeEnrollment;
+import com.habitpay.habitpay.domain.challengeparticipationrecord.dao.ChallengeParticipationRecordRepository;
+import com.habitpay.habitpay.domain.challengeparticipationrecord.domain.ChallengeParticipationRecord;
+import com.habitpay.habitpay.domain.challengepost.domain.ChallengePost;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Service;
+
+@Service
+@RequiredArgsConstructor
+@Slf4j
+public class ChallengeParticipationRecordService {
+
+    private final ChallengeParticipationRecordRepository challengeParticipationRecordRepository;
+
+    public ChallengeParticipationRecord save(ChallengeEnrollment enrollment, ChallengePost post) {
+        // todo : 챌린지 조건 따져서 인정될 때만 저장해야 함
+        return challengeParticipationRecordRepository.save(
+                ChallengeParticipationRecord.builder()
+                        .enrollment(enrollment)
+                        .post(post)
+                        .build());
+    }
+}

--- a/src/main/java/com/habitpay/habitpay/domain/challengeparticipationrecord/application/ChallengeParticipationRecordService.java
+++ b/src/main/java/com/habitpay/habitpay/domain/challengeparticipationrecord/application/ChallengeParticipationRecordService.java
@@ -17,6 +17,7 @@ public class ChallengeParticipationRecordService {
 
     public ChallengeParticipationRecord save(ChallengeEnrollment enrollment, ChallengePost post) {
         // todo : 챌린지 조건 따져서 인정될 때만 저장해야 함
+        // todo : enrollment service에서 enrollment의 성공 횟수를 +1하는 메서드 만들고, 여기에 넣어야 할 듯
         return challengeParticipationRecordRepository.save(
                 ChallengeParticipationRecord.builder()
                         .enrollment(enrollment)

--- a/src/main/java/com/habitpay/habitpay/domain/challengeparticipationrecord/domain/ChallengeParticipationRecord.java
+++ b/src/main/java/com/habitpay/habitpay/domain/challengeparticipationrecord/domain/ChallengeParticipationRecord.java
@@ -1,9 +1,11 @@
 package com.habitpay.habitpay.domain.challengeparticipationrecord.domain;
 
+import com.habitpay.habitpay.domain.challengeenrollment.domain.ChallengeEnrollment;
 import com.habitpay.habitpay.domain.challengepost.domain.ChallengePost;
 import com.habitpay.habitpay.domain.model.BaseTime;
 import jakarta.persistence.*;
 import lombok.AccessLevel;
+import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 import org.springframework.data.jpa.domain.support.AuditingEntityListener;
@@ -18,15 +20,17 @@ public class ChallengeParticipationRecord extends BaseTime {
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;
 
-    // todo : enrollment 도메인 적용하기
-//    @ManyToOne
-//    @JoinColumn
-//    private ChallengeEnrollment enrollment;
+    @ManyToOne
+    @JoinColumn
+    private ChallengeEnrollment enrollment;
 
     @OneToOne
     @JoinColumn
     private ChallengePost post;
 
-//    @Builder
-//    public ChallengeParticipationRecord() {}
+    @Builder
+    public ChallengeParticipationRecord(ChallengeEnrollment enrollment, ChallengePost post) {
+        this.enrollment = enrollment;
+        this.post = post;
+    }
 }

--- a/src/main/java/com/habitpay/habitpay/domain/challengepost/api/ChallengePostApi.java
+++ b/src/main/java/com/habitpay/habitpay/domain/challengepost/api/ChallengePostApi.java
@@ -19,6 +19,7 @@ import com.habitpay.habitpay.domain.postphoto.application.PostPhotoService;
 import com.habitpay.habitpay.domain.postphoto.domain.PostPhoto;
 import com.habitpay.habitpay.domain.refreshtoken.exception.CustomJwtException;
 import com.habitpay.habitpay.global.error.CustomJwtErrorInfo;
+import jakarta.transaction.Transactional;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.http.HttpStatus;
@@ -106,6 +107,7 @@ public class ChallengePostApi {
 //                .body(challengePostsView);
 //    }
 
+    @Transactional
     @PostMapping("/api/challenges/{id}/post")
     public ResponseEntity<List<String>> addPost(@RequestBody AddPostRequest request, @PathVariable Long id, @AuthenticationPrincipal String email) {
 

--- a/src/main/java/com/habitpay/habitpay/domain/challengepost/application/ChallengePostService.java
+++ b/src/main/java/com/habitpay/habitpay/domain/challengepost/application/ChallengePostService.java
@@ -4,6 +4,8 @@ import com.habitpay.habitpay.domain.challenge.domain.Challenge;
 import com.habitpay.habitpay.domain.challengeenrollment.application.ChallengeEnrollmentSearchService;
 import com.habitpay.habitpay.domain.challengeenrollment.dao.ChallengeEnrollmentRepository;
 import com.habitpay.habitpay.domain.challengeenrollment.domain.ChallengeEnrollment;
+import com.habitpay.habitpay.domain.challengeparticipationrecord.application.ChallengeParticipationRecordService;
+import com.habitpay.habitpay.domain.challengeparticipationrecord.domain.ChallengeParticipationRecord;
 import com.habitpay.habitpay.domain.challengepost.dao.ChallengePostRepository;
 import com.habitpay.habitpay.domain.challengepost.domain.ChallengePost;
 import com.habitpay.habitpay.domain.challengepost.dto.AddPostRequest;
@@ -32,9 +34,15 @@ public class ChallengePostService {
     private final PostPhotoService postPhotoService;
     private final ChallengeEnrollmentRepository challengeEnrollmentRepository;
     private final ChallengeEnrollmentSearchService challengeEnrollmentSearchService;
+    private final ChallengeParticipationRecordService challengeParticipationRecordService;
 
     public ChallengePost save(AddPostRequest request, Long challengeEnrollmentId) {
-        return challengePostRepository.save(request.toEntity(challengeEnrollmentId));
+        ChallengePost post = challengePostRepository.save(request.toEntity(challengeEnrollmentId));
+        // todo : service 메서드로 대체하기
+        ChallengeEnrollment enrollment = challengeEnrollmentRepository.findById(challengeEnrollmentId)
+                .orElseThrow(() -> new NoSuchElementException("No Such enrollment " + challengeEnrollmentId));
+        challengeParticipationRecordService.save(enrollment, post);
+        return post;
     }
 
     // todo : 각 챌린지 별로 findAll 해주는 메서드 (ChallengeEnrollment 도메인 만들고 거기서 ChallengeId 가져온 뒤에 할 수 있을 듯)


### PR DESCRIPTION
* `ChallengeParticipationRecord` 도메인의 `enrollment` 요소를 외래키로 연결함
```java
public class ChallengeParticipationRecord extends BaseTime {
...
    @ManyToOne
    @JoinColumn
    private ChallengeEnrollment enrollment;
...
}
```

---

* addPost 메서드에 트랜잭션 어노테이션 추가
```java
@Transactional
    @PostMapping("/api/challenges/{id}/post")
    public ResponseEntity<List<String>> addPost(@RequestBody AddPostRequest request, @PathVariable Long id, @AuthenticationPrincipal String email) { }
```
포스트와 사진 저장, 레코드 생성까지 여러 단계가 얽혀있고 한 세트로 진행되어야 해서 추가함
(트랜잭션의 쓰임새를 다 알지 못해서, 추후 수정할지도.)

---

* `application/ChallengeParticipationRecordService.java` 추가
```java
public ChallengeParticipationRecord save(ChallengeEnrollment enrollment, ChallengePost post) {
        return challengeParticipationRecordRepository.save(
                ChallengeParticipationRecord.builder()
                        .enrollment(enrollment)
                        .post(post)
                        .build());
    }
```
레코드를 생성 및 저장하는 메서드 제작
(레코드에 저장될 자격이 있는 포스트인지 확인하는 메서드, enrollment에 성공 횟수를 +1하는 메서드를 추후 생성해서 추가해야 함)

---

* `application/ChallengeParticipationRecordSearchService.java` 추가
```java
public ChallengeParticipationRecord findById(Long id) {
        return challengeParticipationRecordRepository.findById(id)
                .orElseThrow(() -> new NoSuchElementException("No Such Record " + id));
    }
```
id로 레코드를 검색하는 메서드 제작

---

* `challengepost/application/ChallengePostService.java`의 `save` 메서드에 레코드 저장 로직 추가
```java
public ChallengePost save(AddPostRequest request, Long challengeEnrollmentId) {
        ...
        challengeParticipationRecordService.save(enrollment, post);
        return post;
    }
```