### PR TITLE
:recycle: refactor: request method, uri 로그 출력 

### DIFF
--- a/src/main/java/com/habitpay/habitpay/domain/challenge/api/ChallengeApi.java
+++ b/src/main/java/com/habitpay/habitpay/domain/challenge/api/ChallengeApi.java
@@ -15,6 +15,7 @@ import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.*;
 
 @RestController
+@RequestMapping("/api")
 @RequiredArgsConstructor
 @Slf4j
 public class ChallengeApi {
@@ -26,7 +27,6 @@ public class ChallengeApi {
     @ResponseStatus(HttpStatus.OK)
     public ResponseEntity<ChallengeResponse> getChallengeDetail(@PathVariable("id") Long id,
                                                                 @AuthenticationPrincipal String email) {
-        log.info("[GET /challenges/{}]", id);
         return challengeDetailService.findById(id, email);
     }
 
@@ -34,7 +34,6 @@ public class ChallengeApi {
     @ResponseStatus(HttpStatus.CREATED)
     public ResponseEntity<ApiResponse> createChallenge(@RequestBody ChallengeCreationRequest challengeCreationRequest,
                                                        @AuthenticationPrincipal String email) {
-        log.info("[POST /challenges] email: {}", email);
         return challengeCreationService.save(challengeCreationRequest, email);
     }
 
@@ -42,7 +41,6 @@ public class ChallengeApi {
     @ResponseStatus(HttpStatus.OK)
     public ResponseEntity<ApiResponse> patchChallengeDetails(@PathVariable("id") Long id, @RequestBody ChallengePatchRequest challengePatchRequest,
                                                              @AuthenticationPrincipal String email) {
-        log.info("[PATCH /challenges/{}]: email {}", id, email);
         return challengeUpdateService.update(id, challengePatchRequest, email);
     }
 }

--- a/src/main/java/com/habitpay/habitpay/domain/challengeenrollment/api/ChallengeEnrollmentApi.java
+++ b/src/main/java/com/habitpay/habitpay/domain/challengeenrollment/api/ChallengeEnrollmentApi.java
@@ -10,13 +10,11 @@ import lombok.extern.slf4j.Slf4j;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
-import org.springframework.web.bind.annotation.PathVariable;
-import org.springframework.web.bind.annotation.PostMapping;
-import org.springframework.web.bind.annotation.ResponseStatus;
-import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.bind.annotation.*;
 
 @Slf4j
 @RestController
+@RequestMapping("/api")
 @RequiredArgsConstructor
 public class ChallengeEnrollmentApi {
     private final MemberService memberService;
@@ -27,14 +25,12 @@ public class ChallengeEnrollmentApi {
     @PostMapping("/challenges/{id}/enroll")
     @ResponseStatus(HttpStatus.OK)
     public ResponseEntity<ApiResponse> enrollChallenge(@PathVariable("id") Long id, @AuthenticationPrincipal String email) {
-        log.info("[POST /challenges/{}/enroll] email: {}", id, email);
         return challengeEnrollmentService.enroll(id, email);
     }
 
     @PostMapping("/challenges/{id}/cancel")
     @ResponseStatus(HttpStatus.OK)
     public ResponseEntity<ApiResponse> cancelChallenge(@PathVariable("id") Long id, @AuthenticationPrincipal String email) {
-        log.info("[POST /challenges/{}/cancel]: email {}", id, email);
         return challengeCancellationService.cancel(id, email);
     }
 

--- a/src/main/java/com/habitpay/habitpay/global/config/auth/interceptor/AuthorizationInterceptor.java
+++ b/src/main/java/com/habitpay/habitpay/global/config/auth/interceptor/AuthorizationInterceptor.java
@@ -35,7 +35,6 @@ public class AuthorizationInterceptor implements HandlerInterceptor {
             HttpServletRequest request,
             HttpServletResponse response,
             Object handler) throws Exception {
-
         // final String REDIRECT_URL = "http://localhost:3000";
 
         // todo
@@ -82,6 +81,7 @@ public class AuthorizationInterceptor implements HandlerInterceptor {
             // todo : 인가
             Collection<GrantedAuthority> collection = (Collection<GrantedAuthority>) authentication.getAuthorities();
             log.info("[check ROLE] {}", collection);
+            log.info("[{} {}] email: {}", request.getMethod(), request.getRequestURI(), authentication.getPrincipal());
 
 //            if (!collection.toString().equals("[ROLE_GUEST]")) {
 //                throw new CustomJwtException(HttpStatus.FORBIDDEN, CustomJwtErrorInfo.FORBIDDEN, "request required higher privileges than provided by the


### PR DESCRIPTION
# 작업 내용

기존에는 컨트롤러에서 request method, uri 를 출력하던 로그를 `AuthorizationInterceptor` 에서 출력하도록 했습니다. 

```diff
  @RestController
+ @RequestMapping("/api")
  @RequiredArgsConstructor
  @Slf4j
  public class ChallengeApi {
      @ResponseStatus(HttpStatus.OK)
      public ResponseEntity<ChallengeResponse> getChallengeDetail(@PathVariable("id") Long id,
                                                                  @AuthenticationPrincipal String email) {
-         log.info("[GET /challenges/{}]", id);
          return challengeDetailService.findById(id, email);
      }
```

```java
// AuthorizationInterceptor.java`

@Override
public boolean preHandle(
    HttpServletRequest request,
    HttpServletResponse response,
    Object handler) throws Exception {
    ...
    log.info("[{} {}] email: {}", request.getMethod(), request.getRequestURI(), authentication.getPrincipal());
}
```

출력 예시는 아래와 같습니다.
```
[POST /api/challenges/5/cancel] email: haewrong@gmail.com
```