### PR TITLE
Test/챌린지 등록 post challengeidenroll 테스트 코드 작성#150

### DIFF
--- a/src/docs/asciidoc/api/challenge.adoc
+++ b/src/docs/asciidoc/api/challenge.adoc
@@ -32,3 +32,9 @@ operation::challenge/create-challenge[snippets='http-request,http-response,respo
 챌린지 정보를 수정합니다.
 
 operation::challenge/patch-challenge[snippets='http-request,http-response,response-fields']
+
+=== 챌린지 참여자 등록
+
+사용자를 챌린지 참여자에 등록합니다.
+
+operation::challenge/enroll-challenge[snippets='http-request,http-response,response-fields']

--- a/src/main/java/com/habitpay/habitpay/domain/challengeenrollment/api/ChallengeEnrollmentApi.java
+++ b/src/main/java/com/habitpay/habitpay/domain/challengeenrollment/api/ChallengeEnrollmentApi.java
@@ -1,9 +1,11 @@
 package com.habitpay.habitpay.domain.challengeenrollment.api;
 
-import com.habitpay.habitpay.domain.challengeenrollment.application.ChallengeCancellationService;
+import com.habitpay.habitpay.domain.challengeenrollment.application.ChallengeEnrollmentCancellationService;
 import com.habitpay.habitpay.domain.challengeenrollment.application.ChallengeEnrollmentService;
+import com.habitpay.habitpay.domain.challengeenrollment.dto.ChallengeEnrollmentResponse;
 import com.habitpay.habitpay.global.config.auth.CustomUserDetails;
 import com.habitpay.habitpay.global.response.ApiResponse;
+import com.habitpay.habitpay.global.response.SuccessResponse;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.http.ResponseEntity;
@@ -19,16 +21,16 @@ import org.springframework.web.bind.annotation.RestController;
 @RequiredArgsConstructor
 public class ChallengeEnrollmentApi {
     private final ChallengeEnrollmentService challengeEnrollmentService;
-    private final ChallengeCancellationService challengeCancellationService;
+    private final ChallengeEnrollmentCancellationService challengeEnrollmentCancellationService;
 
     @PostMapping("/challenges/{id}/enroll")
-    public ResponseEntity<ApiResponse> enrollChallenge(@PathVariable("id") Long id, @AuthenticationPrincipal CustomUserDetails user) {
+    public SuccessResponse<ChallengeEnrollmentResponse> enrollChallenge(@PathVariable("id") Long id, @AuthenticationPrincipal CustomUserDetails user) {
         return challengeEnrollmentService.enroll(id, user.getId());
     }
 
     @PostMapping("/challenges/{id}/cancel")
     public ResponseEntity<ApiResponse> cancelChallenge(@PathVariable("id") Long id, @AuthenticationPrincipal CustomUserDetails user) {
-        return challengeCancellationService.cancel(id, user.getId());
+        return challengeEnrollmentCancellationService.cancel(id, user.getId());
     }
 
 }

--- a/src/main/java/com/habitpay/habitpay/domain/challengeenrollment/application/ChallengeEnrollmentCancellationService.java
+++ b/src/main/java/com/habitpay/habitpay/domain/challengeenrollment/application/ChallengeEnrollmentCancellationService.java
@@ -20,7 +20,7 @@ import java.util.Optional;
 @Slf4j
 @Service
 @RequiredArgsConstructor
-public class ChallengeCancellationService {
+public class ChallengeEnrollmentCancellationService {
     private final ChallengeEnrollmentRepository challengeEnrollmentRepository;
     private final ChallengeSearchService challengeSearchService;
     private final MemberSearchService memberSearchService;

--- a/src/main/java/com/habitpay/habitpay/domain/challengeenrollment/domain/ChallengeEnrollment.java
+++ b/src/main/java/com/habitpay/habitpay/domain/challengeenrollment/domain/ChallengeEnrollment.java
@@ -45,13 +45,20 @@ public class ChallengeEnrollment {
     private int totalFee;
 
     @Builder
-    public ChallengeEnrollment(Challenge challenge, Member member, ZonedDateTime enrolledDate) {
+    public ChallengeEnrollment(Challenge challenge, Member member) {
         this.challenge = challenge;
         this.member = member;
         this.isGivenUp = false;
-        this.enrolledDate = enrolledDate;
+        this.enrolledDate = ZonedDateTime.now();
         this.successCount = 0;
         this.failureCount = 0;
         this.totalFee = 0;
+    }
+
+    public static ChallengeEnrollment of(Member member, Challenge challenge) {
+        return ChallengeEnrollment.builder()
+                .challenge(challenge)
+                .member(member)
+                .build();
     }
 }

--- a/src/main/java/com/habitpay/habitpay/domain/challengeenrollment/dto/ChallengeEnrollmentResponse.java
+++ b/src/main/java/com/habitpay/habitpay/domain/challengeenrollment/dto/ChallengeEnrollmentResponse.java
@@ -1,0 +1,26 @@
+package com.habitpay.habitpay.domain.challengeenrollment.dto;
+
+import com.habitpay.habitpay.domain.challenge.domain.Challenge;
+import com.habitpay.habitpay.domain.challengeenrollment.domain.ChallengeEnrollment;
+import com.habitpay.habitpay.domain.member.domain.Member;
+import lombok.*;
+
+import java.time.ZonedDateTime;
+
+@Getter
+@Builder
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@AllArgsConstructor
+public class ChallengeEnrollmentResponse {
+    Long challengeId;
+    Long memberId;
+    ZonedDateTime enrolledDate;
+
+    public static ChallengeEnrollmentResponse of(Challenge challenge, ChallengeEnrollment challengeEnrollment, Member member) {
+        return ChallengeEnrollmentResponse.builder()
+                .challengeId(challenge.getId())
+                .memberId(member.getId())
+                .enrolledDate(challengeEnrollment.getEnrolledDate())
+                .build();
+    }
+}

--- a/src/test/java/com/habitpay/habitpay/domain/challengeenrollment/api/ChallengeEnrollmentApiTest.java
+++ b/src/test/java/com/habitpay/habitpay/domain/challengeenrollment/api/ChallengeEnrollmentApiTest.java
@@ -1,0 +1,87 @@
+package com.habitpay.habitpay.domain.challengeenrollment.api;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.habitpay.habitpay.docs.springrestdocs.AbstractRestDocsTests;
+import com.habitpay.habitpay.domain.challengeenrollment.application.ChallengeEnrollmentCancellationService;
+import com.habitpay.habitpay.domain.challengeenrollment.application.ChallengeEnrollmentService;
+import com.habitpay.habitpay.domain.challengeenrollment.dto.ChallengeEnrollmentResponse;
+import com.habitpay.habitpay.global.config.jwt.TokenProvider;
+import com.habitpay.habitpay.global.config.jwt.TokenService;
+import com.habitpay.habitpay.global.response.SuccessResponse;
+import com.habitpay.habitpay.global.security.WithMockOAuth2User;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.http.HttpHeaders;
+import org.springframework.test.web.servlet.ResultActions;
+
+import java.time.ZonedDateTime;
+
+import static org.mockito.ArgumentMatchers.anyLong;
+import static org.mockito.BDDMockito.given;
+import static org.springframework.restdocs.headers.HeaderDocumentation.headerWithName;
+import static org.springframework.restdocs.headers.HeaderDocumentation.requestHeaders;
+import static org.springframework.restdocs.mockmvc.MockMvcRestDocumentation.document;
+import static org.springframework.restdocs.mockmvc.RestDocumentationRequestBuilders.post;
+import static org.springframework.restdocs.payload.PayloadDocumentation.fieldWithPath;
+import static org.springframework.restdocs.payload.PayloadDocumentation.responseFields;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+@WebMvcTest(ChallengeEnrollmentApi.class)
+public class ChallengeEnrollmentApiTest extends AbstractRestDocsTests {
+
+    static final String AUTHORIZATION_HEADER_PREFIX = "Bearer ";
+
+    @Autowired
+    ObjectMapper objectMapper;
+
+    @MockBean
+    ChallengeEnrollmentService challengeEnrollmentService;
+
+    @MockBean
+    ChallengeEnrollmentCancellationService challengeEnrollmentCancellationService;
+
+    @MockBean
+    TokenService tokenService;
+
+    @MockBean
+    TokenProvider tokenProvider;
+
+    @Test
+    @WithMockOAuth2User
+    @DisplayName("챌린지 등록")
+    void enrollChallenge() throws Exception {
+
+        // given
+        ChallengeEnrollmentResponse challengeEnrollmentResponse = ChallengeEnrollmentResponse.builder()
+                .challengeId(1L)
+                .memberId(1L)
+                .enrolledDate(ZonedDateTime.now())
+                .build();
+
+        given(challengeEnrollmentService.enroll(anyLong(), anyLong()))
+                .willReturn(SuccessResponse.of("챌린지에 정상적으로 등록했습니다.", challengeEnrollmentResponse));
+
+        // when
+        ResultActions result = mockMvc.perform(post("/api/challenges/{id}/enroll", 1L)
+                .header(HttpHeaders.AUTHORIZATION, AUTHORIZATION_HEADER_PREFIX + "ACCESS_TOKEN"));
+
+        // then
+        result.andExpect(status().isOk())
+                .andDo(document("challenge/enroll-challenge",
+                        requestHeaders(
+                                headerWithName(HttpHeaders.AUTHORIZATION).description("액세스 토큰")
+                        ),
+                        responseFields(
+                                fieldWithPath("message").description("메세지"),
+                                fieldWithPath("data.challengeId").description("챌린지 ID"),
+                                fieldWithPath("data.memberId").description("사용자 ID"),
+                                fieldWithPath("data.enrolledDate").description("챌린지 등록 일시")
+                        )
+                ));
+    }
+
+
+}


### PR DESCRIPTION
# 작업 개요

1. 챌린지 등록 컨트롤러 (POST /challenges/{id}/enroll) 테스트 코드 작성
2. `ChallengeEnrollmentResponse` 클래스 생성
3. 챌린지 등록 컨트롤러 반환 자료형 `SuccessResponse` 클래스 적용
4. `ChallengeCancellationService` 서비스 이름 변경 -> `ChallengeEnrollmentCancellationService`

# 공유 사항

기존에 챌린지 등록 서비스 메서드에 사용했던 `@Transactional` 어노테이션을 제거했습니다.
```diff
- @Transactional
  public SuccessResponse<ChallengeEnrollmentResponse> enroll(Long challengeId, Long userId) {
```

자료를 찾아보니 해당 어노테이션을 사용하는 경우는 하나의 메서드 안에서 여러 쿼리가 발생했을 때 전부 성공해야 하거나, 전부 실패해야 한다고 합니다.
예를 들면, A 가 B 에게 5만원을 송금해야 하는 경우에는 아래와 같은 순서로 쿼리가 이루어집니다.

1. A 의 잔고가 5만원 이상인지 확인 (read)
2. B 의 계좌가 입금을 받을 수 있는 상태인지 확인 (read)
3. A 의 계좌에서 5만원 인출 (update)
4. B 의 계좌에 5만원 입금 (update)

1~3번까지 작업이 성공했지만 에러가 발생해서 4번은 진행되지 않았다고 가정해봅니다.
그러면 A 의 계좌에서 돈이 나갔지만, 실제로 B 의 계좌에는 돈이 들어오지 않는 상황이 됩니다.
그래서 모든 작업이 완료될 때까지 쓰기 작업을 지연하다가 작업이 끝나면 DB 에 업데이트하고, 만약 문제가 생기면 이전 상태로 돌려줄 수 있도록 지원하는 것이 Transaction 입니다. 

`ChallengeEnrollmentService` 의 `enroll()` 메서드에서는 위와 같은 상황이 발생할 가능성이 없기 때문에 `@Transactional` 어노테이션을 제거했습니다. 

```java
public SuccessResponse<ChallengeEnrollmentResponse> enroll(Long challengeId, Long userId) {
    Challenge challenge = challengeSearchService.getChallengeById(challengeId);
    validateChallengeEnrollmentTime(challenge);

    Member member = memberSearchService.getMemberById(userId);
    challengeEnrollmentRepository.findByMember(member)
            .ifPresent(entity -> {
                // TODO: 공통 예외 처리 추가하기
                throw new IllegalStateException("이미 참여한 챌린지입니다.");
            });

    ChallengeEnrollment challengeEnrollment = ChallengeEnrollment.of(member, challenge);
    challengeEnrollmentRepository.save(challengeEnrollment);
    log.info("챌린지 등록 완료");
    return SuccessResponse.of(
            "챌린지에 정상적으로 등록했습니다.",
            ChallengeEnrollmentResponse.of(
                    challenge, challengeEnrollment, member
            )
    );
}
```