### PR TITLE
[feat] 챌린지 포스트 변경 시 repository에 save하는 코드 추가#91

### DIFF
--- a/src/main/java/com/habitpay/habitpay/domain/challengepost/application/ChallengePostService.java
+++ b/src/main/java/com/habitpay/habitpay/domain/challengepost/application/ChallengePostService.java
@@ -82,12 +82,14 @@ public class ChallengePostService {
         authorizePostWriter(challengePost);
         if (request.getContent() != null) {
             challengePost.modifyPostContent(request.getContent());
+            challengePostRepository.save(challengePost);
         }
         if (request.getIsAnnouncement() != null) {
             if (request.getIsAnnouncement() && !isChallengeHost(findChallengeByPostId(id), getWriter(challengePost))) {
                 throw new CustomJwtException(HttpStatus.FORBIDDEN, CustomJwtErrorInfo.FORBIDDEN, "Only Host is able to upload an Announcement Post.");
             }
             challengePost.modifyPostIsAnnouncement(request.getIsAnnouncement());
+            challengePostRepository.save(challengePost);
         }
 
         return challengePost;
@@ -110,5 +112,8 @@ public class ChallengePostService {
         return challenge.getHost().equals(member);
     }
 
-    public boolean isChallengeHost(Challenge challenge, String email) { return challenge.getHost().getEmail().equals(email); }
+    public boolean isChallengeHost(Challenge challenge, String email) {
+        String hostEmail = challenge.getHost().getEmail();
+        return hostEmail.equals(email);
+    }
 }


### PR DESCRIPTION
* `챌린지 포스트`의 `content`나 `isAnnouncement` 값에 변경이 있을 시, DB에 반영하기 위한 `save` 메서드 코드를 추가했습니다.
```java
...
            challengePost.modifyPostContent(request.getContent());
            challengePostRepository.save(challengePost);
...

...
            challengePost.modifyPostIsAnnouncement(request.getIsAnnouncement());
            challengePostRepository.save(challengePost);
...

```

---

* `isChallengeHost()` 메서드 중 하나의 가독성을 높이기 위해 return문에 모든 코드를 우겨넣는 대신,
 `hostEmail` 변수에 한 번 값을 받은 후에 처리하는 것으로 리팩토링 했습니다.
```java
public boolean isChallengeHost(Challenge challenge, String email) {
        String hostEmail = challenge.getHost().getEmail();
        return hostEmail.equals(email);
    }
```