### PR TITLE
[feat] 포스트 업로드 시 record 객체 생성 로직 초안 #101

### DIFF
--- a/src/main/java/com/habitpay/habitpay/domain/challengeparticipationrecord/application/ChallengeParticipationRecordSearchService.java
+++ b/src/main/java/com/habitpay/habitpay/domain/challengeparticipationrecord/application/ChallengeParticipationRecordSearchService.java
@@ -1,12 +1,15 @@
 package com.habitpay.habitpay.domain.challengeparticipationrecord.application;
 
+import com.habitpay.habitpay.domain.challengeenrollment.domain.ChallengeEnrollment;
 import com.habitpay.habitpay.domain.challengeparticipationrecord.dao.ChallengeParticipationRecordRepository;
 import com.habitpay.habitpay.domain.challengeparticipationrecord.domain.ChallengeParticipationRecord;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
 
+import java.util.List;
 import java.util.NoSuchElementException;
+import java.util.Optional;
 
 @Service
 @RequiredArgsConstructor
@@ -18,5 +21,9 @@ public class ChallengeParticipationRecordSearchService {
     public ChallengeParticipationRecord findById(Long id) {
         return challengeParticipationRecordRepository.findById(id)
                 .orElseThrow(() -> new NoSuchElementException("No Such Record " + id));
+    }
+
+    public Optional<List<ChallengeParticipationRecord>> findAllByChallengeEnrollment(ChallengeEnrollment enrollment) {
+        return challengeParticipationRecordRepository.findAllByChallengeEnrollment(enrollment);
     }
 }

--- a/src/main/java/com/habitpay/habitpay/domain/challengeparticipationrecord/dao/ChallengeParticipationRecordRepository.java
+++ b/src/main/java/com/habitpay/habitpay/domain/challengeparticipationrecord/dao/ChallengeParticipationRecordRepository.java
@@ -1,8 +1,12 @@
 package com.habitpay.habitpay.domain.challengeparticipationrecord.dao;
 
+import com.habitpay.habitpay.domain.challengeenrollment.domain.ChallengeEnrollment;
 import com.habitpay.habitpay.domain.challengeparticipationrecord.domain.ChallengeParticipationRecord;
 import org.springframework.data.jpa.repository.JpaRepository;
 
-public interface ChallengeParticipationRecordRepository extends JpaRepository<ChallengeParticipationRecord, Long> {
+import java.util.List;
+import java.util.Optional;
 
+public interface ChallengeParticipationRecordRepository extends JpaRepository<ChallengeParticipationRecord, Long> {
+    Optional<List<ChallengeParticipationRecord>> findAllByChallengeEnrollment(ChallengeEnrollment enrollment);
 }

--- a/src/main/java/com/habitpay/habitpay/domain/challengepost/application/ChallengePostCreationService.java
+++ b/src/main/java/com/habitpay/habitpay/domain/challengepost/application/ChallengePostCreationService.java
@@ -19,6 +19,7 @@ import lombok.extern.slf4j.Slf4j;
 import org.springframework.http.HttpStatus;
 import org.springframework.stereotype.Service;
 
+import java.time.ZonedDateTime;
 import java.util.List;
 import java.util.NoSuchElementException;
 
@@ -32,7 +33,6 @@ public class ChallengePostCreationService {
     private final ChallengePostUtilService challengePostUtilService;
     private final PostPhotoCreationService postPhotoCreationService;
     private final ChallengeEnrollmentSearchService challengeEnrollmentSearchService;
-    private final ChallengeParticipationRecordCreationService challengeParticipationRecordCreationService;
 
     private final ChallengePostRepository challengePostRepository;
 
@@ -52,19 +52,13 @@ public class ChallengePostCreationService {
         }
 
         ChallengePost challengePost = this.savePost(request, enrollment);
-        this.checkChallengeParticipationRecord(challengePost, enrollment);
+        challengePostUtilService.verifyChallengeParticipationRecord(challengePost, enrollment);
         return postPhotoCreationService.save(challengePost, request.getPhotos());
     }
 
     private ChallengePost savePost(AddPostRequest request, ChallengeEnrollment enrollment) {
 
         return challengePostRepository.save(request.toEntity(enrollment));
-    }
-
-    private void checkChallengeParticipationRecord(ChallengePost post, ChallengeEnrollment enrollment) {
-
-        // todo : record 인정되는지 확인하는 코드 추가해야 함
-        challengeParticipationRecordCreationService.save(enrollment, post);
     }
 
 }

--- a/src/main/java/com/habitpay/habitpay/domain/challengepost/application/ChallengePostUtilService.java
+++ b/src/main/java/com/habitpay/habitpay/domain/challengepost/application/ChallengePostUtilService.java
@@ -3,6 +3,9 @@ package com.habitpay.habitpay.domain.challengepost.application;
 import com.habitpay.habitpay.domain.challenge.domain.Challenge;
 import com.habitpay.habitpay.domain.challengeenrollment.dao.ChallengeEnrollmentRepository;
 import com.habitpay.habitpay.domain.challengeenrollment.domain.ChallengeEnrollment;
+import com.habitpay.habitpay.domain.challengeparticipationrecord.application.ChallengeParticipationRecordCreationService;
+import com.habitpay.habitpay.domain.challengeparticipationrecord.application.ChallengeParticipationRecordSearchService;
+import com.habitpay.habitpay.domain.challengeparticipationrecord.domain.ChallengeParticipationRecord;
 import com.habitpay.habitpay.domain.challengepost.domain.ChallengePost;
 import com.habitpay.habitpay.domain.member.domain.Member;
 import com.habitpay.habitpay.domain.refreshtoken.exception.CustomJwtException;
@@ -13,12 +16,22 @@ import org.springframework.http.HttpStatus;
 import org.springframework.security.core.context.SecurityContextHolder;
 import org.springframework.stereotype.Service;
 
+import java.time.DayOfWeek;
+import java.time.LocalDateTime;
+import java.time.ZonedDateTime;
+import java.time.chrono.ChronoLocalDate;
+import java.util.ArrayList;
+import java.util.List;
 import java.util.NoSuchElementException;
+import java.util.Optional;
 
 @Service
 @RequiredArgsConstructor
 @Slf4j
 public class ChallengePostUtilService {
+
+    private final ChallengeParticipationRecordCreationService challengeParticipationRecordCreationService;
+    private final ChallengeParticipationRecordSearchService challengeParticipationRecordSearchService;
 
     public void authorizePostWriter(ChallengePost challengePost) {
         String email = SecurityContextHolder.getContext().getAuthentication().getName();
@@ -35,4 +48,63 @@ public class ChallengePostUtilService {
         String hostEmail = challenge.getHost().getEmail();
         return hostEmail.equals(email);
     }
+
+    public void verifyChallengeParticipationRecord(ChallengePost post, ChallengeEnrollment enrollment) {
+        Challenge challenge = post.getChallengeEnrollment().getChallenge();
+
+        ZonedDateTime now = ZonedDateTime.now();
+
+        if (!now.isAfter(challenge.getStartDate()) || !now.isBefore(challenge.getEndDate())) {
+            return;
+        }
+
+        // todo : ParticipationDay 비트 방식 확인하기
+        //  (우선 8비트 기준 앞자리부터 월요일이라고 상정함 ex.0b10101000(월수금))
+        DayOfWeek nowDayOfWeek = now.getDayOfWeek();
+        int nowDayOfWeekValue = nowDayOfWeek.getValue();
+//        int nowDayOfWeekValue = now.getDayOfWeek().getValue();
+        boolean todayIsParticipationDay = (challenge.getParticipatingDays() & (1 << (nowDayOfWeekValue - 1))) != 0;
+
+        // todo : 디버깅 용도
+        log.info("오늘은 " + nowDayOfWeek);
+        log.info("비트로 표현하자면 " + nowDayOfWeekValue);
+        log.info("챌린지 인증해야 하는 날은? " + challenge.getParticipatingDays());
+        log.info("오늘은 챌린지 참여날: " + todayIsParticipationDay);
+
+        if (!todayIsParticipationDay) {
+            return;
+        }
+
+        if (alreadyParticipateToday(enrollment, now)) {
+            return;
+        }
+
+        //todo: challenge.numberOfParticipants +1 하는 메서드 만들기 (challenge 도메인이나 서비스 내 위치?)
+        challengeParticipationRecordCreationService.save(enrollment, post);
+    }
+
+    private boolean alreadyParticipateToday(ChallengeEnrollment enrollment, ZonedDateTime now) {
+        List<ChallengeParticipationRecord> optionalRecordList = challengeParticipationRecordSearchService.findAllByChallengeEnrollment(enrollment)
+                .orElse(new ArrayList<>());
+
+        if (optionalRecordList.isEmpty()) { return false; }
+
+        LocalDateTime today = now.toLocalDate().atStartOfDay();
+
+        Optional<ChallengeParticipationRecord> optionalRecord = optionalRecordList
+                .stream()
+//                .filter(record -> record.getCreatedAt().toLocalDate().isEqual(ChronoLocalDate.from(today)))
+                .filter(record -> {
+                    log.info("레코드 toLocalDate {}", record.getCreatedAt().toLocalDate());
+                    log.info("크로노 today {}", String.valueOf(ChronoLocalDate.from(today)));
+                    return record.getCreatedAt().toLocalDate().isEqual(ChronoLocalDate.from(today));
+                })
+                .findFirst();
+
+        // todo : 디버깅 용도
+        log.info("투데이 atStartOfDay {}", today);
+
+        return optionalRecord.isPresent();
+    }
+
 }


### PR DESCRIPTION
* 챌린지 `포스트` 업로드 시, 특정 조건을 달성하면 `record 객체`가 새로 생성 및 저장되어야 함
* 특정 조건 :
```java
1. 포스트 업로드 된 날짜가 챌린지 진행 기간 이내면서,
2. 챌린지의 참여 요일이면서, (ex. 월요일 인증 챌린지면 업로드된 날짜의 요일이 월요일이어야 함)
3. 해당 날짜에 아직 record 객체가 없다면 (=== 아직 그날의 인증 포스트가 없다면)

=> ChallengeParticipationRecord 객체를 생성 및 저장함
   (해당 Challenge 객체의 numberOfParticipants 속성도 +1 할 예정)
```
---
* 해당 로직은 `포스트 저장 메서드` 내의 `verifyChallengeParticipationRecord` 메서드를 통해 이루어짐
```java
@Transactional
    public List<String> save(AddPostRequest request, Long challengeId, String email) {
       ...
        challengePostUtilService.verifyChallengeParticipationRecord(challengePost, enrollment);
       ...
    }
```
---

```java
// (로직 흐름이 보이게 하기 위해 코드를 거칠게 잘랐습니다.)

public void verifyChallengeParticipationRecord(...) {

        // 챌린지 기간 내인지 확인
        if (!now.isAfter(challenge.getStartDate()) || !now.isBefore(challenge.getEndDate())) {
            return;
        }

        // 포스트 업로드 날짜가 챌린지 참여 요일에 해당하는지 확인
        int nowDayOfWeekValue = now.getDayOfWeek().getValue();
        boolean todayIsParticipationDay = (challenge.getParticipatingDays() & (1 << (nowDayOfWeekValue - 1))) != 0;
        if (!todayIsParticipationDay) {
            return;
        }

        // 앞서 해당 날짜의 인증이 있었는지 여부 확인
        if (alreadyParticipateToday(enrollment, now)) {
            return;
        }

        // 모든 조건에 맞으면 객체 생성 및 저장
        challengeParticipationRecordCreationService.save(enrollment, post);
    }
```
---
* 기타 사항 :
* `verifyChallengeParticipationRecord` 메서드명의 의미가 명확히 와닿지 않아서 고민 중
    (`verifyPostForRecord` 이런 식으로 바꾸면?)
* `record 객체` 생성과 동시에, `challenge 객체`의 `numberOfParticipants` 요소값을 `+1` 해주는 메서드 추가 예정
* 비트 연산과 Date 관련 자바 객체에 익숙하지 않아 내부 메서드 이용할 때 chatGPT의 도움을 많이 받았음 &
     초안으로 작성했고, 추가로 로직 보강해야 함
    -> 그래서 검증 및 추가 수정 목적으로 `log.info()`를 단 디버깅용 코드가 아직 많음