### PR TITLE
[feat] 쿼리 메서드를 이용해 alreadyParticipateToday 메서드 단순화하기 #107

### DIFF
--- a/src/main/java/com/habitpay/habitpay/domain/challengeparticipationrecord/application/ChallengeParticipationRecordSearchService.java
+++ b/src/main/java/com/habitpay/habitpay/domain/challengeparticipationrecord/application/ChallengeParticipationRecordSearchService.java
@@ -7,6 +7,7 @@ import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
 
+import java.time.LocalDateTime;
 import java.util.List;
 import java.util.NoSuchElementException;
 import java.util.Optional;
@@ -25,5 +26,16 @@ public class ChallengeParticipationRecordSearchService {
 
     public Optional<List<ChallengeParticipationRecord>> findAllByChallengeEnrollment(ChallengeEnrollment enrollment) {
         return challengeParticipationRecordRepository.findAllByChallengeEnrollment(enrollment);
+    }
+
+    public Optional<ChallengeParticipationRecord> findByChallengeEnrollmentAndCreatedAtBetween(
+            ChallengeEnrollment enrollment,
+            LocalDateTime startOfDay,
+            LocalDateTime endOfDay) {
+        return challengeParticipationRecordRepository.findByChallengeEnrollmentAndCreatedAtBetween(
+                enrollment,
+                startOfDay,
+                endOfDay
+        );
     }
 }

--- a/src/main/java/com/habitpay/habitpay/domain/challengeparticipationrecord/dao/ChallengeParticipationRecordRepository.java
+++ b/src/main/java/com/habitpay/habitpay/domain/challengeparticipationrecord/dao/ChallengeParticipationRecordRepository.java
@@ -4,9 +4,11 @@ import com.habitpay.habitpay.domain.challengeenrollment.domain.ChallengeEnrollme
 import com.habitpay.habitpay.domain.challengeparticipationrecord.domain.ChallengeParticipationRecord;
 import org.springframework.data.jpa.repository.JpaRepository;
 
+import java.time.LocalDateTime;
 import java.util.List;
 import java.util.Optional;
 
 public interface ChallengeParticipationRecordRepository extends JpaRepository<ChallengeParticipationRecord, Long> {
     Optional<List<ChallengeParticipationRecord>> findAllByChallengeEnrollment(ChallengeEnrollment enrollment);
+    Optional<ChallengeParticipationRecord> findByChallengeEnrollmentAndCreatedAtBetween(ChallengeEnrollment enrollment, LocalDateTime startOfDay, LocalDateTime endOfDay);
 }

--- a/src/main/java/com/habitpay/habitpay/domain/challengepost/application/ChallengePostCreationService.java
+++ b/src/main/java/com/habitpay/habitpay/domain/challengepost/application/ChallengePostCreationService.java
@@ -4,7 +4,6 @@ import com.habitpay.habitpay.domain.challenge.application.ChallengeSearchService
 import com.habitpay.habitpay.domain.challenge.domain.Challenge;
 import com.habitpay.habitpay.domain.challengeenrollment.application.ChallengeEnrollmentSearchService;
 import com.habitpay.habitpay.domain.challengeenrollment.domain.ChallengeEnrollment;
-import com.habitpay.habitpay.domain.challengeparticipationrecord.application.ChallengeParticipationRecordCreationService;
 import com.habitpay.habitpay.domain.challengepost.dao.ChallengePostRepository;
 import com.habitpay.habitpay.domain.challengepost.domain.ChallengePost;
 import com.habitpay.habitpay.domain.challengepost.dto.AddPostRequest;
@@ -19,7 +18,6 @@ import lombok.extern.slf4j.Slf4j;
 import org.springframework.http.HttpStatus;
 import org.springframework.stereotype.Service;
 
-import java.time.ZonedDateTime;
 import java.util.List;
 import java.util.NoSuchElementException;
 
@@ -52,7 +50,7 @@ public class ChallengePostCreationService {
         }
 
         ChallengePost challengePost = this.savePost(request, enrollment);
-        challengePostUtilService.verifyChallengeParticipationRecord(challengePost, enrollment);
+        challengePostUtilService.verifyChallengePostForRecord(challengePost);
         return postPhotoCreationService.save(challengePost, request.getPhotos());
     }
 


### PR DESCRIPTION
* 업로드한 `포스트`가 `record`로 인정되는지 검증하기 위해,
해당 `업로드일에 이미 등록된 record`가 있는지 여부를 확인하는 메서드가 필요함
-> `alreadyParticipateToday`
* 이 메서드를 단순화하기 위해 쿼리 메서드 추가

```java
Optional<ChallengeParticipationRecord> findByChallengeEnrollmentAndCreatedAtBetween
(ChallengeEnrollment enrollment, LocalDateTime startOfDay, LocalDateTime endOfDay);
```
* 해당 `enrollment` 소속 중에 `포스트 CreatedAt` 날짜에 해당하는 객체가 있는지 검색하는 메서드 추가
---

* 동명의 메서드를 record search sevice에 추가
```java
public Optional<ChallengeParticipationRecord> findByChallengeEnrollmentAndCreatedAtBetween(
            ChallengeEnrollment enrollment,
            LocalDateTime startOfDay,
            LocalDateTime endOfDay) {
        return challengeParticipationRecordRepository.findByChallengeEnrollmentAndCreatedAtBetween(
                enrollment,
                startOfDay,
                endOfDay
        );
    }
```

---

* 위의 메서드 사용으로 `alreadyParticipateToday`가 깔끔해졌습니다.

```java
private boolean alreadyParticipateToday
(ChallengeEnrollment enrollment, ZonedDateTime now) {
       Optional<ChallengeParticipationRecord> optionalRecord
                = challengeParticipationRecordSearchService.findByChallengeEnrollmentAndCreatedAtBetween(
                enrollment,
                now.toLocalDate().atStartOfDay(),
                now.toLocalDate().atTime(LocalTime.MAX)
        );

        return optionalRecord.isPresent();
    }
```
* 현재는 인정 시간대가 해당일의 `00:00 ~ 23:59:59999..` 입니다.
* 이전 회의 때 `00:00 ~ 24:00` 시간대를 들은 것 같아서, 이 시간대 역시 코드 추가 후 주석 처리했습니다.
-> 결정 후 선택하면 됨

---

* 업로드된 `포스트`가 `record`가 될 자격이 있는지 검증하고 처리하는 메서드의 이름을 변경했습니다.
```java
verifyChallengeParticipationRecord
=> verifyChallengePostForRecord
```

---

* `verifyChallengePostForRecord` 메서드명에 맞게 `ChallengePost`만 넣어도 되도록 메서드 인자를 수정했습니다.
```java
verifyChallengePostForRecord(ChallengePost post, ChallengeEnrollment enrollment);
=> verifyChallengePostForRecord(ChallengePost post);
```