### PR TITLE
fix: 동일한 이메일에 대해 row 가 2개 생성되는 문제 수정 #138

### DIFF
--- a/src/main/java/com/habitpay/habitpay/global/config/auth/CustomOAuth2UserService.java
+++ b/src/main/java/com/habitpay/habitpay/global/config/auth/CustomOAuth2UserService.java
@@ -31,7 +31,7 @@ public class CustomOAuth2UserService implements OAuth2UserService<OAuth2UserRequ
 
         String email = attributes.getEmail();
         Member member = memberRepository.findByEmail(email)
-                .orElse(createMember(email));
+                .orElseGet(() -> createMember(email));
 
         return new CustomUserDetails(
                 member, oAuth2User.getAttributes()


### PR DESCRIPTION
# 개요

Member 테이블에 동일한 이메일을 가진 row 가 2개 생성되는 문제를 해결했습니다.

# 원인

OAuth 로그인 이후 실행 되는 `loadUser` 메서드에서 `findByEmail` 메서드에서 `orElse` 를 사용한 것이 원인이었습니다.

```diff
@Override
public OAuth2User loadUser(OAuth2UserRequest userRequest) throws OAuth2AuthenticationException {
    
    // ...코드 생략...

    String email = attributes.getEmail();
    Member member = memberRepository.findByEmail(email)
+           .orElse(createMember(email));

    return new CustomUserDetails(
            member, oAuth2User.getAttributes()
    );
}
```

이를 이해하기 위해서는 Optional 객체의 메서드 `orElse` 와 `orElseGet` 작동 방식의 차이를 이해해야 합니다. 

## `orElse` 와 `orElseGet`

`orElse` 와 `orElseGet` 은 모두 Optional 객체가 null 값을 가질 때 사용하는 메서드입니다.
결론부터 이야기하면 아래와 같습니다.

**메서드가 매개변수로 전달된 경우**
- `orElse`: 매개변수로 전달된 메서드를 무조건 실행
- `orElseGet`: Optional 객체의 값이 null 인 경우에만 메서드를 실행

### `orElse` 

`orElse` 의 매개변수로 메서드가 전달되는 경우에는 Optional 객체가 null 이 아니어도 실행됩니다.

```java
import java.util.Optional;

public class Program
{
    public static String getHello() {
        System.out.println("getHello(): hello");
        return "hello";
    }

    public static void main(String[] args) {
        String name = Optional.ofNullable("habitpay").orElse(getHello());
        System.out.println(String.format("name: %s", name));

        String nullName = Optional.<String>ofNullable(null).orElse(getHello());
        System.out.println(String.format("nullName: %s", nullName));
    }
}
```

출력 결과는 아래와 같습니다.

```
getHello(): hello
name: habitpay
getHello(): hello
nullName: hello
```

첫 번째 Optional 객체에는 `habitpay` 라는 String 이 있음에도 불구하고 `getHello()` 메서드가 실행된 것을 확인할 수 있습니다.

`orElse` 메서드 내부는 아래와 같이 구현되어 있습니다.

```java
public T orElse(T other) {
  return value != null ? value : other;
}
```

예제 코드에서는 `orElse` 의 매개변수로 들어간 `T other` 에 메서드가 들어간 것인데요.

```java
public T orElse(getHello()) {
  return value != null ? value : "hello";
}
```

`orElse` 는 매개변수의 타입 제네릭 T 를 결정하기 위해서`getHello()` 메서드가 반환하는 값을 알아야 합니다.
그렇기에 Optional 객체의 value 가 `habitpay` 라는 값을 갖고 있어도 `getHello()` 메서드를 실행한 것입니다.
실행 결과로 `T other` 는 `String other` 가 되고, `other` 는 `getHello()` 메서드의 반환 값인 `hello` 가 됩니다.

```java
String name = Optional.ofNullable("habitpay").orElse(getHello()); // getHello(): hello
System.out.println(String.format("name: %s", name)); // name: habitpay
```

한편, Optional 객체의 값이 null 일 때도 `getHello()` 메서드가 실행되었고, 매개변수인 `T other` 는 `String other` 가 되고, `other` 는 `hello` 를 갖게 됩니다. 

```java
String nullName = Optional.<String>ofNullable(null).orElse(getHello()); // getHello(): hello
System.out.println(String.format("nullName: %s", nullName)); // name: hello
```

### `orElseGet` 

`orElseGet` 의 매개변수로 메서드가 전달되는 경우에는 `orElse` 와 조금 다릅니다.

```java
import java.util.Optional;

public class Program
{
    public static String getHello() {
        System.out.println("getHello(): hello");
        return "hello";
    }

    public static void main(String[] args) {
        String name = Optional.ofNullable("habitpay").orElseGet(() -> getHello());
        System.out.println(String.format("name: %s", name));

        String orElseGetName = Optional.<String>ofNullable(null).orElseGet(() -> getHello());
        System.out.println(String.format("orElseGetName: %s", orElseGetName));
    }
}
```

출력 결과는 아래와 같습니다.

```
name: habitpay
getHello(): hello
orElseGetName: hello
```

`orElse` 와 달리 `getHello()` 메서드가 한 번만 호출된 것을 확인할 수 있습니다.
또한, `getHello()` 메서드가 반환한 `hello` 라는 문자열이 `orElseGetName` 변수에 저장된 것을 확인할 수 있습니다.
`orElseGet` 메서드 내부는 아래와 같이 구현되어 있습니다.

```java
public T orElseGet(Supplier<? extends T> other) {
  return value != null ? value : other.get();
}
```

`Supplier` 는 람다 표현식이나 메서드 레퍼런스를 의미합니다.
내부에 `get()` 메서드가 정의되어 있습니다.

```java
@FunctionalInterface
public interface Supplier<T> {

    T get();
}
```

인터페이스 Supplier 의 `get()` 메서드는 람다 표현식으로 작성된 함수 `getHello()`를 호출합니다. 


```java
() -> getHello()
```

Optional 객체의 값이 null 이고, `getHello()` 메서드를 람다 표현식으로 넘기면 `orElseGet` 은 아래와 같이 평가됩니다.

```java
public String orElseGet(Supplier<String> other) {
  return value != null ? value : other.get();
}
```

`orElse` 에서 매개변수 제네릭 T 를 결정하기 위해 메서드의 반환 값을 실행한 것과 달리, `orElseGet` 의 매개변수는 Supplier 라는 인터페이스로 이미 정의되어 있기 때문에 제네릭 T 를 바로 평가하지 않고, value 가 null 일 때만 평가를 합니다.
이를 지연 평가(Lazy Evaluation) 이라고 하네요.

# 해결 

Optional 객체에 null 이 예상될 때 메서드를 실행하고자 한다면 `orElse` 대신 `orElseGet` 를 사용하는 것으로 해결했습니다.

```java
Member member = memberRepository.findByEmail(email)
        .orElseGet(() -> createMember(email));
```

이해하고 작성하는데 조금 시간이 걸렸지만, 정리한 내용이 도움 되었으면 좋겠습니다.

# 참고자료

- [orElse 와 orElseGet 무슨 차이가 있을까?](https://ysjune.github.io/posts/java/orelsenorelseget/) [github.io]
- [Optional의 orElse, orElseGet, orElseThrow 사용법](https://stir.tistory.com/140)
 [티스토리]
- [Optional 클래스의 orElse와 orElseGet에 대한 정리](https://zgundam.tistory.com/174) [티스토리]
- [[Java/자바] - Supplier<T> interface](https://m.blog.naver.com/zzang9ha/222087025042) [네이버 블로그]