### PR TITLE
Test/챌린지 생성 컨트롤러 테스트 케이스 작성#146

### DIFF
--- a/src/docs/asciidoc/api/challenge.adoc
+++ b/src/docs/asciidoc/api/challenge.adoc
@@ -20,3 +20,9 @@
 HTTP response 예시에 나온 `participatingDays` 의 값 `4` 는 10진수 `4` 를 의미하고 2진수로 `0000011` 이기 때문에 `금요일` 과 `토요일` 이 챌린지 참여 요일이 됩니다.
 
 operation::member/get-challenge-details[snippets='http-request,http-response,response-fields']
+
+=== 챌린지 생성
+
+새로운 첼린지를 생성합니다.
+
+operation::member/create-challenge[snippets='http-request,http-response,response-fields']

--- a/src/main/java/com/habitpay/habitpay/domain/challenge/api/ChallengeApi.java
+++ b/src/main/java/com/habitpay/habitpay/domain/challenge/api/ChallengeApi.java
@@ -4,6 +4,7 @@ import com.habitpay.habitpay.domain.challenge.application.ChallengeCreationServi
 import com.habitpay.habitpay.domain.challenge.application.ChallengeDetailsService;
 import com.habitpay.habitpay.domain.challenge.application.ChallengeUpdateService;
 import com.habitpay.habitpay.domain.challenge.dto.ChallengeCreationRequest;
+import com.habitpay.habitpay.domain.challenge.dto.ChallengeCreationResponse;
 import com.habitpay.habitpay.domain.challenge.dto.ChallengeDetailsResponse;
 import com.habitpay.habitpay.domain.challenge.dto.ChallengePatchRequest;
 import com.habitpay.habitpay.global.config.auth.CustomUserDetails;
@@ -31,9 +32,9 @@ public class ChallengeApi {
     }
 
     @PostMapping("/challenges")
-    public ResponseEntity<ApiResponse> createChallenge(@RequestBody ChallengeCreationRequest challengeCreationRequest,
-                                                       @AuthenticationPrincipal CustomUserDetails user) {
-        return challengeCreationService.save(challengeCreationRequest, user.getId());
+    public SuccessResponse<ChallengeCreationResponse> createChallenge(@RequestBody ChallengeCreationRequest challengeCreationRequest,
+                                                                      @AuthenticationPrincipal CustomUserDetails user) {
+        return challengeCreationService.createChallenge(challengeCreationRequest, user.getId());
     }
 
     @PatchMapping("/challenges/{id}")

--- a/src/main/java/com/habitpay/habitpay/domain/challenge/application/ChallengeCreationService.java
+++ b/src/main/java/com/habitpay/habitpay/domain/challenge/application/ChallengeCreationService.java
@@ -10,6 +10,8 @@ import com.habitpay.habitpay.global.response.SuccessResponse;
 import lombok.AllArgsConstructor;
 import org.springframework.stereotype.Service;
 
+import java.time.ZonedDateTime;
+
 @Service
 @AllArgsConstructor
 public class ChallengeCreationService {
@@ -18,6 +20,11 @@ public class ChallengeCreationService {
 
     public SuccessResponse<ChallengeCreationResponse> createChallenge(ChallengeCreationRequest challengeCreationRequest, Long id) {
         Member host = memberSearchService.getMemberById(id);
+        if (isStartDateBeforeNow(challengeCreationRequest.getStartDate())) {
+            // TODO: 예외 처리 공통 응답 적용하기
+            throw new IllegalArgumentException("챌린지 시작 시간은 현재 시간 이후만 가능합니다.");
+        }
+
         Challenge newChallenge = Challenge.of(host, challengeCreationRequest);
         challengeRepository.save(newChallenge);
 
@@ -25,5 +32,9 @@ public class ChallengeCreationService {
                 "챌린지가 생성되었습니다.",
                 ChallengeCreationResponse.of(host, newChallenge)
         );
+    }
+
+    private boolean isStartDateBeforeNow(ZonedDateTime startDate) {
+        return startDate.isBefore(ZonedDateTime.now());
     }
 }

--- a/src/main/java/com/habitpay/habitpay/domain/challenge/application/ChallengeCreationService.java
+++ b/src/main/java/com/habitpay/habitpay/domain/challenge/application/ChallengeCreationService.java
@@ -3,12 +3,11 @@ package com.habitpay.habitpay.domain.challenge.application;
 import com.habitpay.habitpay.domain.challenge.dao.ChallengeRepository;
 import com.habitpay.habitpay.domain.challenge.domain.Challenge;
 import com.habitpay.habitpay.domain.challenge.dto.ChallengeCreationRequest;
+import com.habitpay.habitpay.domain.challenge.dto.ChallengeCreationResponse;
 import com.habitpay.habitpay.domain.member.application.MemberSearchService;
 import com.habitpay.habitpay.domain.member.domain.Member;
-import com.habitpay.habitpay.global.response.ApiResponse;
+import com.habitpay.habitpay.global.response.SuccessResponse;
 import lombok.AllArgsConstructor;
-import org.springframework.http.HttpStatus;
-import org.springframework.http.ResponseEntity;
 import org.springframework.stereotype.Service;
 
 @Service
@@ -17,21 +16,14 @@ public class ChallengeCreationService {
     private final MemberSearchService memberSearchService;
     private final ChallengeRepository challengeRepository;
 
-    public ResponseEntity<ApiResponse> save(ChallengeCreationRequest challengeCreationRequest, Long id) {
+    public SuccessResponse<ChallengeCreationResponse> createChallenge(ChallengeCreationRequest challengeCreationRequest, Long id) {
         Member host = memberSearchService.getMemberById(id);
-        Challenge challenge = Challenge.builder()
-                .member(host)
-                .title(challengeCreationRequest.getTitle())
-                .description(challengeCreationRequest.getDescription())
-                .startDate(challengeCreationRequest.getStartDate())
-                .endDate(challengeCreationRequest.getEndDate())
-                .participatingDays(challengeCreationRequest.getParticipatingDays())
-                .feePerAbsence(challengeCreationRequest.getFeePerAbsence())
-                .build();
-        challengeRepository.save(challenge);
+        Challenge newChallenge = Challenge.of(host, challengeCreationRequest);
+        challengeRepository.save(newChallenge);
 
-        // TODO: 챌린지 id 도 함께 전달하기
-        ApiResponse apiResponse = ApiResponse.create("챌린지가 생성되었습니다.");
-        return ResponseEntity.status(HttpStatus.CREATED).body(apiResponse);
+        return SuccessResponse.of(
+                "챌린지가 생성되었습니다.",
+                ChallengeCreationResponse.of(host, newChallenge)
+        );
     }
 }

--- a/src/main/java/com/habitpay/habitpay/domain/challenge/domain/Challenge.java
+++ b/src/main/java/com/habitpay/habitpay/domain/challenge/domain/Challenge.java
@@ -44,7 +44,7 @@ public class Challenge extends BaseTime {
     private int numberOfParticipants;
 
     @Column(nullable = false)
-    private int participatingDays;
+    private byte participatingDays;
 
     @Column(nullable = false)
     private int feePerAbsence;

--- a/src/main/java/com/habitpay/habitpay/domain/challenge/domain/Challenge.java
+++ b/src/main/java/com/habitpay/habitpay/domain/challenge/domain/Challenge.java
@@ -1,5 +1,6 @@
 package com.habitpay.habitpay.domain.challenge.domain;
 
+import com.habitpay.habitpay.domain.challenge.dto.ChallengeCreationRequest;
 import com.habitpay.habitpay.domain.member.domain.Member;
 import com.habitpay.habitpay.domain.model.BaseTime;
 import jakarta.persistence.*;
@@ -64,6 +65,18 @@ public class Challenge extends BaseTime {
         this.endDate = endDate;
         this.participatingDays = participatingDays;
         this.feePerAbsence = feePerAbsence;
+    }
+
+    public static Challenge of(Member host, ChallengeCreationRequest challengeCreationRequest) {
+        return Challenge.builder()
+                .member(host)
+                .title(challengeCreationRequest.getTitle())
+                .description(challengeCreationRequest.getDescription())
+                .startDate(challengeCreationRequest.getStartDate())
+                .endDate(challengeCreationRequest.getEndDate())
+                .participatingDays(challengeCreationRequest.getParticipatingDays())
+                .feePerAbsence(challengeCreationRequest.getFeePerAbsence())
+                .build();
     }
 
     public void updateDescription(String description) {

--- a/src/main/java/com/habitpay/habitpay/domain/challenge/dto/ChallengeCreationRequest.java
+++ b/src/main/java/com/habitpay/habitpay/domain/challenge/dto/ChallengeCreationRequest.java
@@ -1,10 +1,13 @@
 package com.habitpay.habitpay.domain.challenge.dto;
 
-import lombok.Getter;
+import lombok.*;
 
 import java.time.ZonedDateTime;
 
 @Getter
+@Builder
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@AllArgsConstructor
 public class ChallengeCreationRequest {
     private String title;
     private String description;

--- a/src/main/java/com/habitpay/habitpay/domain/challenge/dto/ChallengeCreationResponse.java
+++ b/src/main/java/com/habitpay/habitpay/domain/challenge/dto/ChallengeCreationResponse.java
@@ -16,7 +16,7 @@ public class ChallengeCreationResponse {
     private String description;
     private ZonedDateTime startDate;
     private ZonedDateTime endDate;
-    private int participatingDays;
+    private byte participatingDays;
     private int feePerAbsence;
 
     public static ChallengeCreationResponse of(Member host, Challenge challenge) {

--- a/src/main/java/com/habitpay/habitpay/domain/challenge/dto/ChallengeCreationResponse.java
+++ b/src/main/java/com/habitpay/habitpay/domain/challenge/dto/ChallengeCreationResponse.java
@@ -1,0 +1,34 @@
+package com.habitpay.habitpay.domain.challenge.dto;
+
+import com.habitpay.habitpay.domain.challenge.domain.Challenge;
+import com.habitpay.habitpay.domain.member.domain.Member;
+import lombok.Builder;
+import lombok.Getter;
+
+import java.time.ZonedDateTime;
+
+@Getter
+@Builder
+public class ChallengeCreationResponse {
+    private String hostNickname;
+    private Long challengeId;
+    private String title;
+    private String description;
+    private ZonedDateTime startDate;
+    private ZonedDateTime endDate;
+    private int participatingDays;
+    private int feePerAbsence;
+
+    public static ChallengeCreationResponse of(Member host, Challenge challenge) {
+        return ChallengeCreationResponse.builder()
+                .hostNickname(host.getNickname())
+                .challengeId(challenge.getId())
+                .title(challenge.getTitle())
+                .description(challenge.getDescription())
+                .startDate(challenge.getStartDate())
+                .endDate(challenge.getEndDate())
+                .participatingDays(challenge.getParticipatingDays())
+                .feePerAbsence(challenge.getFeePerAbsence())
+                .build();
+    }
+}


### PR DESCRIPTION
# 작업 개요

1. 챌린지 생성(`POST /challenges`) 컨트롤러 테스트 코드를 작성했습니다. 
2. 챌린지 생성 서비스 리팩토링을 진행했습니다.
3. 챌린지 참여 일자 변수인 `participatingDays` 의 자료형을 int 에서 byte 로 변경했습니다. 