### PR TITLE
[feat] 벌금 현황 조회 서비스에서 조회에 필요한 객체를 찾지 못했을 경우, 예외를 던진다 #126

### DIFF
--- a/src/main/java/com/habitpay/habitpay/domain/ChallengeAbsenceFee/application/ChallengeAbsenceFeeSearchService.java
+++ b/src/main/java/com/habitpay/habitpay/domain/ChallengeAbsenceFee/application/ChallengeAbsenceFeeSearchService.java
@@ -9,6 +9,7 @@ import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
 
+import java.util.NoSuchElementException;
 import java.util.Optional;
 
 @Service
@@ -20,8 +21,8 @@ public class ChallengeAbsenceFeeSearchService {
 
     public int findPersonalTotalFeeOfChallenge(Member member, Challenge challenge) {
         Optional<ChallengeEnrollment> optionalEnrollment = challengeEnrollmentSearchService.findByMemberAndChallenge(member, challenge);
-        // todo: enrollment 객체가 없을 때 throw 에러 처리할 것인지, 벌금으로 나올 수 없는 값인 -1 등을 반환하여 클라이언트 메서드가 알아서 처리할 것인지
-        return optionalEnrollment.map(ChallengeEnrollment::getTotalFee).orElse(-1);
+        return optionalEnrollment.map(ChallengeEnrollment::getTotalFee)
+                .orElseThrow(() -> new NoSuchElementException("This member is not in this challenge."));
     }
 
     public int findPersonalTotalFeeOfChallenge(ChallengeEnrollment enrollment) {


### PR DESCRIPTION
```java
 public int findPersonalTotalFeeOfChallenge(Member member, Challenge challenge) {
        Optional<ChallengeEnrollment> optionalEnrollment = challengeEnrollmentSearchService.findByMemberAndChallenge(member, challenge);

        return optionalEnrollment.map(ChallengeEnrollment::getTotalFee)
                .orElseThrow(() -> new NoSuchElementException("This member is not in this challenge."));
    }
```

* `member`와 `challenge` 데이터를 받았으나 그에 맞는 `enrollment 객체`를 찾지 못했을 경우, `예외` `던지기`로 처리