### PR TITLE
[Test] ChallengePost API: findPost(), findChallengePosts() 메서드를 위한 테스트 코드 작성 #143

### DIFF
--- a/src/docs/asciidoc/api/challengePost.adoc
+++ b/src/docs/asciidoc/api/challengePost.adoc
@@ -1,0 +1,16 @@
+== 챌린지 포스트 API
+:doctype: book
+:source-highlighter: highlightjs
+:toc: left
+:toclevels: 2
+:seclinks:
+
+챌린지 포스트를 등록, 조회, 수정 및 삭제할 수 있습니다.
+
+Request Header 에는 ``Authorization: Bearer {access token}`` 와 같은 형식으로 보내야 하며, 사용자의 ``액세스 토큰``이 필요합니다.
+
+=== 챌린지 포스트 조회
+
+경로 변수로 받은 id값을 이용해 챌린지 포스트를 조회합니다.
+
+operation::challengePost/get-challengePost[snippets='http-request,http-response,response-fields']

--- a/src/docs/asciidoc/api/challengePost.adoc
+++ b/src/docs/asciidoc/api/challengePost.adoc
@@ -11,6 +11,20 @@ Request Header 에는 ``Authorization: Bearer {access token}`` 와 같은 형식
 
 === 챌린지 포스트 조회
 
-경로 변수로 받은 id값을 이용해 챌린지 포스트를 조회합니다.
+경로 변수로 받은 challengePost의 id값을 이용해 특정 챌린지 포스트를 조회합니다.
 
 operation::challengePost/get-challengePost[snippets='http-request,http-response,response-fields']
+
+=== 챌린지 내 전체 포스트 조회
+
+경로 변수로 받은 challenge의 id값을 이용해 해당 챌린지 내의 모든 포스트를 조회합니다.
+해당 챌린지에 등록되어 있는 멤버만 포스트를 조회할 수 있습니다.
+
+operation::challengePost/get-challengePosts[snippets='http-request,http-response,response-fields']
+
+=== 챌린지 내 본인이 작성한 모든 포스트 조회
+
+경로 변수로 받은 challenge의 id값을 이용해 해당 챌린지 내에서 본인이 작성한 모든 포스트를 조회합니다.
+'본인'이란 요청을 보낸 멤버를 의미합니다.
+
+operation::challengePost/get-challengePosts-by-me[snippets='http-request,http-response,response-fields']

--- a/src/docs/asciidoc/api/challengePost.adoc
+++ b/src/docs/asciidoc/api/challengePost.adoc
@@ -22,9 +22,9 @@ operation::challengePost/get-challengePost[snippets='http-request,http-response,
 
 operation::challengePost/get-challengePosts[snippets='http-request,http-response,response-fields']
 
-=== 챌린지 내 본인이 작성한 모든 포스트 조회
-
-경로 변수로 받은 challenge의 id값을 이용해 해당 챌린지 내에서 본인이 작성한 모든 포스트를 조회합니다.
-'본인'이란 요청을 보낸 멤버를 의미합니다.
-
-operation::challengePost/get-challengePosts-by-me[snippets='http-request,http-response,response-fields']
+// === 챌린지 내 본인이 작성한 모든 포스트 조회
+//
+// 경로 변수로 받은 challenge의 id값을 이용해 해당 챌린지 내에서 본인이 작성한 모든 포스트를 조회합니다.
+// '본인'이란 요청을 보낸 멤버를 의미합니다.
+//
+// operation::challengePost/get-challengePosts-by-me[snippets='http-request,http-response,response-fields']

--- a/src/main/java/com/habitpay/habitpay/domain/challengepost/dto/PostViewResponse.java
+++ b/src/main/java/com/habitpay/habitpay/domain/challengepost/dto/PostViewResponse.java
@@ -1,5 +1,6 @@
 package com.habitpay.habitpay.domain.challengepost.dto;
 
+import com.fasterxml.jackson.annotation.JsonFormat;
 import com.habitpay.habitpay.domain.challengepost.domain.ChallengePost;
 import com.habitpay.habitpay.domain.postphoto.dto.PostPhotoView;
 import lombok.Getter;
@@ -17,6 +18,7 @@ public class PostViewResponse {
     private String content;
     private String writer;
     private Boolean isAnnouncement;
+    @JsonFormat(shape = JsonFormat.Shape.STRING, pattern = "yyyy-MM-dd'T'HH:mm:ss")
     private LocalDateTime createdAt;
     private List<PostPhotoView> photoViewList;
 

--- a/src/test/java/com/habitpay/habitpay/domain/api/ChallengePostApiTest.java
+++ b/src/test/java/com/habitpay/habitpay/domain/api/ChallengePostApiTest.java
@@ -1,0 +1,130 @@
+package com.habitpay.habitpay.domain.api;
+
+import com.habitpay.habitpay.docs.springrestdocs.AbstractRestDocsTests;
+import com.habitpay.habitpay.domain.challenge.domain.Challenge;
+import com.habitpay.habitpay.domain.challengeenrollment.domain.ChallengeEnrollment;
+import com.habitpay.habitpay.domain.challengepost.api.ChallengePostApi;
+import com.habitpay.habitpay.domain.challengepost.application.*;
+import com.habitpay.habitpay.domain.challengepost.domain.ChallengePost;
+import com.habitpay.habitpay.domain.challengepost.dto.PostViewResponse;
+import com.habitpay.habitpay.domain.member.domain.Member;
+import com.habitpay.habitpay.domain.member.domain.Role;
+import com.habitpay.habitpay.domain.postphoto.dto.PostPhotoView;
+import com.habitpay.habitpay.global.config.jwt.TokenProvider;
+import com.habitpay.habitpay.global.config.jwt.TokenService;
+import com.habitpay.habitpay.global.security.WithMockOAuth2User;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.http.HttpHeaders;
+import org.springframework.test.web.servlet.ResultActions;
+
+import java.time.ZonedDateTime;
+import java.util.Date;
+import java.util.List;
+
+import static java.util.Date.*;
+import static org.mockito.ArgumentMatchers.anyLong;
+import static org.mockito.BDDMockito.given;
+import static org.springframework.restdocs.headers.HeaderDocumentation.headerWithName;
+import static org.springframework.restdocs.headers.HeaderDocumentation.requestHeaders;
+import static org.springframework.restdocs.mockmvc.MockMvcRestDocumentation.document;
+import static org.springframework.restdocs.mockmvc.RestDocumentationRequestBuilders.get;
+import static org.springframework.restdocs.payload.PayloadDocumentation.fieldWithPath;
+import static org.springframework.restdocs.payload.PayloadDocumentation.responseFields;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+@WebMvcTest(ChallengePostApi.class)
+public class ChallengePostApiTest extends AbstractRestDocsTests {
+
+    static final String AUTHORIZATION_HEADER_PREFIX = "Bearer ";
+
+    // 해당 클래스가 의존하고 있는 객체는 @MockBean으로 가짜 객체 만들어주기
+    @MockBean
+    ChallengePostSearchService challengePostSearchService;
+
+    @MockBean
+    ChallengePostUpdateService challengePostUpdateService;
+
+    @MockBean
+    ChallengePostDeleteService challengePostDeleteService;
+
+    @MockBean
+    ChallengePostCreationService challengePostCreationService;
+
+    @MockBean
+    TokenProvider tokenProvider;
+
+    @MockBean
+    TokenService tokenService;
+
+    // given.(의존관계에 있는 객체의 메서드(인자)).willReturn(반환값);
+    // 역시 의존성 단절 과정
+
+    @Test
+    @DisplayName("챌린지 포스트 조회")
+    void findPost() throws Exception {
+
+        // given
+        Member mockMember = Member.builder()
+                .id(1L)
+                .email("test@gmail.com")
+//                .role(Role.valueOf("ROLE_GUEST"))
+                .imageFileName(null)
+                .nickname("testy user")
+                .build();
+
+        Challenge mockChallenge = Challenge.builder()
+                .member(mockMember)
+                .title("making test code")
+                .description("making test code for restDocs")
+                .startDate(ZonedDateTime.now())
+                .endDate(ZonedDateTime.now())
+                .feePerAbsence(1000)
+                .build();
+
+        ChallengeEnrollment mockEnrollment = ChallengeEnrollment.builder()
+                .challenge(mockChallenge)
+                .member(mockMember)
+                .enrolledDate(ZonedDateTime.now())
+                .build();
+
+        ChallengePost mockPost = ChallengePost.builder()
+                .content("This is test post.")
+                .isAnnouncement(false)
+                .enrollment(mockEnrollment)
+                .build();
+
+        List<PostPhotoView> mockPostPhotoViewList = null;
+
+        // todo: API 리턴 타입을 SuccessResponse로 바꾸고 다시 해야 할 듯
+        PostViewResponse mockPostViewResponse = new PostViewResponse(mockPost, mockPostPhotoViewList);
+
+        given(challengePostSearchService.findPostById(anyLong())).willReturn(mockPostViewResponse);
+
+        // when
+        // Mock을 통해 실행한 요청의 결과 (체이닝 방식?)
+        ResultActions result = mockMvc.perform(get("/api/posts/{id}", anyLong())
+                .header(HttpHeaders.AUTHORIZATION, AUTHORIZATION_HEADER_PREFIX + "ACCESS_TOKEN"));
+
+        //then
+        result.andExpect(status().isOk())
+                .andDo(document("challengePost/get-challengePost",
+                        requestHeaders(
+                                headerWithName(HttpHeaders.AUTHORIZATION).description("액세스 토큰")
+                        ),
+                        responseFields(
+                                // fieldWithPath("message").description("메시지"),
+                                fieldWithPath("data.id").description("포스트 id"),
+                                fieldWithPath("data.challengeEnrollmentId").description("포스트가 소속된 enrollment id"),
+                                fieldWithPath("data.content").description("포스트 내용"),
+                                fieldWithPath("data.writer").description("작성자"),
+                                fieldWithPath("data.isAnnouncement").description("공지글 여부"),
+                                fieldWithPath("data.createdAt").description("생성 일시"),
+                                fieldWithPath("data.photoViewList").description("포스트 포토 URL을 담은 배열")
+                        )
+                ));
+    }
+
+}

--- a/src/test/java/com/habitpay/habitpay/domain/api/ChallengePostApiTest.java
+++ b/src/test/java/com/habitpay/habitpay/domain/api/ChallengePostApiTest.java
@@ -1,26 +1,39 @@
 package com.habitpay.habitpay.domain.api;
 
 import com.habitpay.habitpay.docs.springrestdocs.AbstractRestDocsTests;
+import com.habitpay.habitpay.domain.challenge.dao.ChallengeRepository;
 import com.habitpay.habitpay.domain.challenge.domain.Challenge;
+import com.habitpay.habitpay.domain.challengeenrollment.dao.ChallengeEnrollmentRepository;
 import com.habitpay.habitpay.domain.challengeenrollment.domain.ChallengeEnrollment;
 import com.habitpay.habitpay.domain.challengepost.api.ChallengePostApi;
 import com.habitpay.habitpay.domain.challengepost.application.*;
+import com.habitpay.habitpay.domain.challengepost.dao.ChallengePostRepository;
 import com.habitpay.habitpay.domain.challengepost.domain.ChallengePost;
 import com.habitpay.habitpay.domain.challengepost.dto.PostViewResponse;
+import com.habitpay.habitpay.domain.member.dao.MemberRepository;
 import com.habitpay.habitpay.domain.member.domain.Member;
 import com.habitpay.habitpay.domain.member.domain.Role;
+import com.habitpay.habitpay.domain.model.BaseTime;
+import com.habitpay.habitpay.domain.postphoto.dao.PostPhotoRepository;
+import com.habitpay.habitpay.domain.postphoto.domain.PostPhoto;
 import com.habitpay.habitpay.domain.postphoto.dto.PostPhotoView;
 import com.habitpay.habitpay.global.config.jwt.TokenProvider;
 import com.habitpay.habitpay.global.config.jwt.TokenService;
 import com.habitpay.habitpay.global.security.WithMockOAuth2User;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
 import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.boot.test.mock.mockito.MockBean;
 import org.springframework.http.HttpHeaders;
+import org.springframework.restdocs.payload.JsonFieldType;
 import org.springframework.security.test.context.support.WithMockUser;
 import org.springframework.test.web.servlet.ResultActions;
 
+import java.lang.reflect.Field;
+import java.time.LocalDateTime;
 import java.time.ZonedDateTime;
 import java.util.ArrayList;
 import java.util.Date;
@@ -29,8 +42,7 @@ import java.util.stream.Collectors;
 import java.util.stream.IntStream;
 
 import static java.util.Date.*;
-import static org.mockito.ArgumentMatchers.anyLong;
-import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.ArgumentMatchers.*;
 import static org.mockito.BDDMockito.given;
 import static org.springframework.restdocs.headers.HeaderDocumentation.headerWithName;
 import static org.springframework.restdocs.headers.HeaderDocumentation.requestHeaders;
@@ -45,12 +57,13 @@ import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.
 import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.print;
 
 
-@WebMvcTest(ChallengePostApi.class)
+//@WebMvcTest(ChallengePostApi.class)
+@SpringBootTest
+@AutoConfigureMockMvc
 public class ChallengePostApiTest extends AbstractRestDocsTests {
 
     static final String AUTHORIZATION_HEADER_PREFIX = "Bearer ";
 
-    // 해당 클래스가 의존하고 있는 객체는 @MockBean으로 가짜 객체 만들어주기
     @MockBean
     ChallengePostSearchService challengePostSearchService;
 
@@ -63,6 +76,21 @@ public class ChallengePostApiTest extends AbstractRestDocsTests {
     @MockBean
     ChallengePostCreationService challengePostCreationService;
 
+    @Autowired
+    MemberRepository memberRepository;
+
+    @Autowired
+    ChallengeRepository challengeRepository;
+
+    @Autowired
+    ChallengeEnrollmentRepository challengeEnrollmentRepository;
+
+    @Autowired
+    ChallengePostRepository challengePostRepository;
+
+    @Autowired
+    PostPhotoRepository postPhotoRepository;
+
     @MockBean
     TokenProvider tokenProvider;
 
@@ -70,53 +98,65 @@ public class ChallengePostApiTest extends AbstractRestDocsTests {
     TokenService tokenService;
 
     private Member createTestMember() {
-        return Member.builder()
-                .id(1L)
+        return memberRepository.save(Member.builder()
                 .email("test@gmail.com")
-//                .role(Role.valueOf("ROLE_GUEST"))
+                .role(Role.GUEST)
                 .imageFileName(null)
                 .nickname("test member")
-                .build();
+                .build());
     }
 
     private Challenge createTestChallenge(Member testMember) {
-        return Challenge.builder()
+        return challengeRepository.save(Challenge.builder()
                 .member(testMember)
                 .title("making test code")
                 .description("making test code for restDocs")
                 .startDate(ZonedDateTime.now())
                 .endDate(ZonedDateTime.now())
                 .feePerAbsence(1000)
-                .build();
+                .build());
     }
 
     private ChallengeEnrollment createTestChallengeEnrollment(Member testMember, Challenge testChallenge) {
-        return ChallengeEnrollment.builder()
+        return challengeEnrollmentRepository.save(ChallengeEnrollment.builder()
                 .challenge(testChallenge)
                 .member(testMember)
                 .enrolledDate(ZonedDateTime.now())
-                .build();
+                .build());
     }
 
-    private ChallengePost createTestChallengePost(ChallengeEnrollment testEnrollment) {
-        return ChallengePost.builder()
-                .content("This is test post.")
+    private ChallengePost createTestChallengePost(ChallengeEnrollment testEnrollment, String content) {
+        return challengePostRepository.save(ChallengePost.builder()
+                .content(content)
                 .isAnnouncement(false)
                 .enrollment(testEnrollment)
-                .build();
+                .build());
     }
 
-    private List<ChallengePost> createTestChallengePostList(ChallengeEnrollment testEnrollment) {
-        return IntStream.rangeClosed(1,10)
-                .mapToObj(i -> ChallengePost.builder()
-                        .content("This is test post" + i)
+    private List<ChallengePost> createTestChallengePostList(ChallengeEnrollment testEnrollment, int i) {
+        List<ChallengePost> postList = IntStream.rangeClosed(1, i)
+                .mapToObj(index -> challengePostRepository.save(ChallengePost.builder()
+                        .content("This is test post" + index)
                             .isAnnouncement(false)
                             .enrollment(testEnrollment)
-                            .build())
+                            .build()))
                 .toList();
+
+        return postList;
     }
 
-    // given.(의존관계에 있는 객체의 메서드(인자)).willReturn(반환값);
+    private List<PostPhotoView> createTestPostPhotoViewList(ChallengePost post) {
+        PostPhoto photo = postPhotoRepository.save(PostPhoto.builder()
+                .post(post)
+                .viewOrder(1L)
+                //.imageFileName(eq("https://picsum.photos/id/40/200/300"))
+                .build());
+
+        List<PostPhotoView> photoViewList = new ArrayList<>();
+        photoViewList.add(new PostPhotoView(photo.getId(), photo.getViewOrder(), "https://picsum.photos/id/40/200/300"));
+
+        return photoViewList;
+    }
 
     @Test
     @DisplayName("챌린지 포스트 조회")
@@ -126,14 +166,13 @@ public class ChallengePostApiTest extends AbstractRestDocsTests {
         Member testMember = createTestMember();
         Challenge testChallenge = createTestChallenge(testMember);
         ChallengeEnrollment testEnrollment = createTestChallengeEnrollment(testMember, testChallenge);
-        ChallengePost mockPost = createTestChallengePost(testEnrollment);
-
-        List<PostPhotoView> mockPostPhotoViewList = null;
+        ChallengePost testPost = createTestChallengePost(testEnrollment, "This is test post");
+        List<PostPhotoView> mockPostPhotoViewList = createTestPostPhotoViewList(testPost);
 
         // todo: API 리턴 타입을 SuccessResponse로 바꾸고 수정하기
-        PostViewResponse mockPostViewResponse = new PostViewResponse(mockPost, mockPostPhotoViewList);
+        PostViewResponse mockPostViewResponse = new PostViewResponse(testPost, mockPostPhotoViewList);
 
-        given(challengePostSearchService.findPostById(anyLong())).willReturn(mockPostViewResponse);
+        given(challengePostSearchService.findPostById(1L)).willReturn(mockPostViewResponse);
 
         // when
         // Mock을 통해 실행한 요청의 결과 (체이닝 방식?)
@@ -157,13 +196,16 @@ public class ChallengePostApiTest extends AbstractRestDocsTests {
 //                                fieldWithPath("data.isAnnouncement").description("공지글 여부"),
 //                                fieldWithPath("data.createdAt").description("생성 일시"),
 //                                fieldWithPath("data.photoViewList").description("포스트 포토 URL을 담은 배열")
-                                fieldWithPath("id").description("포스트 id"),
-                                fieldWithPath("challengeEnrollmentId").description("포스트가 소속된 enrollment id"),
+                                fieldWithPath("id").description("포스트 id(삭제 예정)"),
+                                fieldWithPath("challengeEnrollmentId").description("포스트가 소속된 enrollment id(삭제 예정)"),
                                 fieldWithPath("content").description("포스트 내용"),
                                 fieldWithPath("writer").description("작성자"),
                                 fieldWithPath("isAnnouncement").description("공지글 여부"),
-                                fieldWithPath("createdAt").description("생성 일시"),
-                                fieldWithPath("photoViewList").description("포스트 포토 URL을 담은 배열")
+                                fieldWithPath("createdAt").description("생성 일시, yyyy-MM-dd'T'HH:mm:ss 패턴 사용"),
+                                fieldWithPath("photoViewList").description("포스트 포토(URL 포함) 데이터를 담은 객체 배열"),
+                                fieldWithPath("photoViewList[].postPhotoId").description("포토 id(삭제 예정)"),
+                                fieldWithPath("photoViewList[].viewOrder").description("포스트 내 포토의 순서"),
+                                fieldWithPath("photoViewList[].imageUrl").description("포스트 포토 url")
                         )
                 ));
     }
@@ -176,17 +218,16 @@ public class ChallengePostApiTest extends AbstractRestDocsTests {
         Member testMember = createTestMember();
         Challenge testChallenge = createTestChallenge(testMember);
         ChallengeEnrollment testEnrollment = createTestChallengeEnrollment(testMember, testChallenge);
-        List<ChallengePost> mockPostList = createTestChallengePostList(testEnrollment);
 
-        List<PostPhotoView> mockPostPhotoViewList = null;
-        List<PostViewResponse> mockPostViewResponseList = new ArrayList<>();
-
+        int postCount = 3;
+        List<ChallengePost> testPostList = createTestChallengePostList(testEnrollment, postCount);
+        List<PostViewResponse> testPostViewResponseList = new ArrayList<>();
         // todo: 리턴 타입 SuccessResponse로 바꾸고 수정
-        for (ChallengePost mockPost : mockPostList) {
-            mockPostViewResponseList.add(new PostViewResponse(mockPost, mockPostPhotoViewList));
+        for (ChallengePost post : testPostList) {
+            testPostViewResponseList.add(new PostViewResponse(post, createTestPostPhotoViewList(post)));
         }
 
-        given(challengePostSearchService.findChallengePostsByChallengeId(anyLong())).willReturn(mockPostViewResponseList);
+        given(challengePostSearchService.findChallengePostsByChallengeId(anyLong())).willReturn(testPostViewResponseList);
 
         // when
         // Mock을 통해 실행한 요청의 결과 (체이닝 방식?)
@@ -207,57 +248,61 @@ public class ChallengePostApiTest extends AbstractRestDocsTests {
                                 fieldWithPath("[].content").description("포스트 내용"),
                                 fieldWithPath("[].writer").description("작성자"),
                                 fieldWithPath("[].isAnnouncement").description("공지글 여부"),
-                                fieldWithPath("[].createdAt").description("생성 일시"),
-                                fieldWithPath("[].photoViewList").description("포스트 포토 URL을 담은 배열")
+                                fieldWithPath("[].createdAt").description("생성 일시, yyyy-MM-dd'T'HH:mm:ss 패턴 사용"),
+                                fieldWithPath("[].photoViewList").description("포스트 포토(URL 포함) 데이터를 담은 객체 배열"),
+                                fieldWithPath("[].photoViewList[].postPhotoId").description("포토 id(삭제 예정)"),
+                                fieldWithPath("[].photoViewList[].viewOrder").description("포스트 내 포토의 순서"),
+                                fieldWithPath("[].photoViewList[].imageUrl").description("포스트 포토 url")
                         )
                 ));
     }
 
-    @Test
-    @DisplayName("챌린지 내 본인이 작성한 모든 포스트 조회")
-    void findChallengePostsByMe() throws Exception {
-
-        // given
-        Member testMember = createTestMember();
-        Challenge testChallenge = createTestChallenge(testMember);
-        ChallengeEnrollment testEnrollment = createTestChallengeEnrollment(testMember, testChallenge);
-        List<ChallengePost> mockPostList = createTestChallengePostList(testEnrollment);
-
-        List<PostPhotoView> mockPostPhotoViewList = null;
-        List<PostViewResponse> mockPostViewResponseList = new ArrayList<>();
-
-        // todo: 리턴 타입 SuccessResponse로 바꾸고 수정
-        for (ChallengePost mockPost : mockPostList) {
-            mockPostViewResponseList.add(new PostViewResponse(mockPost, mockPostPhotoViewList));
-        }
-        System.out.println(mockPostViewResponseList);
-
-        given(challengePostSearchService.findChallengePostsByMember(1L, "test@gmail.com")).willReturn(mockPostViewResponseList);
-
-        // when
-        // Mock을 통해 실행한 요청의 결과 (체이닝 방식?)
-        ResultActions result = mockMvc.perform(get("/api/challenges/{id}/posts/me", 1L)
-                .header(HttpHeaders.AUTHORIZATION, AUTHORIZATION_HEADER_PREFIX + "ACCESS_TOKEN"));
-
-        //then
-        result.andExpect(status().isOk())
-//                .andExpect(jsonPath("$[0].id").value(1L))
-                .andDo(document("challengePost/get-challengePosts-by-me",
-                        requestHeaders(
-                                headerWithName(HttpHeaders.AUTHORIZATION).description("액세스 토큰")
-                        ),
-                        responseFields(
-                                // todo: API 리턴 타입을 SuccessResponse로 바꾸고 수정하기
-                                fieldWithPath("[].id").description("포스트 id"),
-                                fieldWithPath("[].challengeEnrollmentId").description("포스트가 소속된 enrollment id"),
-                                fieldWithPath("[].content").description("포스트 내용"),
-                                fieldWithPath("[].writer").description("작성자"),
-                                fieldWithPath("[].isAnnouncement").description("공지글 여부"),
-                                fieldWithPath("[].createdAt").description("생성 일시"),
-                                fieldWithPath("[].photoViewList").description("포스트 포토 URL을 담은 배열")
-                        )
-                ));
-
-    }
+    // todo : given()에서 설정한 리턴 객체가 아닌 빈 배열이 오는 문제 -> 메서드에서 인자 수정하고 다시 시도
+//    @Test
+//    @DisplayName("챌린지 내 본인이 작성한 모든 포스트 조회")
+//    void findChallengePostsByMe() throws Exception {
+//
+//        // given
+//        Member testMember = createTestMember();
+//        Challenge testChallenge = createTestChallenge(testMember);
+//        ChallengeEnrollment testEnrollment = createTestChallengeEnrollment(testMember, testChallenge);
+//        List<ChallengePost> mockPostList = createTestChallengePostList(testEnrollment);
+//
+//        List<PostPhotoView> mockPostPhotoViewList = null;
+//        List<PostViewResponse> mockPostViewResponseList = new ArrayList<>();
+//
+//        // todo: 리턴 타입 SuccessResponse로 바꾸고 수정
+//        for (ChallengePost mockPost : mockPostList) {
+//            mockPostViewResponseList.add(new PostViewResponse(mockPost, mockPostPhotoViewList));
+//        }
+//        System.out.println(mockPostViewResponseList);
+//
+//        given(challengePostSearchService.findChallengePostsByMember(1L, "test@gmail.com")).willReturn(mockPostViewResponseList);
+//
+//        // when
+//        // Mock을 통해 실행한 요청의 결과 (체이닝 방식?)
+//        ResultActions result = mockMvc.perform(get("/api/challenges/{id}/posts/me", 1L)
+//                .header(HttpHeaders.AUTHORIZATION, AUTHORIZATION_HEADER_PREFIX + "ACCESS_TOKEN"));
+//
+//        //then
+//        result.andExpect(status().isOk())
+////                .andExpect(jsonPath("$[0].id").value(1L))
+//                .andDo(document("challengePost/get-challengePosts-by-me",
+//                        requestHeaders(
+//                                headerWithName(HttpHeaders.AUTHORIZATION).description("액세스 토큰")
+//                        ),
+//                        responseFields(
+//                                // todo: API 리턴 타입을 SuccessResponse로 바꾸고 수정하기
+//                                fieldWithPath("[].id").description("포스트 id"),
+//                                fieldWithPath("[].challengeEnrollmentId").description("포스트가 소속된 enrollment id"),
+//                                fieldWithPath("[].content").description("포스트 내용"),
+//                                fieldWithPath("[].writer").description("작성자"),
+//                                fieldWithPath("[].isAnnouncement").description("공지글 여부"),
+//                                fieldWithPath("[].createdAt").description("생성 일시"),
+//                                fieldWithPath("[].photoViewList").description("포스트 포토 URL을 담은 배열")
+//                        )
+//                ));
+//
+//    }
 
 }


### PR DESCRIPTION
### 작업 개요

* `ChallengePost API`를 위한 컨트롤러의 `테스트 코드` 작성을 시작했습니다.
* 포스트를 조회하는 다음의 두 메서드를 위한 테스트 코드를 생성했습니다.
* `/GET "/api/posts/{id}"` `findPost()`
* `/GET "/api/challenges/{id}/posts"` `findChallengePosts()`

---

### 코드 주요 내용

* `테스트 클래스`의 `설정`
* 엔티티 생성 과정에서 자동 생성되어야 할 값이 `null`로 들어오는 문제 해결 (Many thanks to joonhan)
```java
@SpringBootTest
@AutoConfigureMockMvc
public class ChallengePostApiTest extends AbstractRestDocsTests {
...
}
```
* 처음에 `@WebMvcTest(ChallengePostApi.class)` 어노테이션을 사용했습니다.
* 그러나 `Post` 객체에서 자동 생성되어야 할 `CreatedAt`의 속성값이 `null`로 나오는 문제에 직면했습니다.
* `@CreateDate` 어노테이션을 단 `CreatedAt` 속성은 실제 엔티티가 생성되고 `JPA Repository`에 저장되는 과정에서 값이 자동 생성되는데,
컨트롤러 등에만 적용되는 웹 레이어 기반인 `@WebMvcTest` 설정에서는 `DB` 컨텍스트가 아예 없기 때문이죠,,
(컨트롤러 및 필터 기반만 테스트하고, DB는 테스트하지 않기 때문에 아예 자동 생성이 이루어지지 않음)
* 그래서 DB 컨텍스트를 포함하여 테스트할 수 있도록, 테스트 설정 어노테이션을 위처럼 바꾸었습니다.

---

* `DB` 컨텍스트에 필요한 객체 추가
```java
...
@Autowired
    ChallengePostRepository challengePostRepository;
...
```
* `Member`, `Challenge` 등 `ChallengePost`와 관련된 `도메인` `Repository`들을 위처럼 `@Autowired`로 추가했습니다.
* 테스트 코드에서는, `mock 데이터`를 만들고 해당 `repository`에 `save()` 해주면 됩니다.

```java
challengePostRepository.save(ChallengePost.builder()
                .content(content)
                .isAnnouncement(false)
                .enrollment(testEnrollment)
                .build());
    }
```

---

* 쉬운 `mock 객체` 생성을 위한 `create 메서드` 생성
```java
private ChallengePost createTestChallengePost(...) {
        return challengePostRepository.save(ChallengePost.builder()
                ...
                .build());
    }
```
* 메서드마다 테스트를 위해 `mock 객체`를 만드는 작업이 반복됩니다.
* 반복 작업을 줄여 가독성을 높이기 위해, `mock 객체`를 생성 및 저장한 후 반환하는 `private` `create.. 메서드` 시리즈를 만들었습니다.
* `Member`, `Challenge` 등 테스트에 필요한 도메인 객체를 대상으로 합니다.
* `create 메서드` 자체가 많아지니 가독성이 아쉬워서, 추후 `팩토리 클래스`로 분리해 파일을 나눌 생각도 하고 있습니다.

---

* `/GET "/api/posts/{id}"` `findPost()` 테스트 메서드
```java
    @Test
    @DisplayName("챌린지 포스트 조회")
    void findPost() throws Exception {

        // given
        Member testMember = createTestMember();
        Challenge testChallenge = createTestChallenge(testMember);
        ChallengeEnrollment testEnrollment = createTestChallengeEnrollment(testMember, testChallenge);
        ChallengePost testPost = createTestChallengePost(testEnrollment, "This is test post");
        List<PostPhotoView> mockPostPhotoViewList = createTestPostPhotoViewList(testPost);
        PostViewResponse mockPostViewResponse = new PostViewResponse(testPost, mockPostPhotoViewList);

        given(challengePostSearchService.findPostById(1L)).willReturn(mockPostViewResponse);

        // when
        ResultActions result = mockMvc.perform(get("/api/posts/{id}", 1L)
                .header(HttpHeaders.AUTHORIZATION, AUTHORIZATION_HEADER_PREFIX + "ACCESS_TOKEN"));

        //then
        result.andExpect(status().isOk())
                .andDo(document("challengePost/get-challengePost",
                        requestHeaders(
                                headerWithName(HttpHeaders.AUTHORIZATION).description("액세스 토큰")
                        ),
                        responseFields(
                                // fieldWithPath("message").description("메시지"),
                               // fieldWithPath("data.id").description("포스트 id"),
                                  ...
                                  fieldWithPath("id").description("포스트 id(삭제 예정)"),
                                 ...
                        )
                ));
    }
```
* 준한님이 선지적으로 작성하신 테스트 코드를 참고하여 작성했습니다.
* 아직 `SuccessResponse`로 일관화하는 내용이 적용되지 않아, `응답 객체`의 `field 요소`가 `data.[속성명]` 대신 `[속성명]`으로 표시되어 있습니다.
* 추후 수정할 예정입니다.

---

* `/GET "/api/challenges/{id}/posts"` `findChallengePosts()` 테스트 메서드
```java
@Test
    @DisplayName("챌린지 내 전체 포스트 조회")
    void findChallengePosts() throws Exception {

        // given
        Member testMember = createTestMember();
        Challenge testChallenge = createTestChallenge(testMember);
        ChallengeEnrollment testEnrollment = createTestChallengeEnrollment(testMember, testChallenge);

        int postCount = 3;
        List<ChallengePost> testPostList = createTestChallengePostList(testEnrollment, postCount);
        List<PostViewResponse> testPostViewResponseList = new ArrayList<>();
        for (ChallengePost post : testPostList) {
            testPostViewResponseList.add(new PostViewResponse(post, createTestPostPhotoViewList(post)));
        }
        given(challengePostSearchService.findChallengePostsByChallengeId(anyLong())).willReturn(testPostViewResponseList);

        // when
        ResultActions result = mockMvc.perform(get("/api/challenges/{id}/posts", 1L)
                .header(HttpHeaders.AUTHORIZATION, AUTHORIZATION_HEADER_PREFIX + "ACCESS_TOKEN"));

        //then
        result.andExpect(status().isOk())
                .andDo(document("challengePost/get-challengePosts",
                        requestHeaders(
                                headerWithName(HttpHeaders.AUTHORIZATION).description("액세스 토큰")
                        ),
                        responseFields(
                                // todo: API 리턴 타입을 SuccessResponse로 바꾸고 수정하기
                                fieldWithPath("[].id").description("포스트 id"),
                                ...
                                fieldWithPath("[].photoViewList").description("포스트 포토(URL 포함) 데이터를 담은 객체 배열"),
                                fieldWithPath("[].photoViewList[].postPhotoId").description("포토 id(삭제 예정)"),
                                ...
                        )
                ));
    }
```
* 앞선 테스트 코드와 비슷하나, 배열을 반환하는 경우에는 `[ ]`를 사용해 표시하는 차이점이 있습니다.

---

### `RestDocs` 작성

* `challengePost.adoc`를 작성했습니다.

---

### 기타

* `createdAt` 속성의 표시값을 일관적이고 보기 좋게 만들기 위해, `응답 DTO`에서 해당 속성의 포맷값을 설정했습니다.

```java
// PostViewResponse.java

public class PostViewResponse {
    ...
    @JsonFormat(shape = JsonFormat.Shape.STRING, pattern = "yyyy-MM-dd'T'HH:mm:ss")
    private LocalDateTime createdAt;
    ...
}
```
* "2024-07-19T16:06:46" 식으로, 소수점 자리를 뗀 초 단위까지만 기록해 응답으로 보냅니다.

---

* 미완성인 테스트 코드가 주석으로 달려있습니다.