### PR TITLE
[Feat] POST /api/member 경로를 위한 인터셉터 설정 수정 #115

### DIFF
--- a/src/main/java/com/habitpay/habitpay/global/config/auth/CorsConfig.java
+++ b/src/main/java/com/habitpay/habitpay/global/config/auth/CorsConfig.java
@@ -33,9 +33,7 @@ public class CorsConfig implements WebMvcConfigurer {
     public void addInterceptors(InterceptorRegistry registry) {
 
         registry.addInterceptor(signUpInterceptor()).addPathPatterns("/api/member");
-        registry.addInterceptor(authorizationInterceptor())
-                .addPathPatterns("/api/**")
-                .excludePathPatterns("/api/member");
+        registry.addInterceptor(authorizationInterceptor()).addPathPatterns("/api/**");
     }
 
     @Bean

--- a/src/main/java/com/habitpay/habitpay/global/config/auth/CorsConfig.java
+++ b/src/main/java/com/habitpay/habitpay/global/config/auth/CorsConfig.java
@@ -31,11 +31,11 @@ public class CorsConfig implements WebMvcConfigurer {
 
     @Override
     public void addInterceptors(InterceptorRegistry registry) {
-//        registry.addInterceptor(authorizationInterceptor());
 
-        // todo
-        registry.addInterceptor(authorizationInterceptor()).addPathPatterns("/api/**");
-        registry.addInterceptor(signUpInterceptor()).addPathPatterns("/member");
+        registry.addInterceptor(signUpInterceptor()).addPathPatterns("/api/member");
+        registry.addInterceptor(authorizationInterceptor())
+                .addPathPatterns("/api/**")
+                .excludePathPatterns("/api/member");
     }
 
     @Bean

--- a/src/main/java/com/habitpay/habitpay/global/config/auth/interceptor/AuthorizationInterceptor.java
+++ b/src/main/java/com/habitpay/habitpay/global/config/auth/interceptor/AuthorizationInterceptor.java
@@ -39,16 +39,16 @@ public class AuthorizationInterceptor implements HandlerInterceptor {
         // todo
 //        if (!(handler instanceof HandlerMethod)) {}
 
-        String httpRequestMethod = request.getMethod();
-        if ("/api/member".equals(request.getRequestURI()) && "POST".equalsIgnoreCase(httpRequestMethod)) {
-            return true;
-        }
-
         // todo : for debug
         HandlerMethod handlerMethod = (HandlerMethod) handler;
         Method method = handlerMethod.getMethod();
         log.info("Bean : {}", handlerMethod.getBean());
         log.info("Method : {}", method);
+
+        String httpMethod = request.getMethod();
+        if ("/api/member".equals(request.getRequestURI()) && "POST".equalsIgnoreCase(httpMethod)) {
+            return true;
+        }
 
         String authorizationHeader = request.getHeader("Authorization");
         // todo : authorization header가 빈 값인 경우와, 아예 헤더 자체가 없는 경우 분리 안 되나? 안 되면 에러 메시지 숨겨야 할 듯?

--- a/src/main/java/com/habitpay/habitpay/global/config/auth/interceptor/AuthorizationInterceptor.java
+++ b/src/main/java/com/habitpay/habitpay/global/config/auth/interceptor/AuthorizationInterceptor.java
@@ -35,10 +35,14 @@ public class AuthorizationInterceptor implements HandlerInterceptor {
             HttpServletRequest request,
             HttpServletResponse response,
             Object handler) throws Exception {
-        // final String REDIRECT_URL = "http://localhost:3000";
 
         // todo
 //        if (!(handler instanceof HandlerMethod)) {}
+
+        String httpRequestMethod = request.getMethod();
+        if ("/api/member".equals(request.getRequestURI()) && "POST".equalsIgnoreCase(httpRequestMethod)) {
+            return true;
+        }
 
         // todo : for debug
         HandlerMethod handlerMethod = (HandlerMethod) handler;
@@ -51,8 +55,6 @@ public class AuthorizationInterceptor implements HandlerInterceptor {
         if (authorizationHeader == null) {
             // todo : 분리 못 하면 그냥 'the request lacks any authentication information' 상태로 보고 처리해도 될 듯
             //      이 경우면, 어떤 error 코드나 정보를 주어선 안 된다고 함! by RFC
-            //response.sendRedirect(REDIRECT_URL);
-            //return false;
             throw new CustomJwtException(HttpStatus.BAD_REQUEST, CustomJwtErrorInfo.BAD_REQUEST, "Request was missing the 'Authorization' header.");
         }
 
@@ -90,8 +92,6 @@ public class AuthorizationInterceptor implements HandlerInterceptor {
             return true;
         }
 
-        // todo
-//        response.sendRedirect(REDIRECT_URL);
         return false;
     }
 

--- a/src/main/java/com/habitpay/habitpay/global/config/auth/interceptor/SignUpInterceptor.java
+++ b/src/main/java/com/habitpay/habitpay/global/config/auth/interceptor/SignUpInterceptor.java
@@ -38,16 +38,16 @@ public class SignUpInterceptor implements HandlerInterceptor {
         // todo
 //        if (!(handler instanceof HandlerMethod)) {}
 
-        String httpRequestMethod = request.getMethod();
-        if (!"/api/member".equals(request.getRequestURI()) || !"POST".equalsIgnoreCase(httpRequestMethod)) {
-            return true;
-        }
-
         // todo : for debug
         HandlerMethod handlerMethod = (HandlerMethod) handler;
         Method method = handlerMethod.getMethod();
         log.info("Bean : {}", handlerMethod.getBean());
         log.info("Method : {}", method);
+
+        String httpMethod = request.getMethod();
+        if (!"/api/member".equals(request.getRequestURI()) || !"POST".equalsIgnoreCase(httpMethod)) {
+            return true;
+        }
 
         String authorizationHeader = request.getHeader("Authorization");
         // todo : authorization header가 빈 값인 경우와, 아예 헤더 자체가 없는 경우 분리 안 되나? 안 되면 에러 메시지 숨겨야 할 듯?
@@ -68,7 +68,6 @@ public class SignUpInterceptor implements HandlerInterceptor {
                 throw new CustomJwtException(HttpStatus.UNAUTHORIZED, CustomJwtErrorInfo.UNAUTHORIZED, "");
             }
 
-            String httpMethod = request.getMethod();
             if ("POST".equals(httpMethod)) {
                 if (tokenService.getIsActive(token)) {
                     throw new CustomJwtException(HttpStatus.UNAUTHORIZED, CustomJwtErrorInfo.UNAUTHORIZED, "Request was trying to signup with a member already signed up.");

--- a/src/main/java/com/habitpay/habitpay/global/config/auth/interceptor/SignUpInterceptor.java
+++ b/src/main/java/com/habitpay/habitpay/global/config/auth/interceptor/SignUpInterceptor.java
@@ -35,10 +35,13 @@ public class SignUpInterceptor implements HandlerInterceptor {
             HttpServletResponse response,
             Object handler) throws Exception {
 
-        // final String REDIRECT_URL = "http://localhost:3000";
-
         // todo
 //        if (!(handler instanceof HandlerMethod)) {}
+
+        String httpRequestMethod = request.getMethod();
+        if (!"/api/member".equals(request.getRequestURI()) || !"POST".equalsIgnoreCase(httpRequestMethod)) {
+            return true;
+        }
 
         // todo : for debug
         HandlerMethod handlerMethod = (HandlerMethod) handler;
@@ -51,8 +54,6 @@ public class SignUpInterceptor implements HandlerInterceptor {
         if (authorizationHeader == null) {
             // todo : 분리 못 하면 그냥 'the request lacks any authentication information' 상태로 보고 처리해도 될 듯
             //      이 경우면, 어떤 error 코드나 정보를 주어선 안 된다고 함! by RFC
-            //response.sendRedirect(REDIRECT_URL);
-            //return false;
             throw new CustomJwtException(HttpStatus.BAD_REQUEST, CustomJwtErrorInfo.BAD_REQUEST, "Request was missing the 'Authorization' header.");
         }
 
@@ -95,8 +96,6 @@ public class SignUpInterceptor implements HandlerInterceptor {
             return true;
         }
 
-        // todo
-//        response.sendRedirect(REDIRECT_URL);
         return false;
     }
 


### PR DESCRIPTION
* 이전 코드 : `POST /api/member` 경로를 처리하는 `signUp 인터셉터`와, `/api/**` 경로를 처리하는 `인증 인터셉터`가 각각 존재
   -> `/api/member`가 `signUp 인터셉터`를 거치고 난 후, `인증 인터셉터` 역시 거치는 문제 발생
        (사실 특별한 설정이 없으면, 메서드는 등록된 모든 인터셉터를 차례로 거치게 되어 있음)

---

* 시도 : 패턴 구체화를 통해 해결하고자 함
          `excludePathPatterns()` 메서드를 이용해 `인증 인터셉터`가 `/api/member`를 처리하지 않도록 하기
```java
registry.addInterceptor(authorizationInterceptor())
                    .addPathPatterns("/api/**")
                    .excludePathPatterns("/api/member");
```
---
* 발생한 문제 : `/api/member`에는 `signUp 인터셉터`을 거치는 `POST 메서드` 뿐만 아니라, `인증 인터셉터`를 거쳐야 하는` GET, PATCH, DELETE `등 다른 메서드도 존재함.
다른 메서드들이 원래 거쳐야 할 `인증 인터셉터`를 거르고 `signUp 인터셉터`만을 거치는 문제 발생

---

* 서치해봤으나, CorsConfig를 이용한 인터셉터 설정에서 HTTP 메서드까지 분류해주는 기능은 없는 것으로 보임
(비슷한 질문을 한 사람이 있었고, 김영한 선생님께서 그런 방법은 없는 걸로 안다는 답변을 한 것도 봄,,😢)

---

* 다른 해결책 :  인터셉터의 preHandle 메서드에서, 경로와 메서드를 분석해 따로 처리하기
---
```java
// signUp 인터셉터
...
        String httpMethod = request.getMethod();
        if (!"/api/member".equals(request.getRequestURI()) || !"POST".equalsIgnoreCase(httpMethod)) {
            return true;
        }
...
```

경로가 `/api/member`면서 HTTP 메서드가 `POST`인 경우에만 `if문`을 벗어나 나머지 코드 진행.
둘 중에 하나라도 충족하지 않으면, `return true`로 해당 인터셉터를 바로 종료하고 다음 인터셉터로 넘어감.

---

```java
// 인증 인터셉터
...
        String httpMethod = request.getMethod();
        if ("/api/member".equals(request.getRequestURI()) && "POST".equalsIgnoreCase(httpMethod)) {
            return true;
        }
...
```
경로가 `/api/member`면서 HTTP 메서드가 `POST`인 경우,
다른 코드를 실행하지 않고 `return true`하여 해당 인터셉터를 바로 종료해버림.

---

* 결론 : 인터셉터를 위해 Cors 설정에서 경로를 설정할 수는 있으나, HTTP 메서드까지 설정할 수는 없다.

---

* 코드 : `/api`로 시작하는 모든 경로는 `AuthorizationInterceptor`를 거치게 됨
           But, `POST /api/member`는 해당 인터셉터에 들어와도 코드 수행 없이 바로 통과시켜버림
* 코드 : `/api/member` 경로는 모두 `SignUpInterceptor`를 거치게 됨
           But, `POST` 메서드가 아니라면 해당 인터셉터에 들어와도 코드 수행 없이 바로 통과시켜버림

---

* 다른 대안 : `POST /api/member` 메서드 수행 내용이 특수한 만큼, 이 메서드만을 위한 유니크한 경로 이름 만들기.
                    (`signUp Interceptor`가 필요한 유일한 메서드)
                   ex) `/api`없이 `/member`로만 설정한다거나.
                    -> 그러면 위의 if문을 없애고, /api 등 경로들이 모든 인터셉터를 거칠 필요가 없어짐.