### PR TITLE
refact/change_name_of_method_realted_with_alreadyParticipateToday#109

### DIFF
--- a/src/main/java/com/habitpay/habitpay/domain/challengeparticipationrecord/application/ChallengeParticipationRecordSearchService.java
+++ b/src/main/java/com/habitpay/habitpay/domain/challengeparticipationrecord/application/ChallengeParticipationRecordSearchService.java
@@ -28,7 +28,7 @@ public class ChallengeParticipationRecordSearchService {
         return challengeParticipationRecordRepository.findAllByChallengeEnrollment(enrollment);
     }
 
-    public Optional<ChallengeParticipationRecord> findByChallengeEnrollmentAndCreatedAtBetween(
+    public Optional<ChallengeParticipationRecord> findTodayRecordInEnrollment(
             ChallengeEnrollment enrollment,
             LocalDateTime startOfDay,
             LocalDateTime endOfDay) {

--- a/src/main/java/com/habitpay/habitpay/domain/challengepost/application/ChallengePostUtilService.java
+++ b/src/main/java/com/habitpay/habitpay/domain/challengepost/application/ChallengePostUtilService.java
@@ -70,7 +70,7 @@ public class ChallengePostUtilService {
             return;
         }
 
-        if (alreadyParticipateToday(enrollment, now)) {
+        if (isAlreadyParticipateToday(enrollment, now)) {
             return;
         }
 
@@ -78,24 +78,14 @@ public class ChallengePostUtilService {
         challengeParticipationRecordCreationService.save(enrollment, post);
     }
 
-    private boolean alreadyParticipateToday(ChallengeEnrollment enrollment, ZonedDateTime now) {
-        // todo : 인정 시간대 확인하고 남기거나 삭제
-        //      해당일 00:00 ~ 23:59:59999...
+    private boolean isAlreadyParticipateToday(ChallengeEnrollment enrollment, ZonedDateTime now) {
+
         Optional<ChallengeParticipationRecord> optionalRecord
-                = challengeParticipationRecordSearchService.findByChallengeEnrollmentAndCreatedAtBetween(
+                = challengeParticipationRecordSearchService.findTodayRecordInEnrollment(
                 enrollment,
                 now.toLocalDate().atStartOfDay(),
                 now.toLocalDate().atTime(LocalTime.MAX)
         );
-
-        // todo : 인정 시간대 확인하고 남기거나 삭제
-        //      해당일 00:00 ~ 24:00 (다음날 00:00까지)
-//        Optional<ChallengeParticipationRecord> optionalRecord
-//                = challengeParticipationRecordSearchService.findByChallengeEnrollmentAndCreatedAtBetween(
-//                enrollment,
-//                now.toLocalDate().atStartOfDay(),
-//                now.toLocalDate().plusDays(1).atStartOfDay()
-//        );
 
         return optionalRecord.isPresent();
     }


### PR DESCRIPTION
* `alreadyParticipateToday`의 이름을 반환 데이터 타입인 `boolean`에 맞게 `isAlreadyParticipateToday`로 바꿨습니다.
 ---
* `record` 인정 시간대인 `00:00~23:59:999..`와 관련 없는 코드(주석 처리 되어있던 것)를 삭제했습니다.
---
* `challengeParticipationRecordSearchService`에서, 특정 `챌린지 등록 객체`에서 `해당일`의 `record`를 찾는 메서드의 이름을 변경했습니다.
```java
// before
Optional<ChallengeParticipationRecord> findByChallengeEnrollmentAndCreatedAtBetween
// repository 메서드와 동일한 이름을 사용

// after
Optional<ChallengeParticipationRecord> findTodayRecordInEnrollment
// challengePost 서비스에서 해당 메서드 사용 시, 역할과 필요 인자가 더 잘 드러나도록 이름 변경
```