### PR TITLE
[fix] 인터셉터 수정 #121

### DIFF
--- a/src/main/java/com/habitpay/habitpay/global/config/auth/interceptor/AuthorizationInterceptor.java
+++ b/src/main/java/com/habitpay/habitpay/global/config/auth/interceptor/AuthorizationInterceptor.java
@@ -38,7 +38,7 @@ public class AuthorizationInterceptor implements HandlerInterceptor {
 
         if (!(handler instanceof HandlerMethod)) {
             // todo : response로 error 응답 보내기 or throw
-            log.error("handler is not instanceof HandlerMethod"); // 임시
+            log.error("handler is not instanceof HandlerMethod, but {}", handler.getClass().getName()); // 임시
             return false;
         }
 
@@ -63,7 +63,7 @@ public class AuthorizationInterceptor implements HandlerInterceptor {
             if (isSignupRequest) { return true; }
 
             if (!tokenService.getIsActive(token)) {
-                throw new CustomJwtException(HttpStatus.UNAUTHORIZED, CustomJwtErrorInfo.UNAUTHORIZED, "Not an available token.");
+                throw new CustomJwtException(HttpStatus.FORBIDDEN, CustomJwtErrorInfo.FORBIDDEN, "Unavailable token.");
             }
 
             Authentication authentication = tokenService.getAuthentication(token);
@@ -107,7 +107,7 @@ public class AuthorizationInterceptor implements HandlerInterceptor {
             if (!tokenService.getIsActive(token)) {
                 return true;
             } else {
-                throw new CustomJwtException(HttpStatus.UNAUTHORIZED, CustomJwtErrorInfo.UNAUTHORIZED, "Signup try with a member already signed up.");
+                throw new CustomJwtException(HttpStatus.FORBIDDEN, CustomJwtErrorInfo.FORBIDDEN, "Signup try with a member already signed up.");
             }
         }
         return false;


### PR DESCRIPTION
* #119 에서 받은 코멘트를 반영하여 수정

---

* `token`의 `isActive`값이 맞지 않아 에러가 발생한 경우 상태 코드를,
   `UNAUTHORIZED`보다 더 적절한 `FORBIDDEN` 상태 코드로 변경함
* 에러 메시지의 어색한 영어 표현 수정
```java
// before
"Not an available token."

// after
"Unavailable token."
```

---

* 기타
* `handler instanceof HandlerMethod` 예외 처리 분기에서, 디버깅 겸 학습용으로 handler의 정체를 출력하는 코드 추가
```java
log.error("handler is not instanceof HandlerMethod, but {}", handler.getClass().getName());
```