### PR TITLE
Feat/사용자 탈퇴 시 개인 정보 삭제#137

### DIFF
--- a/src/main/java/com/habitpay/habitpay/domain/member/api/MemberApi.java
+++ b/src/main/java/com/habitpay/habitpay/domain/member/api/MemberApi.java
@@ -1,36 +1,24 @@
 package com.habitpay.habitpay.domain.member.api;
 
-import com.habitpay.habitpay.domain.member.application.MemberActivationService;
-import com.habitpay.habitpay.domain.member.application.MemberUpdateService;
-import com.habitpay.habitpay.domain.member.application.MemberSearchService;
-import com.habitpay.habitpay.domain.member.application.MemberService;
-import com.habitpay.habitpay.domain.member.domain.Member;
+import com.habitpay.habitpay.domain.member.application.*;
 import com.habitpay.habitpay.domain.member.dto.*;
 import com.habitpay.habitpay.global.config.auth.CustomUserDetails;
-import com.habitpay.habitpay.global.config.aws.S3FileService;
-import com.habitpay.habitpay.global.config.jwt.TokenService;
-import com.habitpay.habitpay.global.error.ErrorResponse;
 import com.habitpay.habitpay.global.response.SuccessResponse;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.http.HttpStatus;
-import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.*;
-
-import java.util.Optional;
 
 @RestController
 @RequiredArgsConstructor
 @RequestMapping("/api")
 @Slf4j
 public class MemberApi {
-    private final MemberService memberService;
     private final MemberSearchService memberSearchService;
     private final MemberActivationService memberActivationService;
     private final MemberUpdateService memberUpdateService;
-    private final TokenService tokenService;
-    private final S3FileService s3FileService;
+    private final MemberDeleteService memberDeleteService;
 
     @GetMapping("/member")
     public SuccessResponse<MemberProfileResponse> getMember(@AuthenticationPrincipal CustomUserDetails user) {
@@ -60,21 +48,7 @@ public class MemberApi {
 
     @DeleteMapping("/member")
     @ResponseStatus(HttpStatus.OK)
-    public ResponseEntity<String> deleteMember(@RequestHeader("Authorization") String authorizationHeader) {
-        Optional<String> optionalToken = tokenService.getTokenFromHeader(authorizationHeader);
-        if (optionalToken.isEmpty()) {
-            String message = ErrorResponse.UNAUTHORIZED.getMessage();
-            return ResponseEntity.status(HttpStatus.UNAUTHORIZED).body(message);
-        }
-
-        String token = optionalToken.get();
-        String email = tokenService.getEmail(token);
-        Member member = memberService.findByEmail(email);
-
-        String imageFileName = member.getImageFileName();
-        log.info("[DELETE /member] imageFileName: {}", imageFileName);
-        s3FileService.deleteImage("profiles", imageFileName);
-        memberService.delete(member);
-        return ResponseEntity.status(HttpStatus.OK).body("정상적으로 탈퇴되었습니다.");
+    public SuccessResponse<Long> deleteMember(@AuthenticationPrincipal CustomUserDetails user) {
+        return memberDeleteService.delete(user.getId());
     }
 }

--- a/src/main/java/com/habitpay/habitpay/domain/member/application/MemberDeleteService.java
+++ b/src/main/java/com/habitpay/habitpay/domain/member/application/MemberDeleteService.java
@@ -1,0 +1,35 @@
+package com.habitpay.habitpay.domain.member.application;
+
+import com.habitpay.habitpay.domain.member.dao.MemberRepository;
+import com.habitpay.habitpay.domain.member.domain.Member;
+import com.habitpay.habitpay.global.config.aws.S3FileService;
+import com.habitpay.habitpay.global.response.SuccessResponse;
+import lombok.AllArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Service;
+
+@Slf4j
+@Service
+@AllArgsConstructor
+public class MemberDeleteService {
+
+    private final MemberRepository memberRepository;
+    private final S3FileService s3FileService;
+
+    public SuccessResponse<Long> delete(Long id) {
+        // TODO: 공통 예외처리 응답으로 처리하기
+        Member member = memberRepository.findById(id)
+                .filter(Member::isActive)
+                .orElseThrow(() -> new IllegalAccessError("이미 탈퇴한 사용자입니다."));
+
+        String imageFileName = member.getImageFileName();
+        log.info("[DELETE /member] imageFileName: {}", imageFileName);
+        s3FileService.deleteImage("profiles", imageFileName);
+
+        member.clear();
+        memberRepository.save(member);
+
+        return SuccessResponse.of("정상적으로 탈퇴되었습니다.", id);
+    }
+
+}

--- a/src/main/java/com/habitpay/habitpay/domain/member/application/MemberDeleteService.java
+++ b/src/main/java/com/habitpay/habitpay/domain/member/application/MemberDeleteService.java
@@ -24,7 +24,9 @@ public class MemberDeleteService {
 
         String imageFileName = member.getImageFileName();
         log.info("[DELETE /member] imageFileName: {}", imageFileName);
-        s3FileService.deleteImage("profiles", imageFileName);
+        if (imageFileName != null) {
+            s3FileService.deleteImage("profiles", imageFileName);
+        }
 
         member.clear();
         memberRepository.save(member);

--- a/src/main/java/com/habitpay/habitpay/domain/member/domain/Member.java
+++ b/src/main/java/com/habitpay/habitpay/domain/member/domain/Member.java
@@ -6,6 +6,8 @@ import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 
+import java.time.LocalDateTime;
+
 @Getter
 @NoArgsConstructor
 @Entity
@@ -18,10 +20,10 @@ public class Member extends BaseTime {
     @Column()
     private String nickname;
 
-    @Column()
+    @Column(unique = true)
     private String imageFileName;
 
-    @Column(nullable = false)
+    @Column(unique = true, nullable = false)
     private String email;
 
     @Column(nullable = false)
@@ -49,9 +51,12 @@ public class Member extends BaseTime {
         this.imageFileName = imageFileName;
     }
 
-    public void updateProfile(String nickname, String imageFileName) {
-        this.nickname = nickname;
-        this.imageFileName = imageFileName;
+    public void clear() {
+        this.nickname = "탈퇴한 사용자";
+        this.imageFileName = null;
+        this.email = null;
+        this.isActive = false;
+        this.setDeletedAt(LocalDateTime.now());
     }
 
     public void activate(String nickname) {

--- a/src/main/java/com/habitpay/habitpay/domain/member/domain/Member.java
+++ b/src/main/java/com/habitpay/habitpay/domain/member/domain/Member.java
@@ -26,9 +26,6 @@ public class Member extends BaseTime {
     @Column()
     private String email;
 
-    @Column(nullable = false)
-    private boolean isActive;
-
     @Enumerated(EnumType.STRING)
     @Column(nullable = false)
     private Role role;
@@ -39,7 +36,6 @@ public class Member extends BaseTime {
         this.email = email;
         this.imageFileName = imageFileName;
         this.nickname = nickname;
-        this.isActive = false;
         this.role = role;
     }
 
@@ -55,13 +51,15 @@ public class Member extends BaseTime {
         this.nickname = "탈퇴한 사용자";
         this.imageFileName = null;
         this.email = null;
-        this.isActive = false;
         this.setDeletedAt(LocalDateTime.now());
+    }
+
+    public boolean isActive() {
+        return this.getDeletedAt() == null;
     }
 
     public void activate(String nickname) {
         this.nickname = nickname;
-        this.isActive = true;
     }
 
     public Member create(String email) {

--- a/src/main/java/com/habitpay/habitpay/domain/member/domain/Member.java
+++ b/src/main/java/com/habitpay/habitpay/domain/member/domain/Member.java
@@ -20,10 +20,10 @@ public class Member extends BaseTime {
     @Column()
     private String nickname;
 
-    @Column(unique = true)
+    @Column()
     private String imageFileName;
 
-    @Column(unique = true, nullable = false)
+    @Column()
     private String email;
 
     @Column(nullable = false)

--- a/src/main/java/com/habitpay/habitpay/domain/model/BaseTime.java
+++ b/src/main/java/com/habitpay/habitpay/domain/model/BaseTime.java
@@ -5,7 +5,6 @@ import jakarta.persistence.EntityListeners;
 import jakarta.persistence.MappedSuperclass;
 import lombok.Getter;
 import org.springframework.data.annotation.CreatedDate;
-import org.springframework.data.annotation.LastModifiedBy;
 import org.springframework.data.annotation.LastModifiedDate;
 import org.springframework.data.jpa.domain.support.AuditingEntityListener;
 
@@ -23,4 +22,8 @@ public abstract class BaseTime {
 
     @Column
     private LocalDateTime deletedAt;
+
+    public void setDeletedAt(LocalDateTime deletedAt) {
+        this.deletedAt = deletedAt;
+    }
 }


### PR DESCRIPTION
# 작업 개요

`DELETE /member` 컨트롤러에서 회원 정보 삭제 시 개인 정보만 null 로 바꾸는 soft delete 를 구현했습니다. 

# 작업 상세 내용

## 1. 컨트롤러에서 서비스 로직 분리

컨트롤러에서 수행하던 서비스 로직을 `MemberDeleteService` 로 분리했습니다.

```java
@Service
@AllArgsConstructor
public class MemberDeleteService {

    private final MemberRepository memberRepository;
    private final S3FileService s3FileService;

    public SuccessResponse<Long> delete(Long id) {
        // TODO: 공통 예외처리 응답으로 처리하기
        Member member = memberRepository.findById(id)
                .filter(Member::isActive)
                .orElseThrow(() -> new IllegalAccessError("이미 탈퇴한 사용자입니다."));

        String imageFileName = member.getImageFileName();
        log.info("[DELETE /member] imageFileName: {}", imageFileName);
        if (imageFileName != null) {
            s3FileService.deleteImage("profiles", imageFileName);
        }

        member.clear();
        memberRepository.save(member);

        return SuccessResponse.of("정상적으로 탈퇴되었습니다.", id);
    }

}

```

## 2. Member 엔티티에서 `isActive` 컬럼 제거

닉네임을 입력해야 사이트를 사용할 수 있도록 생성했던 `isActive` 컬럼을 삭제했습니다.
대신 회원이 탈퇴했는지 여부를 확인하는`isActive()` 메서드를 생성했습니다.

```java
public boolean isActive() {
    return this.getDeletedAt() == null;
}
```

## 3. 탈퇴한 사용자 개인 정보 삭제

탈퇴한 사용자의 개인 정보(이메일, 프로필 이미지)를 null 값으로 변경하고, 닉네임은 `탈퇴한 사용자` 로 변경했습니다.

```java
public void clear() {
    this.nickname = "탈퇴한 사용자";
    this.imageFileName = null;
    this.email = null;
    this.setDeletedAt(LocalDateTime.now());
}
```