### PR TITLE
[Refactor] 서비스 메서드의 이름을 더 명확하게 바꾸기 #97

### DIFF
--- a/src/main/java/com/habitpay/habitpay/domain/challengepost/api/ChallengePostApi.java
+++ b/src/main/java/com/habitpay/habitpay/domain/challengepost/api/ChallengePostApi.java
@@ -1,26 +1,9 @@
 package com.habitpay.habitpay.domain.challengepost.api;
 
-import com.habitpay.habitpay.domain.challenge.application.ChallengeSearchService;
-import com.habitpay.habitpay.domain.challenge.domain.Challenge;
-import com.habitpay.habitpay.domain.challengeenrollment.application.ChallengeEnrollmentSearchService;
-import com.habitpay.habitpay.domain.challengeenrollment.dao.ChallengeEnrollmentRepository;
-import com.habitpay.habitpay.domain.challengeenrollment.domain.ChallengeEnrollment;
 import com.habitpay.habitpay.domain.challengepost.application.*;
-import com.habitpay.habitpay.domain.challengepost.domain.ChallengePost;
 import com.habitpay.habitpay.domain.challengepost.dto.AddPostRequest;
 import com.habitpay.habitpay.domain.challengepost.dto.ModifyPostRequest;
-import com.habitpay.habitpay.domain.member.application.MemberService;
-import com.habitpay.habitpay.domain.member.domain.Member;
-import com.habitpay.habitpay.domain.postphoto.application.PostPhotoCreationService;
-import com.habitpay.habitpay.domain.postphoto.application.PostPhotoDeleteService;
-import com.habitpay.habitpay.domain.postphoto.application.PostPhotoSearchService;
-import com.habitpay.habitpay.domain.postphoto.application.PostPhotoUtilService;
-import com.habitpay.habitpay.domain.postphoto.dto.PostPhotoView;
 import com.habitpay.habitpay.domain.challengepost.dto.PostViewResponse;
-import com.habitpay.habitpay.domain.postphoto.domain.PostPhoto;
-import com.habitpay.habitpay.domain.refreshtoken.exception.CustomJwtException;
-import com.habitpay.habitpay.global.error.CustomJwtErrorInfo;
-import jakarta.transaction.Transactional;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.http.HttpStatus;
@@ -28,9 +11,7 @@ import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.*;
 
-import java.security.Principal;
 import java.util.List;
-import java.util.NoSuchElementException;
 
 @RestController
 @RequiredArgsConstructor
@@ -46,14 +27,14 @@ public class ChallengePostApi {
     public ResponseEntity<PostViewResponse> findPost(@PathVariable Long id) {
 
         return ResponseEntity.ok()
-                .body(challengePostSearchService.findPost(id));
+                .body(challengePostSearchService.findPostById(id));
     }
 
     @GetMapping("/api/challenges/{id}/posts")
     public ResponseEntity<List<PostViewResponse>> findChallengePosts(@PathVariable Long id) {
 
         return ResponseEntity.ok()
-                .body(challengePostSearchService.findChallengePosts(id));
+                .body(challengePostSearchService.findChallengePostsByChallengeId(id));
     }
 
     @GetMapping("/api/challenges/{id}/posts/me")
@@ -83,7 +64,7 @@ public class ChallengePostApi {
 
         return ResponseEntity
                 .status(HttpStatus.CREATED)
-                .body(challengePostCreationService.addPost(request, id, email));
+                .body(challengePostCreationService.save(request, id, email));
     }
 
     @PutMapping("/api/posts/{id}")
@@ -91,14 +72,14 @@ public class ChallengePostApi {
             @RequestBody ModifyPostRequest request, @PathVariable Long id) {
 
         return ResponseEntity.ok()
-                .body(challengePostUpdateService.modifyPost(request, id));
+                .body(challengePostUpdateService.update(request, id));
     }
 
     @DeleteMapping("/api/posts/{id}")
     public ResponseEntity<Void> deletePost(
             @PathVariable Long id, @AuthenticationPrincipal String email) {
 
-        challengePostDeleteService.deletePost(id, email);
+        challengePostDeleteService.delete(id, email);
         return ResponseEntity.ok()
                 .build();
     }

--- a/src/main/java/com/habitpay/habitpay/domain/challengepost/application/ChallengePostCreationService.java
+++ b/src/main/java/com/habitpay/habitpay/domain/challengepost/application/ChallengePostCreationService.java
@@ -3,7 +3,6 @@ package com.habitpay.habitpay.domain.challengepost.application;
 import com.habitpay.habitpay.domain.challenge.application.ChallengeSearchService;
 import com.habitpay.habitpay.domain.challenge.domain.Challenge;
 import com.habitpay.habitpay.domain.challengeenrollment.application.ChallengeEnrollmentSearchService;
-import com.habitpay.habitpay.domain.challengeenrollment.dao.ChallengeEnrollmentRepository;
 import com.habitpay.habitpay.domain.challengeenrollment.domain.ChallengeEnrollment;
 import com.habitpay.habitpay.domain.challengeparticipationrecord.application.ChallengeParticipationRecordCreationService;
 import com.habitpay.habitpay.domain.challengepost.dao.ChallengePostRepository;
@@ -18,11 +17,7 @@ import jakarta.transaction.Transactional;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.http.HttpStatus;
-import org.springframework.http.ResponseEntity;
-import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.stereotype.Service;
-import org.springframework.web.bind.annotation.PathVariable;
-import org.springframework.web.bind.annotation.RequestBody;
 
 import java.util.List;
 import java.util.NoSuchElementException;
@@ -40,35 +35,36 @@ public class ChallengePostCreationService {
     private final ChallengeParticipationRecordCreationService challengeParticipationRecordCreationService;
 
     private final ChallengePostRepository challengePostRepository;
-    private final ChallengeEnrollmentRepository challengeEnrollmentRepository;
 
     @Transactional
-    public List<String> addPost(AddPostRequest request, Long challengeId, String email) {
+    public List<String> save(AddPostRequest request, Long challengeId, String email) {
 
         Member member = memberService.findByEmail(email);
+        Challenge challenge = challengeSearchService.findById(challengeId);
         // todo : List<>로 받게 될 경우 'challenge id' 이용해 enrollment 특정해야 함
         ChallengeEnrollment enrollment = challengeEnrollmentSearchService.findByMember(member)
                 .orElseThrow(() -> new NoSuchElementException("(for debugging) no enrollment for : " + email));
 
         if (request.getIsAnnouncement()) {
-            Challenge challenge = challengeSearchService.findById(challengeId);
-            // todo : isChallengeHost가 email, member 모두 사용 가능
             if (!challengePostUtilService.isChallengeHost(challenge, member)) {
                 throw new CustomJwtException(HttpStatus.FORBIDDEN, CustomJwtErrorInfo.FORBIDDEN, "Only Host is able to upload an Announcement Post.");
             }
         }
 
-        ChallengePost challengePost = this.save(request, enrollment.getId());
+        ChallengePost challengePost = this.savePost(request, enrollment.getId());
+        checkChallengeParticipationRecord(challengePost, enrollment);
         return postPhotoCreationService.save(challengePost, request.getPhotos());
     }
 
-    private ChallengePost save(AddPostRequest request, Long challengeEnrollmentId) {
-        ChallengePost post = challengePostRepository.save(request.toEntity(challengeEnrollmentId));
-        // todo : service 메서드로 대체하기
-        ChallengeEnrollment enrollment = challengeEnrollmentRepository.findById(challengeEnrollmentId)
-                .orElseThrow(() -> new NoSuchElementException("No Such enrollment " + challengeEnrollmentId));
+    private ChallengePost savePost(AddPostRequest request, Long challengeEnrollmentId) {
+
+        return challengePostRepository.save(request.toEntity(challengeEnrollmentId));
+    }
+
+    private void checkChallengeParticipationRecord(ChallengePost post, ChallengeEnrollment enrollment) {
+
+        // todo : record 인정되는지 확인하는 코드 추가해야 함
         challengeParticipationRecordCreationService.save(enrollment, post);
-        return post;
     }
 
 }

--- a/src/main/java/com/habitpay/habitpay/domain/challengepost/application/ChallengePostDeleteService.java
+++ b/src/main/java/com/habitpay/habitpay/domain/challengepost/application/ChallengePostDeleteService.java
@@ -42,7 +42,7 @@ public class ChallengePostDeleteService {
     private void deletePost(Long id) {
         ChallengePost challengePost = challengePostSearchService.findById(id);
 
-        postPhotoDeleteService.deleteAllByPost(challengePost);
+        postPhotoDeleteService.deleteByPost(challengePost);
         challengePostRepository.delete(challengePost);
     }
 }

--- a/src/main/java/com/habitpay/habitpay/domain/challengepost/application/ChallengePostDeleteService.java
+++ b/src/main/java/com/habitpay/habitpay/domain/challengepost/application/ChallengePostDeleteService.java
@@ -1,5 +1,6 @@
 package com.habitpay.habitpay.domain.challengepost.application;
 
+import com.habitpay.habitpay.domain.challenge.domain.Challenge;
 import com.habitpay.habitpay.domain.challengepost.dao.ChallengePostRepository;
 import com.habitpay.habitpay.domain.challengepost.domain.ChallengePost;
 import com.habitpay.habitpay.domain.postphoto.application.PostPhotoDeleteService;
@@ -9,8 +10,6 @@ import jakarta.transaction.Transactional;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.http.HttpStatus;
-import org.springframework.http.ResponseEntity;
-import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.stereotype.Service;
 
 @Service
@@ -24,23 +23,23 @@ public class ChallengePostDeleteService {
     private final ChallengePostUtilService challengePostUtilService;
 
     @Transactional
-    public void deletePost(Long postId, String email) {
+    public void delete(Long postId, String email) {
         ChallengePost post = challengePostSearchService.findById(postId);
+        Challenge challenge = challengePostSearchService.findChallengeByPostId(postId);
 
         if (post.getIsAnnouncement()) {
-            if (!challengePostUtilService.isChallengeHost(challengePostSearchService.findChallengeByPostId(postId), email)) {
+            if (!challengePostUtilService.isChallengeHost(challenge, email)) {
                 throw new CustomJwtException(HttpStatus.FORBIDDEN, CustomJwtErrorInfo.FORBIDDEN, "Only Host is able to delete an Announcement Post.");
             }
         }
         else {
-            // todo : 관리자 계정이 생겨서 일반 포스트도 삭제할 수 있게 되면 수정
             throw new CustomJwtException(HttpStatus.FORBIDDEN, CustomJwtErrorInfo.FORBIDDEN, "Post cannot be deleted.");
         }
 
-        this.delete(postId);
+        this.deletePost(postId);
     }
 
-    private void delete(Long id) {
+    private void deletePost(Long id) {
         ChallengePost challengePost = challengePostSearchService.findById(id);
 
         postPhotoDeleteService.deleteAllByPost(challengePost);

--- a/src/main/java/com/habitpay/habitpay/domain/challengepost/application/ChallengePostSearchService.java
+++ b/src/main/java/com/habitpay/habitpay/domain/challengepost/application/ChallengePostSearchService.java
@@ -15,7 +15,6 @@ import com.habitpay.habitpay.domain.postphoto.domain.PostPhoto;
 import com.habitpay.habitpay.domain.postphoto.dto.PostPhotoView;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
-import org.springframework.http.ResponseEntity;
 import org.springframework.stereotype.Service;
 
 import java.util.List;
@@ -34,7 +33,7 @@ public class ChallengePostSearchService {
     private final ChallengePostRepository challengePostRepository;
     private final ChallengeEnrollmentRepository challengeEnrollmentRepository;
 
-    public PostViewResponse findPost(Long postId) {
+    public PostViewResponse findPostById(Long postId) {
         ChallengePost challengePost = this.findById(postId);
         List<PostPhoto> photoList = postPhotoSearchService.findAllByPost(challengePost);
         List<PostPhotoView> photoViewList = postPhotoUtilService.makePhotoViewList(photoList);
@@ -42,7 +41,7 @@ public class ChallengePostSearchService {
         return new PostViewResponse(challengePost, photoViewList);
     }
 
-    public List<PostViewResponse> findChallengePosts(Long challengeId) {
+    public List<PostViewResponse> findChallengePostsByChallengeId(Long challengeId) {
 
         return this.findAllByChallenge(challengeId)
                 .stream()

--- a/src/main/java/com/habitpay/habitpay/domain/challengepost/application/ChallengePostUpdateService.java
+++ b/src/main/java/com/habitpay/habitpay/domain/challengepost/application/ChallengePostUpdateService.java
@@ -35,7 +35,7 @@ public class ChallengePostUpdateService {
     public List<String> update(ModifyPostRequest request, Long postId) {
         this.updatePost(request, postId);
 
-        request.getDeletedPhotoIds().forEach(postPhotoDeleteService::delete);
+        postPhotoDeleteService.deletePhotoList(request.getDeletedPhotoIds());
         request.getModifiedPhotos().forEach(photo -> postPhotoUtilService.changeViewOrder(photo.getPhotoId(), photo.getViewOrder()));
         return postPhotoCreationService.save(challengePostSearchService.findById(postId), request.getNewPhotos());
     }

--- a/src/main/java/com/habitpay/habitpay/domain/postphoto/application/PostPhotoDeleteService.java
+++ b/src/main/java/com/habitpay/habitpay/domain/postphoto/application/PostPhotoDeleteService.java
@@ -21,7 +21,18 @@ public class PostPhotoDeleteService {
     private final PostPhotoSearchService postPhotoSearchService;
     private final PostPhotoUtilService postPhotoUtilService;
 
-    public void delete(Long id) {
+    public void deleteByPost(ChallengePost post) {
+        List<PostPhoto> photoList = postPhotoRepository.findAllByPost(post)
+                .orElseThrow(() -> new NoSuchElementException("(for debugging) not found post : " + post.getId()));
+
+        photoList.forEach(photo -> deletePhoto(photo.getId()));
+    }
+
+    public void deletePhotoList(List<Long> photoIdList) {
+        photoIdList.forEach(this::deletePhoto);
+    }
+
+    private void deletePhoto(Long id) {
         PostPhoto postPhoto = postPhotoRepository.findById(id)
                 .orElseThrow(() -> new NoSuchElementException("(for debugging) not found : " + id));
 
@@ -33,10 +44,4 @@ public class PostPhotoDeleteService {
         postPhotoRepository.delete(postPhoto);
     }
 
-    public void deleteAllByPost(ChallengePost post) {
-        List<PostPhoto> photoList = postPhotoRepository.findAllByPost(post)
-                .orElseThrow(() -> new NoSuchElementException("(for debugging) not found post : " + post.getId()));
-
-        photoList.forEach(photo -> {delete(photo.getId());});
-    }
 }


### PR DESCRIPTION
* 서비스 메서드의 이름을, 컨트롤러 메서드에서 바로 사용해도 의미가 명확히 전달될 수 있도록 변경했습니다.

```java
// ex)

public List<String> addPost(...) { }
=>    public List<String> save(...) { }

public void deletePost(...) { }
=>    public void delete(...) { }

public PostViewResponse findPost(...) { }
=>    public PostViewResponse findPostById(...) { }

...
```

---

* 관련하여 서비스 내의 다른 메서드와 이름이 겹칠 경우, private 메서드 `save -> savePost` 식으로 코드 내에서 작동하는 내용이 뭔지 더 드러나도록 변경했습니다.

```java
// ex

@Transactional
public List<String> save(...) {
    포스트가 공지글인지 아닌지 확인,
    포스트가 record로 등록되어야 하는지 아닌지 확인,
    사진들도 따로 저장,
    savePost() 메서드 호출 등
}

private ChallengePost savePost(AddPostRequest request, Long challengeEnrollmentId) {
...
        // 포스트 저장만 하는 메서드여서 이름이 savePost
        return challengePostRepository.save(request.toEntity(challengeEnrollmentId));
    }
```

---

* 하나의 메서드가 너무 많은 기능을 담고 있는 경우, 기능 별로 분리하는 리팩토링도 일부 진행했습니다.
```java
// ex

savePost : 포스트를 repo에 저장 + record로 저장되어야 하는지 확인

=> 

savePost : 포스트를 repo에 저장
checkChallengeParticipationRecord : record로 저장되어야 하는지 확인
```

---

* 코드가 너무 길어져 가독성이 떨어지는 경우, 변수로 따로 빼내어 좀 더 보기 편하게 바꿨습니다.

```java
// before ex
        ...
            if (...(challengePostSearchService.findChallengeByPostId(postId), email))
...

// after ex
...
Challenge challenge = challengePostSearchService.findChallengeByPostId(postId);
...
            if (...(challenge, email))
...
```