### PR TITLE
Test/챌린지 정보 수정patch challengesid 테스트 코드 작성#148

### DIFF
--- a/src/docs/asciidoc/api/challenge.adoc
+++ b/src/docs/asciidoc/api/challenge.adoc
@@ -19,10 +19,16 @@
 
 HTTP response 예시에 나온 `participatingDays` 의 값 `4` 는 10진수 `4` 를 의미하고 2진수로 `0000011` 이기 때문에 `금요일` 과 `토요일` 이 챌린지 참여 요일이 됩니다.
 
-operation::member/get-challenge-details[snippets='http-request,http-response,response-fields']
+operation::challenge/get-challenge-details[snippets='http-request,http-response,response-fields']
 
 === 챌린지 생성
 
 새로운 첼린지를 생성합니다.
 
-operation::member/create-challenge[snippets='http-request,http-response,response-fields']
+operation::challenge/create-challenge[snippets='http-request,http-response,response-fields']
+
+=== 챌린지 정보 수정
+
+챌린지 정보를 수정합니다.
+
+operation::challenge/patch-challenge[snippets='http-request,http-response,response-fields']

--- a/src/main/java/com/habitpay/habitpay/domain/challenge/api/ChallengeApi.java
+++ b/src/main/java/com/habitpay/habitpay/domain/challenge/api/ChallengeApi.java
@@ -2,17 +2,12 @@ package com.habitpay.habitpay.domain.challenge.api;
 
 import com.habitpay.habitpay.domain.challenge.application.ChallengeCreationService;
 import com.habitpay.habitpay.domain.challenge.application.ChallengeDetailsService;
-import com.habitpay.habitpay.domain.challenge.application.ChallengeUpdateService;
-import com.habitpay.habitpay.domain.challenge.dto.ChallengeCreationRequest;
-import com.habitpay.habitpay.domain.challenge.dto.ChallengeCreationResponse;
-import com.habitpay.habitpay.domain.challenge.dto.ChallengeDetailsResponse;
-import com.habitpay.habitpay.domain.challenge.dto.ChallengePatchRequest;
+import com.habitpay.habitpay.domain.challenge.application.ChallengePatchService;
+import com.habitpay.habitpay.domain.challenge.dto.*;
 import com.habitpay.habitpay.global.config.auth.CustomUserDetails;
-import com.habitpay.habitpay.global.response.ApiResponse;
 import com.habitpay.habitpay.global.response.SuccessResponse;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
-import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.*;
 
@@ -22,7 +17,7 @@ import org.springframework.web.bind.annotation.*;
 @Slf4j
 public class ChallengeApi {
     private final ChallengeCreationService challengeCreationService;
-    private final ChallengeUpdateService challengeUpdateService;
+    private final ChallengePatchService challengePatchService;
     private final ChallengeDetailsService challengeDetailsService;
 
     @GetMapping("/challenges/{id}")
@@ -38,8 +33,8 @@ public class ChallengeApi {
     }
 
     @PatchMapping("/challenges/{id}")
-    public ResponseEntity<ApiResponse> patchChallengeDetails(@PathVariable("id") Long id, @RequestBody ChallengePatchRequest challengePatchRequest,
-                                                             @AuthenticationPrincipal CustomUserDetails user) {
-        return challengeUpdateService.update(id, challengePatchRequest, user.getId());
+    public SuccessResponse<ChallengePatchResponse> patchChallengeDetails(@PathVariable("id") Long id, @RequestBody ChallengePatchRequest challengePatchRequest,
+                                                                         @AuthenticationPrincipal CustomUserDetails user) {
+        return challengePatchService.patch(id, challengePatchRequest, user.getId());
     }
 }

--- a/src/main/java/com/habitpay/habitpay/domain/challenge/application/ChallengePatchService.java
+++ b/src/main/java/com/habitpay/habitpay/domain/challenge/application/ChallengePatchService.java
@@ -3,42 +3,50 @@ package com.habitpay.habitpay.domain.challenge.application;
 import com.habitpay.habitpay.domain.challenge.dao.ChallengeRepository;
 import com.habitpay.habitpay.domain.challenge.domain.Challenge;
 import com.habitpay.habitpay.domain.challenge.dto.ChallengePatchRequest;
+import com.habitpay.habitpay.domain.challenge.dto.ChallengePatchResponse;
 import com.habitpay.habitpay.domain.member.application.MemberSearchService;
 import com.habitpay.habitpay.domain.member.domain.Member;
-import com.habitpay.habitpay.global.response.ApiResponse;
+import com.habitpay.habitpay.global.response.SuccessResponse;
 import lombok.RequiredArgsConstructor;
-import org.springframework.http.HttpStatus;
-import org.springframework.http.ResponseEntity;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
 @Service
 @RequiredArgsConstructor
-public class ChallengeUpdateService {
+public class ChallengePatchService {
     private final MemberSearchService memberSearchService;
     private final ChallengeRepository challengeRepository;
     private final ChallengeSearchService challengeSearchService;
 
     @Transactional
-    public ResponseEntity<ApiResponse> update(Long challengeId, ChallengePatchRequest challengePatchRequest, Long userId) {
-        ApiResponse apiResponse;
+    public SuccessResponse<ChallengePatchResponse> patch(Long challengeId, ChallengePatchRequest challengePatchRequest, Long userId) {
         Member member = memberSearchService.getMemberById(userId);
         Challenge challenge = challengeSearchService.getChallengeById(challengeId);
 
         if (isChallengeHost(member, challenge) == false) {
-            // TODO: throw 로 예외 처리 가능한지 확인하기
-            apiResponse = ApiResponse.create("챌린지 수정 권한이 없습니다.");
-            return ResponseEntity.status(HttpStatus.UNAUTHORIZED).body(apiResponse);
+            // TODO: 공통 예외 처리 응답 적용하기
+            throw new IllegalArgumentException("챌린지 주최자만 수정 가능합니다.");
         }
 
-        challenge.updateDescription(challengePatchRequest.getDescription());
+        if (isChallengeDescriptionUnchanged(challenge, challengePatchRequest)) {
+            // TODO: 공통 예외 처리 응답 적용하기
+            throw new IllegalArgumentException("변경 사항이 없습니다.");
+        }
+
+        challenge.patch(challengePatchRequest);
         challengeRepository.save(challenge);
 
-        apiResponse = ApiResponse.create("챌린지 정보 수정이 반영되었습니다.");
-        return ResponseEntity.status(HttpStatus.OK).body(apiResponse);
+        return SuccessResponse.of(
+                "챌린지 정보 수정이 반영되었습니다.",
+                ChallengePatchResponse.of(challenge)
+        );
     }
 
     private boolean isChallengeHost(Member member, Challenge challenge) {
         return member.getEmail().equals(challenge.getHost().getEmail());
+    }
+
+    private boolean isChallengeDescriptionUnchanged(Challenge challenge, ChallengePatchRequest challengePatchRequest) {
+        return challenge.getDescription().equals(challengePatchRequest.getDescription());
     }
 }

--- a/src/main/java/com/habitpay/habitpay/domain/challenge/domain/Challenge.java
+++ b/src/main/java/com/habitpay/habitpay/domain/challenge/domain/Challenge.java
@@ -1,6 +1,7 @@
 package com.habitpay.habitpay.domain.challenge.domain;
 
 import com.habitpay.habitpay.domain.challenge.dto.ChallengeCreationRequest;
+import com.habitpay.habitpay.domain.challenge.dto.ChallengePatchRequest;
 import com.habitpay.habitpay.domain.member.domain.Member;
 import com.habitpay.habitpay.domain.model.BaseTime;
 import jakarta.persistence.*;
@@ -79,7 +80,7 @@ public class Challenge extends BaseTime {
                 .build();
     }
 
-    public void updateDescription(String description) {
-        this.description = description;
+    public void patch(ChallengePatchRequest challengePatchRequest) {
+        this.description = challengePatchRequest.getDescription();
     }
 }

--- a/src/main/java/com/habitpay/habitpay/domain/challenge/dto/ChallengePatchRequest.java
+++ b/src/main/java/com/habitpay/habitpay/domain/challenge/dto/ChallengePatchRequest.java
@@ -1,8 +1,11 @@
 package com.habitpay.habitpay.domain.challenge.dto;
 
-import lombok.Getter;
+import lombok.*;
 
 @Getter
+@Builder
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@AllArgsConstructor
 public class ChallengePatchRequest {
     private String description;
 }

--- a/src/main/java/com/habitpay/habitpay/domain/challenge/dto/ChallengePatchResponse.java
+++ b/src/main/java/com/habitpay/habitpay/domain/challenge/dto/ChallengePatchResponse.java
@@ -1,0 +1,29 @@
+package com.habitpay.habitpay.domain.challenge.dto;
+
+import com.habitpay.habitpay.domain.challenge.domain.Challenge;
+import lombok.Builder;
+import lombok.Getter;
+
+import java.time.ZonedDateTime;
+
+@Getter
+@Builder
+public class ChallengePatchResponse {
+    private String title;
+    private String description;
+    private ZonedDateTime startDate;
+    private ZonedDateTime endDate;
+    private int participatingDays;
+    private int feePerAbsence;
+
+    public static ChallengePatchResponse of(Challenge challenge) {
+        return ChallengePatchResponse.builder()
+                .title(challenge.getTitle())
+                .description(challenge.getDescription())
+                .startDate(challenge.getStartDate())
+                .endDate(challenge.getEndDate())
+                .participatingDays(challenge.getParticipatingDays())
+                .feePerAbsence(challenge.getFeePerAbsence())
+                .build();
+    }
+}


### PR DESCRIPTION
# 작업 개요

1. 챌린지 정보 수정 컨트롤러 `PATCH /challenges/{id}` 테스트 코드를 작성했습니다. 
2. 해당 컨트롤러의 반환 자료형을 `SuccessResponse` 로 감싸주었습니다.
3. 해당 컨트롤러의 데이터에 해당하는 `ChallengePatchResponse` 클래스를 생성했습니다. (Challenge 나 ChallengeDetailsResponse 클래스를 재사용 하려고 했으나, 각 요청에 맞는 응답을 보내주는 것이 안전하다고 판단.)