### PR TITLE
[refact] 반복되는 코드 없애기, 반환값 애매한 부분에 주석 추가 #124

### DIFF
--- a/src/main/java/com/habitpay/habitpay/domain/ChallengeAbsenceFee/application/ChallengeAbsenceFeeSearchService.java
+++ b/src/main/java/com/habitpay/habitpay/domain/ChallengeAbsenceFee/application/ChallengeAbsenceFeeSearchService.java
@@ -20,7 +20,8 @@ public class ChallengeAbsenceFeeSearchService {
 
     public int findPersonalTotalFeeOfChallenge(Member member, Challenge challenge) {
         Optional<ChallengeEnrollment> optionalEnrollment = challengeEnrollmentSearchService.findByMemberAndChallenge(member, challenge);
-        return optionalEnrollment.map(ChallengeEnrollment::getTotalFee).orElse(0);
+        // todo: enrollment 객체가 없을 때 throw 에러 처리할 것인지, 벌금으로 나올 수 없는 값인 -1 등을 반환하여 클라이언트 메서드가 알아서 처리할 것인지
+        return optionalEnrollment.map(ChallengeEnrollment::getTotalFee).orElse(-1);
     }
 
     public int findPersonalTotalFeeOfChallenge(ChallengeEnrollment enrollment) {

--- a/src/main/java/com/habitpay/habitpay/domain/challengepost/api/ChallengePostApi.java
+++ b/src/main/java/com/habitpay/habitpay/domain/challengepost/api/ChallengePostApi.java
@@ -42,17 +42,19 @@ public class ChallengePostApi {
             @PathVariable Long id, @AuthenticationPrincipal String email) {
 
         return ResponseEntity.ok()
-                .body(challengePostSearchService.findChallengePostsByMe(id, email));
+                .body(challengePostSearchService.findChallengePostsByMember(id, email));
     }
 
     // -----------------------------------------------------------------------------
     // todo : 'challengeEnrollmentId' or 'memberId' 등 멤버 식별할 수 있는 데이터를 받아야 함
     @GetMapping("/api/challenges/{id}/posts/member")
     public ResponseEntity<List<PostViewResponse>> findChallengePostsByMember(
-            @PathVariable Long id, @AuthenticationPrincipal String email) {
+            @PathVariable Long id) {
+
+        String memberEmail = "otherMember's@email.address"; // todo : 임시
 
         return ResponseEntity.ok()
-                .body(challengePostSearchService.findChallengePostsByMember(id, email));
+                .body(challengePostSearchService.findChallengePostsByMember(id, memberEmail));
     }
     // -------------------------------------------------------------------------------
 

--- a/src/main/java/com/habitpay/habitpay/domain/challengepost/application/ChallengePostSearchService.java
+++ b/src/main/java/com/habitpay/habitpay/domain/challengepost/application/ChallengePostSearchService.java
@@ -53,22 +53,6 @@ public class ChallengePostSearchService {
                 .toList();
     }
 
-    public List<PostViewResponse> findChallengePostsByMe(Long challengeId, String email) {
-        Member member = memberService.findByEmail(email);
-        Challenge challenge = challengeSearchService.findById(challengeId);
-         ChallengeEnrollment enrollment = challengeEnrollmentSearchService.findByMemberAndChallenge(member, challenge)
-                 .orElseThrow(() -> new NoSuchElementException("No Challenge for this Member"));
-
-        Long challengeEnrollmentId = enrollment.getId();
-
-        return this.findAllByChallengeEnrollment(challengeEnrollmentId)
-                .stream()
-                .filter(post -> !post.getIsAnnouncement())
-                // .sorted() // todo : 순서 설정하고 싶을 때
-                .map(post -> new PostViewResponse(post, postPhotoUtilService.makePhotoViewList(postPhotoSearchService.findAllByPost(post))))
-                .toList();
-    }
-
     // todo : 수정해야 함
     public List<PostViewResponse> findChallengePostsByMember(Long challengeId, String email) {
         Member member = memberService.findByEmail(email);


### PR DESCRIPTION
### 중복 코드 삭제

* `멤버`의 `챌린지 내 포스트`를 `모아보는 기능`을 하는 서비스 메서드에 두 종류가 있었음

```java
// 내가 쓴 포스트 모아보기
public List<PostViewResponse> findChallengePostsByMe(Long challengeId, String email) { }

// email 정보를 가진 멤버가 쓴 포스트 모아보기
public List<PostViewResponse> findChallengePostsByMember(Long challengeId, String email) { }
```

* 코드 수정을 거치다보니 두 메서드의 코드가 똑같아짐.
* `findChallengePostsByMember` 이름의 메서드만 남기고 삭제하여 리팩토링 진행

---

### 반환값에 주석 추가

* `enrollment`를 검색해 `벌금값`을 반환하는 메서드
* `벌금값이 0원`인 경우와, `enrollment 객체를 찾지 못한` 경우 모두 `0`을 반환했었음
* 그러나 두 경우가 구분되어야 함

```java
public int findPersonalTotalFeeOfChallenge(Member member, Challenge challenge) {
        Optional<ChallengeEnrollment> optionalEnrollment = challengeEnrollmentSearchService.findByMemberAndChallenge(member, challenge);
        return optionalEnrollment.map(ChallengeEnrollment::getTotalFee).orElse(-1);
    }
```

* 위처럼 `-1`을 반환하게 수정함
* throw로 예외 처리할 수도 있고, 위의 메서드를 이용하는 다른 메서드가 처리할 수도 있기 때문에 수정된 내용처럼 `벌금으로 나올 수 없는 int값` 넣어서 처리할 수도 있을 듯함