### PR TITLE
[refactor] isHost() 메서드의 이름을 isChallengeHost()로 변경#89

### DIFF
--- a/src/main/java/com/habitpay/habitpay/domain/challengepost/api/ChallengePostApi.java
+++ b/src/main/java/com/habitpay/habitpay/domain/challengepost/api/ChallengePostApi.java
@@ -1,7 +1,6 @@
 package com.habitpay.habitpay.domain.challengepost.api;
 
 import com.habitpay.habitpay.domain.challenge.application.ChallengeSearchService;
-import com.habitpay.habitpay.domain.challenge.dao.ChallengeRepository;
 import com.habitpay.habitpay.domain.challenge.domain.Challenge;
 import com.habitpay.habitpay.domain.challengeenrollment.application.ChallengeEnrollmentSearchService;
 import com.habitpay.habitpay.domain.challengeenrollment.dao.ChallengeEnrollmentRepository;
@@ -11,7 +10,6 @@ import com.habitpay.habitpay.domain.challengepost.domain.ChallengePost;
 import com.habitpay.habitpay.domain.challengepost.dto.AddPostRequest;
 import com.habitpay.habitpay.domain.challengepost.dto.ModifyPostRequest;
 import com.habitpay.habitpay.domain.member.application.MemberService;
-import com.habitpay.habitpay.domain.member.dao.MemberRepository;
 import com.habitpay.habitpay.domain.member.domain.Member;
 import com.habitpay.habitpay.domain.postphoto.dto.PostPhotoView;
 import com.habitpay.habitpay.domain.challengepost.dto.PostViewResponse;
@@ -120,7 +118,7 @@ public class ChallengePostApi {
 
         if (request.getIsAnnouncement()) {
             Challenge challenge = challengeSearchService.findById(id);
-            if (!challengePostService.isHost(challenge, member)) {
+            if (!challengePostService.isChallengeHost(challenge, member)) {
                 throw new CustomJwtException(HttpStatus.FORBIDDEN, CustomJwtErrorInfo.FORBIDDEN, "Only Host is able to upload an Announcement Post.");
             }
         }
@@ -149,7 +147,7 @@ public class ChallengePostApi {
         ChallengePost post = challengePostService.findById(id);
 
         if (post.getIsAnnouncement()) {
-            if (!challengePostService.isHost(challengePostService.findChallengeByPostId(id), email)) {
+            if (!challengePostService.isChallengeHost(challengePostService.findChallengeByPostId(id), email)) {
                 throw new CustomJwtException(HttpStatus.FORBIDDEN, CustomJwtErrorInfo.FORBIDDEN, "Only Host is able to delete an Announcement Post.");
             }
         }

--- a/src/main/java/com/habitpay/habitpay/domain/challengepost/application/ChallengePostService.java
+++ b/src/main/java/com/habitpay/habitpay/domain/challengepost/application/ChallengePostService.java
@@ -84,7 +84,7 @@ public class ChallengePostService {
             challengePost.modifyPostContent(request.getContent());
         }
         if (request.getIsAnnouncement() != null) {
-            if (request.getIsAnnouncement() && !isChallengeHost(id, getWriter(challengePost))) {
+            if (request.getIsAnnouncement() && !isChallengeHost(findChallengeByPostId(id), getWriter(challengePost))) {
                 throw new CustomJwtException(HttpStatus.FORBIDDEN, CustomJwtErrorInfo.FORBIDDEN, "Only Host is able to upload an Announcement Post.");
             }
             challengePost.modifyPostIsAnnouncement(request.getIsAnnouncement());
@@ -106,13 +106,9 @@ public class ChallengePostService {
             throw new CustomJwtException(HttpStatus.UNAUTHORIZED, CustomJwtErrorInfo.UNAUTHORIZED, "Not a Member who posted.");
         }
     }
-
-    // todo : ChallengePostConroller 리팩토링 후에 메서드 개수 줄이거나 코드 간단하게 만들기
     public boolean isChallengeHost(Challenge challenge, Member member) {
         return challenge.getHost().equals(member);
     }
 
     public boolean isChallengeHost(Challenge challenge, String email) { return challenge.getHost().getEmail().equals(email); }
-
-    public boolean isChallengeHost(Long postId, Member member) { return findChallengeByPostId(postId).getHost().equals(member); }
 }

--- a/src/main/java/com/habitpay/habitpay/domain/challengepost/application/ChallengePostService.java
+++ b/src/main/java/com/habitpay/habitpay/domain/challengepost/application/ChallengePostService.java
@@ -5,7 +5,6 @@ import com.habitpay.habitpay.domain.challengeenrollment.application.ChallengeEnr
 import com.habitpay.habitpay.domain.challengeenrollment.dao.ChallengeEnrollmentRepository;
 import com.habitpay.habitpay.domain.challengeenrollment.domain.ChallengeEnrollment;
 import com.habitpay.habitpay.domain.challengeparticipationrecord.application.ChallengeParticipationRecordService;
-import com.habitpay.habitpay.domain.challengeparticipationrecord.domain.ChallengeParticipationRecord;
 import com.habitpay.habitpay.domain.challengepost.dao.ChallengePostRepository;
 import com.habitpay.habitpay.domain.challengepost.domain.ChallengePost;
 import com.habitpay.habitpay.domain.challengepost.dto.AddPostRequest;
@@ -16,7 +15,6 @@ import com.habitpay.habitpay.domain.refreshtoken.exception.CustomJwtException;
 import com.habitpay.habitpay.global.error.CustomJwtErrorInfo;
 import jakarta.transaction.Transactional;
 import lombok.RequiredArgsConstructor;
-import lombok.extern.java.Log;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.http.HttpStatus;
 import org.springframework.security.core.context.SecurityContextHolder;
@@ -86,7 +84,7 @@ public class ChallengePostService {
             challengePost.modifyPostContent(request.getContent());
         }
         if (request.getIsAnnouncement() != null) {
-            if (request.getIsAnnouncement() && !isHost(id, getWriter(challengePost))) {
+            if (request.getIsAnnouncement() && !isChallengeHost(id, getWriter(challengePost))) {
                 throw new CustomJwtException(HttpStatus.FORBIDDEN, CustomJwtErrorInfo.FORBIDDEN, "Only Host is able to upload an Announcement Post.");
             }
             challengePost.modifyPostIsAnnouncement(request.getIsAnnouncement());
@@ -109,16 +107,12 @@ public class ChallengePostService {
         }
     }
 
-    public boolean isHost(Challenge challenge, Member member) {
+    // todo : ChallengePostConroller 리팩토링 후에 메서드 개수 줄이거나 코드 간단하게 만들기
+    public boolean isChallengeHost(Challenge challenge, Member member) {
         return challenge.getHost().equals(member);
     }
 
-    public boolean isHost(Challenge challenge, String email) {
-        return challenge.getHost().getEmail().equals(email);
-    }
+    public boolean isChallengeHost(Challenge challenge, String email) { return challenge.getHost().getEmail().equals(email); }
 
-    public boolean isHost(Long postId, Member member) {
-        Challenge challenge = findChallengeByPostId(postId);
-        return challenge.getHost().equals(member);
-    }
+    public boolean isChallengeHost(Long postId, Member member) { return findChallengeByPostId(postId).getHost().equals(member); }
 }


### PR DESCRIPTION
* `특정 멤버`가 `특정 챌린지`의 `Host`인지 아닌지 판별하는 메서드의 이름을 변경했습니다.
```java
isHost() => isChallengeHost()
```

* 기존에 있던 메서드를 활용해 `isChallengeHost()`의 오버로딩 개수를 줄일 수 있어 그렇게 했습니다.
```java
    public boolean isChallengeHost(Challenge challenge, Member member) { }
    public boolean isChallengeHost(Challenge challenge, String email) { }
```

* 줄이고 나니, `Member`의 `getEmail() 메서드`를 이용하거나 email을 이용해 Member 객체를 얻는 방식을 사용하면,
 하나의 `isChallengeHost()`만으로 충분하다는 생각도 드네요,,!
의미상 `Member` 객체가 들어가는 게 정확해보이긴 하는데, 함수 하나라도 덜 쓸 수 있을까 싶어서 오버로딩으로 만들었던 거라 조금 고민이 됩니다.
필요하면 언제든 더 리팩토링 하겠습니다.