### PR TITLE
Chore/spring rest docs 적용#102

### DIFF
--- a/.github/workflows/api-docs.yaml
+++ b/.github/workflows/api-docs.yaml
@@ -6,7 +6,7 @@ on:
       - chore/spring-rest-docs-적용#102
 
 concurrency:
-  group: ${{ github.workflow }}-${{ github.ref }}
+  group: "github-pages"
   cancel-in-progress: true
 
 jobs:

--- a/.github/workflows/api-docs.yaml
+++ b/.github/workflows/api-docs.yaml
@@ -1,0 +1,47 @@
+name: Spring Rest Docs
+on:
+  push:
+    branches:
+      - main
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  deploy:
+    permissions:
+      pages: write
+      id-token: write
+
+    environment:
+      name: github-pages
+      url: ${{ steps.deployment.outputs.page_url }}
+
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Set up JDK 17
+        uses: actions/setup-java@v4
+        with:
+          java-version: '17'
+          distribution: 'temurin'
+          cache: 'gradle'
+
+      - name: Set up Pages
+        uses: actions/configure-pages@v5
+
+      - name: Build Asciidoc
+        run: ./gradlew asciidoctor
+
+      - name: Upload pages artifact
+        uses: actions/upload-pages-artifact@v4
+        with:
+          path: './build/docs/asciidoc'
+
+      - name: Deploy to GitHub Pages
+        id: deployment
+        uses: actions/deploy-pages@v4

--- a/.github/workflows/api-docs.yaml
+++ b/.github/workflows/api-docs.yaml
@@ -11,13 +11,11 @@ concurrency:
   group: github-pages
   cancel-in-progress: true
 
-permissions:
-  contents: read
-  pages: write
-  id-token: write
-
 jobs:
   deploy:
+    permissions:
+      pages: write
+      id-token: write
     environment:
       name: github-pages
       url: ${{ steps.deployment.outputs.page_url }}

--- a/.github/workflows/api-docs.yaml
+++ b/.github/workflows/api-docs.yaml
@@ -36,7 +36,7 @@ jobs:
       - name: Build Asciidoc
         run: ./gradlew asciidoctor
       - name: Upload pages artifact
-        uses: actions/upload-pages-artifact@v4
+        uses: actions/upload-pages-artifact@v3
         with:
           path: './build/docs/asciidoc'
       - name: Deploy to GitHub Pages

--- a/.github/workflows/api-docs.yaml
+++ b/.github/workflows/api-docs.yaml
@@ -3,6 +3,7 @@ on:
   push:
     branches:
       - main
+      - chore/spring-rest-docs-적용#102
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}

--- a/.github/workflows/api-docs.yaml
+++ b/.github/workflows/api-docs.yaml
@@ -1,48 +1,44 @@
 name: Spring Rest Docs
+
 on:
   push:
     branches:
       - main
       - chore/spring-rest-docs-적용#102
+    workflow_dispatch:
 
 concurrency:
-  group: "github-pages"
+  group: github-pages
   cancel-in-progress: true
+
+permissions:
+  contents: read
+  pages: write
+  id-token: write
 
 jobs:
   deploy:
-    permissions:
-      pages: write
-      id-token: write
-
     environment:
       name: github-pages
       url: ${{ steps.deployment.outputs.page_url }}
-
     runs-on: ubuntu-latest
-
     steps:
       - name: Checkout
         uses: actions/checkout@v4
-
+      - name: Set up Pages
+        uses: actions/configure-pages@v5
       - name: Set up JDK 17
         uses: actions/setup-java@v4
         with:
           java-version: '17'
           distribution: 'temurin'
           cache: 'gradle'
-
-      - name: Set up Pages
-        uses: actions/configure-pages@v5
-
       - name: Build Asciidoc
         run: ./gradlew asciidoctor
-
       - name: Upload pages artifact
         uses: actions/upload-pages-artifact@v4
         with:
           path: './build/docs/asciidoc'
-
       - name: Deploy to GitHub Pages
         id: deployment
         uses: actions/deploy-pages@v4

--- a/build.gradle
+++ b/build.gradle
@@ -43,6 +43,7 @@ dependencies {
 
     asciidoctorExt 'org.springframework.restdocs:spring-restdocs-asciidoctor:3.0.1'
     testImplementation 'org.springframework.restdocs:spring-restdocs-mockmvc:3.0.1'
+    testImplementation 'com.h2database:h2'
 }
 
 ext {
@@ -50,6 +51,7 @@ ext {
 }
 
 test {
+    useJUnitPlatform()
     outputs.dir snippetsDir
 }
 

--- a/build.gradle
+++ b/build.gradle
@@ -59,4 +59,5 @@ asciidoctor {
     inputs.dir snippetsDir
     configurations 'asciidoctorExt'
     dependsOn test
+    baseDirFollowsSourceFile()
 }

--- a/build.gradle
+++ b/build.gradle
@@ -2,6 +2,7 @@ plugins {
     id 'java'
     id 'org.springframework.boot' version '3.2.3'
     id 'io.spring.dependency-management' version '1.1.4'
+    id "org.asciidoctor.jvm.convert" version "3.3.2"
 }
 
 group = 'com.habitpay'
@@ -15,6 +16,7 @@ configurations {
     compileOnly {
         extendsFrom annotationProcessor
     }
+    asciidoctorExt
 }
 
 repositories {
@@ -38,4 +40,21 @@ dependencies {
     testImplementation 'org.springframework.boot:spring-boot-starter-test'
     testImplementation 'org.springframework.security:spring-security-test'
     developmentOnly 'org.springframework.boot:spring-boot-devtools'
+
+    asciidoctorExt 'org.springframework.restdocs:spring-restdocs-asciidoctor:3.0.1'
+    testImplementation 'org.springframework.restdocs:spring-restdocs-mockmvc:3.0.1'
+}
+
+ext {
+    snippetsDir = file('build/generated-snippets')
+}
+
+test {
+    outputs.dir snippetsDir
+}
+
+asciidoctor {
+    inputs.dir snippetsDir
+    configurations 'asciidoctorExt'
+    dependsOn test
 }

--- a/src/docs/asciidoc/api/member.adoc
+++ b/src/docs/asciidoc/api/member.adoc
@@ -1,0 +1,16 @@
+== 사용자 API
+:doctype: book
+:source-highlighter: highlightjs
+:toc: left
+:toclevels: 2
+:seclinks:
+
+사용자의 정보를 조회 및 수정할 수 있습니다.
+
+Request Header 에는 ``Authorization: Bearer {access token}`` 와 같은 형식으로 보내야 하며, 사용자의 ``액세스 토큰``이 필요합니다.
+
+=== 사용자 조회
+
+사용자의 정보를 조회합니다.
+
+operation::member/get-member[snippets='http-request,http-response,response-fields']

--- a/src/docs/asciidoc/index.adoc
+++ b/src/docs/asciidoc/index.adoc
@@ -1,0 +1,8 @@
+= HabitPay API
+:doctype: book
+:source-highlighter: highlightjs
+:toc: left
+:toclevels: 2
+:seclinks:
+
+include::test.adoc[]

--- a/src/docs/asciidoc/test.adoc
+++ b/src/docs/asciidoc/test.adoc
@@ -1,8 +1,3 @@
 == RestDocsTestController
-:doctype: book
-:source-highlighter: highlightjs
-:toc: left
-:toclevels: 2
-:seclinks:
 
 operation::rest-docs[snippets="http-request,http-response"]

--- a/src/docs/asciidoc/test.adoc
+++ b/src/docs/asciidoc/test.adoc
@@ -1,3 +1,8 @@
 == RestDocsTestController
+:doctype: book
+:source-highlighter: highlightjs
+:toc: left
+:toclevels: 2
+:seclinks:
 
 operation::rest-docs[snippets="http-request,http-response"]

--- a/src/docs/asciidoc/test.adoc
+++ b/src/docs/asciidoc/test.adoc
@@ -1,0 +1,3 @@
+== RestDocsTestController
+
+operation::rest-docs[snippets="http-request,http-response"]

--- a/src/main/java/com/habitpay/habitpay/HabitpayApplication.java
+++ b/src/main/java/com/habitpay/habitpay/HabitpayApplication.java
@@ -2,9 +2,7 @@ package com.habitpay.habitpay;
 
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
-import org.springframework.data.jpa.repository.config.EnableJpaAuditing;
 
-@EnableJpaAuditing
 @SpringBootApplication
 public class HabitpayApplication {
 

--- a/src/main/java/com/habitpay/habitpay/domain/challenge/domain/Challenge.java
+++ b/src/main/java/com/habitpay/habitpay/domain/challenge/domain/Challenge.java
@@ -43,7 +43,7 @@ public class Challenge extends BaseTime {
     private int numberOfParticipants;
 
     @Column(nullable = false)
-    private byte participatingDays;
+    private int participatingDays;
 
     @Column(nullable = false)
     private int feePerAbsence;

--- a/src/main/java/com/habitpay/habitpay/domain/challenge/dto/ChallengeResponse.java
+++ b/src/main/java/com/habitpay/habitpay/domain/challenge/dto/ChallengeResponse.java
@@ -14,7 +14,7 @@ public class ChallengeResponse {
     private String description;
     private ZonedDateTime startDate;
     private ZonedDateTime endDate;
-    private byte participatingDays;
+    private int participatingDays;
     private int feePerAbsence;
     private String hostNickname;
     private String hostProfileImage;

--- a/src/main/java/com/habitpay/habitpay/domain/member/application/MemberSearchService.java
+++ b/src/main/java/com/habitpay/habitpay/domain/member/application/MemberSearchService.java
@@ -1,0 +1,37 @@
+package com.habitpay.habitpay.domain.member.application;
+
+import com.habitpay.habitpay.domain.member.dao.MemberRepository;
+import com.habitpay.habitpay.domain.member.domain.Member;
+import com.habitpay.habitpay.domain.member.dto.MemberResponse;
+import com.habitpay.habitpay.global.config.aws.S3FileService;
+import org.springframework.transaction.annotation.Transactional;
+import lombok.AllArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.stereotype.Service;
+
+import java.util.Optional;
+
+@Service
+@AllArgsConstructor
+public class MemberSearchService {
+    private final MemberRepository memberRepository;
+    private final S3FileService s3FileService;
+
+    public MemberResponse getMemberProfile(String email) {
+        Member member = getMember(email).
+                orElseThrow(() -> new IllegalArgumentException("사용자를 찾을 수 없습니다."));
+        String imageFileName = Optional.ofNullable(member.getImageFileName()).orElse("");
+
+        // TODO: 꼭 이미지를 presigned url 로 받아와야 할 필요가 있을까?
+        String imageUrl = "";
+        if (imageFileName.isEmpty() == false) {
+            imageUrl = s3FileService.getGetPreSignedUrl("profiles", imageFileName);
+        }
+        return new MemberResponse(member.getNickname(), imageUrl);
+    }
+
+    @Transactional(readOnly = true)
+    public Optional<Member> getMember(String email) {
+        return memberRepository.findByEmail(email);
+    }
+}

--- a/src/main/java/com/habitpay/habitpay/domain/member/dto/MemberResponse.java
+++ b/src/main/java/com/habitpay/habitpay/domain/member/dto/MemberResponse.java
@@ -1,9 +1,13 @@
 package com.habitpay.habitpay.domain.member.dto;
 
+import com.habitpay.habitpay.domain.member.domain.Member;
 import lombok.AllArgsConstructor;
+import lombok.Builder;
 import lombok.Getter;
+import lombok.NoArgsConstructor;
 
 @Getter
+@Builder
 @AllArgsConstructor
 public class MemberResponse {
     private String nickname;

--- a/src/main/java/com/habitpay/habitpay/domain/restdocs/RestDocsController.java
+++ b/src/main/java/com/habitpay/habitpay/domain/restdocs/RestDocsController.java
@@ -1,0 +1,13 @@
+package com.habitpay.habitpay.domain.restdocs;
+
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+public class RestDocsController {
+
+    @GetMapping("/restDocs")
+    public String getRestDocs() {
+        return "hello";
+    }
+}

--- a/src/main/java/com/habitpay/habitpay/global/config/JpaConfiguration.java
+++ b/src/main/java/com/habitpay/habitpay/global/config/JpaConfiguration.java
@@ -1,0 +1,9 @@
+package com.habitpay.habitpay.global.config;
+
+import org.springframework.context.annotation.Configuration;
+import org.springframework.data.jpa.repository.config.EnableJpaAuditing;
+
+@Configuration
+@EnableJpaAuditing
+public class JpaConfiguration {
+}

--- a/src/test/java/com/habitpay/habitpay/HabitpayApplicationTests.java
+++ b/src/test/java/com/habitpay/habitpay/HabitpayApplicationTests.java
@@ -3,11 +3,10 @@ package com.habitpay.habitpay;
 import org.junit.jupiter.api.Test;
 import org.springframework.boot.test.context.SpringBootTest;
 
-@SpringBootTest
+@SpringBootTest(classes = HabitpayApplication.class)
 class HabitpayApplicationTests {
 
-	@Test
-	void contextLoads() {
-	}
-
+    @Test
+    void contextLoads() {
+    }
 }

--- a/src/test/java/com/habitpay/habitpay/RestDocsControllerTest.java
+++ b/src/test/java/com/habitpay/habitpay/RestDocsControllerTest.java
@@ -15,7 +15,6 @@ import static org.springframework.test.web.servlet.request.MockMvcRequestBuilder
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
 @WebMvcTest(RestDocsController.class)
-@Import({CorsConfig.class, TokenService.class, TokenProvider.class})
 public class RestDocsControllerTest extends AbstractRestDocsTests {
 
     @MockBean

--- a/src/test/java/com/habitpay/habitpay/RestDocsControllerTest.java
+++ b/src/test/java/com/habitpay/habitpay/RestDocsControllerTest.java
@@ -1,0 +1,35 @@
+package com.habitpay.habitpay;
+
+import com.habitpay.habitpay.docs.springrestdocs.AbstractRestDocsTests;
+import com.habitpay.habitpay.domain.restdocs.RestDocsController;
+import com.habitpay.habitpay.global.config.auth.CorsConfig;
+import com.habitpay.habitpay.global.config.jwt.TokenProvider;
+import com.habitpay.habitpay.global.config.jwt.TokenService;
+import org.junit.jupiter.api.Test;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.context.annotation.Import;
+
+import static org.springframework.restdocs.mockmvc.MockMvcRestDocumentation.document;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+@WebMvcTest(RestDocsController.class)
+@Import({CorsConfig.class, TokenService.class, TokenProvider.class})
+public class RestDocsControllerTest extends AbstractRestDocsTests {
+
+    @MockBean
+    TokenService tokenService;
+
+    @MockBean
+    TokenProvider tokenProvider;
+
+    @MockBean
+    CorsConfig corsConfig;
+
+    @Test
+    void RestDocsTest() throws Exception {
+        mockMvc.perform(get("/restDocs")).andExpect(status().isOk())
+                .andDo(document("rest-docs"));
+    }
+}

--- a/src/test/java/com/habitpay/habitpay/RestDocsControllerTest.java
+++ b/src/test/java/com/habitpay/habitpay/RestDocsControllerTest.java
@@ -8,7 +8,6 @@ import com.habitpay.habitpay.global.config.jwt.TokenService;
 import org.junit.jupiter.api.Test;
 import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
 import org.springframework.boot.test.mock.mockito.MockBean;
-import org.springframework.context.annotation.Import;
 
 import static org.springframework.restdocs.mockmvc.MockMvcRestDocumentation.document;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;

--- a/src/test/java/com/habitpay/habitpay/docs/springrestdocs/AbstractRestDocsTests.java
+++ b/src/test/java/com/habitpay/habitpay/docs/springrestdocs/AbstractRestDocsTests.java
@@ -1,12 +1,8 @@
 package com.habitpay.habitpay.docs.springrestdocs;
 
-import static org.springframework.restdocs.mockmvc.MockMvcRestDocumentation.documentationConfiguration;
-import static org.springframework.restdocs.operation.preprocess.Preprocessors.prettyPrint;
-
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.boot.test.autoconfigure.restdocs.AutoConfigureRestDocs;
 import org.springframework.restdocs.RestDocumentationContextProvider;
 import org.springframework.restdocs.RestDocumentationExtension;
 import org.springframework.test.web.servlet.MockMvc;
@@ -15,16 +11,19 @@ import org.springframework.test.web.servlet.setup.MockMvcBuilders;
 import org.springframework.web.context.WebApplicationContext;
 import org.springframework.web.filter.CharacterEncodingFilter;
 
+import static org.springframework.restdocs.mockmvc.MockMvcRestDocumentation.documentationConfiguration;
+import static org.springframework.restdocs.operation.preprocess.Preprocessors.prettyPrint;
+
 @ExtendWith(RestDocumentationExtension.class)
 public abstract class AbstractRestDocsTests {
     @Autowired
     protected MockMvc mockMvc;
 
     @BeforeEach
-    void setUpRestDocs(
+    void setUp(
             final WebApplicationContext context,
             final RestDocumentationContextProvider restDocumentation
-            ) {
+    ) {
         this.mockMvc = MockMvcBuilders.webAppContextSetup(context)
                 .apply(documentationConfiguration(restDocumentation)
                         .operationPreprocessors()

--- a/src/test/java/com/habitpay/habitpay/docs/springrestdocs/AbstractRestDocsTests.java
+++ b/src/test/java/com/habitpay/habitpay/docs/springrestdocs/AbstractRestDocsTests.java
@@ -1,0 +1,38 @@
+package com.habitpay.habitpay.docs.springrestdocs;
+
+import static org.springframework.restdocs.mockmvc.MockMvcRestDocumentation.documentationConfiguration;
+import static org.springframework.restdocs.operation.preprocess.Preprocessors.prettyPrint;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.restdocs.AutoConfigureRestDocs;
+import org.springframework.restdocs.RestDocumentationContextProvider;
+import org.springframework.restdocs.RestDocumentationExtension;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.test.web.servlet.result.MockMvcResultHandlers;
+import org.springframework.test.web.servlet.setup.MockMvcBuilders;
+import org.springframework.web.context.WebApplicationContext;
+import org.springframework.web.filter.CharacterEncodingFilter;
+
+@ExtendWith(RestDocumentationExtension.class)
+public abstract class AbstractRestDocsTests {
+    @Autowired
+    protected MockMvc mockMvc;
+
+    @BeforeEach
+    void setUpRestDocs(
+            final WebApplicationContext context,
+            final RestDocumentationContextProvider restDocumentation
+            ) {
+        this.mockMvc = MockMvcBuilders.webAppContextSetup(context)
+                .apply(documentationConfiguration(restDocumentation)
+                        .operationPreprocessors()
+                        .withRequestDefaults(prettyPrint())
+                        .withResponseDefaults(prettyPrint())
+                )
+                .alwaysDo(MockMvcResultHandlers.print())
+                .addFilter(new CharacterEncodingFilter("UTF-8", true))
+                .build();
+    }
+}

--- a/src/test/java/com/habitpay/habitpay/member/api/MemberApiTest.java
+++ b/src/test/java/com/habitpay/habitpay/member/api/MemberApiTest.java
@@ -1,0 +1,87 @@
+package com.habitpay.habitpay.member.api;
+
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.BDDMockito.given;
+import static org.springframework.restdocs.mockmvc.MockMvcRestDocumentation.document;
+import static org.springframework.restdocs.headers.HeaderDocumentation.headerWithName;
+import static org.springframework.restdocs.headers.HeaderDocumentation.requestHeaders;
+import static org.springframework.restdocs.payload.PayloadDocumentation.fieldWithPath;
+import static org.springframework.restdocs.payload.PayloadDocumentation.responseFields;
+import static org.springframework.restdocs.mockmvc.RestDocumentationRequestBuilders.get;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.habitpay.habitpay.docs.springrestdocs.AbstractRestDocsTests;
+import com.habitpay.habitpay.domain.member.api.MemberApi;
+import com.habitpay.habitpay.domain.member.application.MemberProfileService;
+import com.habitpay.habitpay.domain.member.application.MemberSearchService;
+import com.habitpay.habitpay.domain.member.application.MemberService;
+import com.habitpay.habitpay.domain.member.dto.MemberResponse;
+import com.habitpay.habitpay.domain.refreshtoken.application.RefreshTokenCreationService;
+import com.habitpay.habitpay.global.config.aws.S3FileService;
+import com.habitpay.habitpay.global.config.jwt.TokenService;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.MediaType;
+import org.springframework.test.web.servlet.ResultActions;
+
+@WebMvcTest(MemberApi.class)
+public class MemberApiTest extends AbstractRestDocsTests {
+
+    static final String AUTHORIZATION_HEADER_PREFIX = "Bearer ";
+
+    @Autowired
+    ObjectMapper objectMapper;
+
+    @MockBean
+    MemberService memberService;
+
+    @MockBean
+    MemberSearchService memberSearchService;
+
+    @MockBean
+    MemberProfileService memberProfileService;
+
+    @MockBean
+    TokenService tokenService;
+
+    @MockBean
+    RefreshTokenCreationService refreshTokenCreationService;
+
+    @MockBean
+    S3FileService s3FileService;
+
+    @Test
+    @DisplayName("사용자 조회")
+    void getMember() throws Exception {
+
+        // given
+        MemberResponse memberResponse = MemberResponse.builder()
+                .imageUrl("https://picsum.photos/id/40/200/300")
+                .nickname("HabitPay")
+                .build();
+
+        // when
+        ResultActions result = mockMvc.perform(get("/member")
+                .header(HttpHeaders.AUTHORIZATION, AUTHORIZATION_HEADER_PREFIX + "ACCESS_TOKEN")
+                .content(objectMapper.writeValueAsString(memberResponse))
+                .contentType(MediaType.APPLICATION_JSON));
+
+        // then
+        result.andExpect(status().isOk())
+                .andDo(document("member/get-member",
+                        requestHeaders(
+                                headerWithName(HttpHeaders.AUTHORIZATION).description("액세스 토큰")
+                        ),
+                        responseFields(
+                                fieldWithPath("status").description("응답 상태 코드"),
+                                fieldWithPath("data.nickname").description("사용자 닉네임"),
+                                fieldWithPath("data.imageUrl").description("사용자 이미지 URL")
+                        )
+                ));
+    }
+}

--- a/src/test/java/com/habitpay/habitpay/member/api/MemberApiTest.java
+++ b/src/test/java/com/habitpay/habitpay/member/api/MemberApiTest.java
@@ -1,87 +1,85 @@
-package com.habitpay.habitpay.member.api;
-
-import static org.mockito.ArgumentMatchers.anyString;
-import static org.mockito.BDDMockito.given;
-import static org.springframework.restdocs.mockmvc.MockMvcRestDocumentation.document;
-import static org.springframework.restdocs.headers.HeaderDocumentation.headerWithName;
-import static org.springframework.restdocs.headers.HeaderDocumentation.requestHeaders;
-import static org.springframework.restdocs.payload.PayloadDocumentation.fieldWithPath;
-import static org.springframework.restdocs.payload.PayloadDocumentation.responseFields;
-import static org.springframework.restdocs.mockmvc.RestDocumentationRequestBuilders.get;
-import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
-
-import com.fasterxml.jackson.databind.ObjectMapper;
-import com.habitpay.habitpay.docs.springrestdocs.AbstractRestDocsTests;
-import com.habitpay.habitpay.domain.member.api.MemberApi;
-import com.habitpay.habitpay.domain.member.application.MemberProfileService;
-import com.habitpay.habitpay.domain.member.application.MemberSearchService;
-import com.habitpay.habitpay.domain.member.application.MemberService;
-import com.habitpay.habitpay.domain.member.dto.MemberResponse;
-import com.habitpay.habitpay.domain.refreshtoken.application.RefreshTokenCreationService;
-import com.habitpay.habitpay.global.config.aws.S3FileService;
-import com.habitpay.habitpay.global.config.jwt.TokenService;
-import org.junit.jupiter.api.DisplayName;
-import org.junit.jupiter.api.Test;
-import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
-import org.springframework.boot.test.mock.mockito.MockBean;
-import org.springframework.http.HttpHeaders;
-import org.springframework.http.MediaType;
-import org.springframework.test.web.servlet.ResultActions;
-
-@WebMvcTest(MemberApi.class)
-public class MemberApiTest extends AbstractRestDocsTests {
-
-    static final String AUTHORIZATION_HEADER_PREFIX = "Bearer ";
-
-    @Autowired
-    ObjectMapper objectMapper;
-
-    @MockBean
-    MemberService memberService;
-
-    @MockBean
-    MemberSearchService memberSearchService;
-
-    @MockBean
-    MemberProfileService memberProfileService;
-
-    @MockBean
-    TokenService tokenService;
-
-    @MockBean
-    RefreshTokenCreationService refreshTokenCreationService;
-
-    @MockBean
-    S3FileService s3FileService;
-
-    @Test
-    @DisplayName("사용자 조회")
-    void getMember() throws Exception {
-
-        // given
-        MemberResponse memberResponse = MemberResponse.builder()
-                .imageUrl("https://picsum.photos/id/40/200/300")
-                .nickname("HabitPay")
-                .build();
-
-        // when
-        ResultActions result = mockMvc.perform(get("/member")
-                .header(HttpHeaders.AUTHORIZATION, AUTHORIZATION_HEADER_PREFIX + "ACCESS_TOKEN")
-                .content(objectMapper.writeValueAsString(memberResponse))
-                .contentType(MediaType.APPLICATION_JSON));
-
-        // then
-        result.andExpect(status().isOk())
-                .andDo(document("member/get-member",
-                        requestHeaders(
-                                headerWithName(HttpHeaders.AUTHORIZATION).description("액세스 토큰")
-                        ),
-                        responseFields(
-                                fieldWithPath("status").description("응답 상태 코드"),
-                                fieldWithPath("data.nickname").description("사용자 닉네임"),
-                                fieldWithPath("data.imageUrl").description("사용자 이미지 URL")
-                        )
-                ));
-    }
-}
+//package com.habitpay.habitpay.member.api;
+//
+//import com.fasterxml.jackson.databind.ObjectMapper;
+//import com.habitpay.habitpay.docs.springrestdocs.AbstractRestDocsTests;
+//import com.habitpay.habitpay.domain.member.api.MemberApi;
+//import com.habitpay.habitpay.domain.member.application.MemberProfileService;
+//import com.habitpay.habitpay.domain.member.application.MemberSearchService;
+//import com.habitpay.habitpay.domain.member.application.MemberService;
+//import com.habitpay.habitpay.domain.member.dto.MemberResponse;
+//import com.habitpay.habitpay.domain.refreshtoken.application.RefreshTokenCreationService;
+//import com.habitpay.habitpay.global.config.jwt.TokenService;
+//import org.junit.jupiter.api.DisplayName;
+//import org.junit.jupiter.api.Test;
+//import org.springframework.beans.factory.annotation.Autowired;
+//import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+//import org.springframework.boot.test.mock.mockito.MockBean;
+//import org.springframework.http.HttpHeaders;
+//import org.springframework.http.MediaType;
+//import org.springframework.test.web.servlet.ResultActions;
+//import software.amazon.awssdk.services.s3.S3Client;
+//
+//import static org.springframework.restdocs.headers.HeaderDocumentation.headerWithName;
+//import static org.springframework.restdocs.headers.HeaderDocumentation.requestHeaders;
+//import static org.springframework.restdocs.mockmvc.MockMvcRestDocumentation.document;
+//import static org.springframework.restdocs.mockmvc.RestDocumentationRequestBuilders.get;
+//import static org.springframework.restdocs.payload.PayloadDocumentation.fieldWithPath;
+//import static org.springframework.restdocs.payload.PayloadDocumentation.responseFields;
+//import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+//
+//@WebMvcTest(MemberApi.class)
+//public class MemberApiTest extends AbstractRestDocsTests {
+//
+//    static final String AUTHORIZATION_HEADER_PREFIX = "Bearer ";
+//
+//    @Autowired
+//    ObjectMapper objectMapper;
+//
+//    @MockBean
+//    MemberService memberService;
+//
+//    @MockBean
+//    MemberSearchService memberSearchService;
+//
+//    @MockBean
+//    MemberProfileService memberProfileService;
+//
+//    @MockBean
+//    TokenService tokenService;
+//
+//    @MockBean
+//    RefreshTokenCreationService refreshTokenCreationService;
+//
+//    @MockBean
+//    private S3Client s3Client;
+//
+//    @Test
+//    @DisplayName("사용자 조회")
+//    void getMember() throws Exception {
+//
+//        // given
+//        MemberResponse memberResponse = MemberResponse.builder()
+//                .imageUrl("https://picsum.photos/id/40/200/300")
+//                .nickname("HabitPay")
+//                .build();
+//
+//        // when
+//        ResultActions result = mockMvc.perform(get("/member")
+//                .header(HttpHeaders.AUTHORIZATION, AUTHORIZATION_HEADER_PREFIX + "ACCESS_TOKEN")
+//                .content(objectMapper.writeValueAsString(memberResponse))
+//                .contentType(MediaType.APPLICATION_JSON));
+//
+//        // then
+//        result.andExpect(status().isOk())
+//                .andDo(document("member/get-member",
+//                        requestHeaders(
+//                                headerWithName(HttpHeaders.AUTHORIZATION).description("액세스 토큰")
+//                        ),
+//                        responseFields(
+//                                fieldWithPath("status").description("응답 상태 코드"),
+//                                fieldWithPath("data.nickname").description("사용자 닉네임"),
+//                                fieldWithPath("data.imageUrl").description("사용자 이미지 URL")
+//                        )
+//                ));
+//    }
+//}

--- a/src/test/resources/application.yaml
+++ b/src/test/resources/application.yaml
@@ -1,0 +1,42 @@
+spring:
+  config:
+    activate:
+      on-profile: test
+---
+spring:
+  h2:
+    console:
+      enabled: true
+  jpa:
+    database: h2
+    hibernate:
+      ddl-auto: create
+  datasource:
+    driver-class-name: org.h2.Driver
+    url: jdbc:h2:tcp://localhost/~/test;MODE=PostgreSQL;
+    username: sa
+    password:
+---
+spring:
+  cloud:
+    aws:
+      s3:
+        bucket: hello
+      stack:
+        auto: false
+      region:
+        static: ap-northeast-2
+      credentials:
+        access-key: hello
+        secret-key: world
+---
+spring:
+  security:
+    oauth2:
+      client:
+        registration:
+          google:
+            client-id: ${GOOGLE_CLIENT_ID}
+            client-secret: ${GOOGLE_CLIENT_SECRET}
+            redirect-uri: ${GOOGLE_REDIRECT_URI}
+            scope: ${GOOGLE_SCOPE}

--- a/src/test/resources/application.yaml
+++ b/src/test/resources/application.yaml
@@ -13,7 +13,7 @@ spring:
       ddl-auto: create
   datasource:
     driver-class-name: org.h2.Driver
-    url: jdbc:h2:tcp://localhost/~/test;MODE=PostgreSQL;
+    url: jdbc:h2:mem:test;MODE=PostgreSQL;
     username: sa
     password:
 ---


### PR DESCRIPTION
# 작업 내용

- Spring Rest Docs 를 이용해서 API 명세서를 자동으로 작성하고, 이를 Github Pages ([링크](https://habitpay.github.io/backend/)) 로 배포할 수 있도록 Github Actions 설정을 추가했습니다.
- 테스트 케이스에 통과한 컨트롤러에 대해서만 API 명세서를 생성합니다.
- 현재는 테스트 목적으로 작성한 컨트롤러에 대해서만 API 명세서만 작성되어있는 상태입니다.
- 자세한 작업 내용은 아래의 링크로 대체합니다.
  - 링크: [[Spring] Spring Rest Docs 적용 및 Github Pages 자동 배포](https://han-joon-hyeok.github.io/posts/java-spring-rest-docs-with-deploying-github-pages/)