### PR TITLE
[Feat] 페이지네이션 적용을 위한 백엔드 코드 초안 작성 #160

### DIFF
--- a/src/main/java/com/habitpay/habitpay/domain/challengepost/api/ChallengePostApi.java
+++ b/src/main/java/com/habitpay/habitpay/domain/challengepost/api/ChallengePostApi.java
@@ -9,7 +9,6 @@ import com.habitpay.habitpay.global.response.SuccessResponse;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.data.domain.Pageable;
-import org.springframework.data.web.PageableDefault;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.*;
 
@@ -42,7 +41,7 @@ public class ChallengePostApi {
             @RequestParam(defaultValue = "5") int size,
             @RequestParam(defaultValue = "asc") String[] sort) {
 
-        Pageable pageable = challengePostUtilService.checkPageableParam(page, size, sort);
+        Pageable pageable = challengePostUtilService.makePageable(page, size, sort);
 
         return SuccessResponse.of(
                 "",
@@ -58,7 +57,7 @@ public class ChallengePostApi {
             @RequestParam(defaultValue = "5") int size,
             @RequestParam(defaultValue = "asc") String[] sort) {
 
-        Pageable pageable = challengePostUtilService.checkPageableParam(page, size, sort);
+        Pageable pageable = challengePostUtilService.makePageable(page, size, sort);
 
         return SuccessResponse.of(
           "",
@@ -76,7 +75,7 @@ public class ChallengePostApi {
             @RequestParam(defaultValue = "asc") String[] sort) {
 
         String memberEmail = "otherMember@email.address"; // todo : 임시
-        Pageable pageable = challengePostUtilService.checkPageableParam(page, size, sort);
+        Pageable pageable = challengePostUtilService.makePageable(page, size, sort);
 
         return SuccessResponse.of(
                 "",

--- a/src/main/java/com/habitpay/habitpay/domain/challengepost/api/ChallengePostApi.java
+++ b/src/main/java/com/habitpay/habitpay/domain/challengepost/api/ChallengePostApi.java
@@ -8,6 +8,8 @@ import com.habitpay.habitpay.global.config.auth.CustomUserDetails;
 import com.habitpay.habitpay.global.response.SuccessResponse;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.web.PageableDefault;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.*;
 
@@ -33,7 +35,9 @@ public class ChallengePostApi {
     }
 
     @GetMapping("/api/challenges/{id}/posts")
-    public SuccessResponse<List<PostViewResponse>> getChallengePosts(@PathVariable Long id) {
+    public SuccessResponse<List<PostViewResponse>> getChallengePosts(
+            @PathVariable Long id,
+            @PageableDefault(page = 0, size = 5) Pageable pageable) {
 
         return SuccessResponse.of(
                 "",

--- a/src/main/java/com/habitpay/habitpay/domain/challengepost/api/ChallengePostApi.java
+++ b/src/main/java/com/habitpay/habitpay/domain/challengepost/api/ChallengePostApi.java
@@ -24,6 +24,7 @@ public class ChallengePostApi {
     private final ChallengePostSearchService challengePostSearchService;
     private final ChallengePostUpdateService challengePostUpdateService;
     private final ChallengePostDeleteService challengePostDeleteService;
+    private final ChallengePostUtilService challengePostUtilService;
 
     @GetMapping("/api/posts/{id}")
     public SuccessResponse<PostViewResponse> getPost(@PathVariable Long id) {
@@ -37,21 +38,31 @@ public class ChallengePostApi {
     @GetMapping("/api/challenges/{id}/posts")
     public SuccessResponse<List<PostViewResponse>> getChallengePosts(
             @PathVariable Long id,
-            @PageableDefault(page = 0, size = 5) Pageable pageable) {
+            @RequestParam(defaultValue = "0") int page,
+            @RequestParam(defaultValue = "5") int size,
+            @RequestParam(defaultValue = "asc") String[] sort) {
+
+        Pageable pageable = challengePostUtilService.checkPageableParam(page, size, sort);
 
         return SuccessResponse.of(
                 "",
-                challengePostSearchService.findPostViewResponseListByChallengeId(id)
+                challengePostSearchService.findPostViewResponseListByChallengeId(id, pageable)
         );
     }
 
     @GetMapping("/api/challenges/{id}/posts/me")
     public SuccessResponse<List<PostViewResponse>> getChallengePostsByMe(
-            @PathVariable Long id, @AuthenticationPrincipal CustomUserDetails user) {
+            @PathVariable Long id,
+            @AuthenticationPrincipal CustomUserDetails user,
+            @RequestParam(defaultValue = "0") int page,
+            @RequestParam(defaultValue = "5") int size,
+            @RequestParam(defaultValue = "asc") String[] sort) {
+
+        Pageable pageable = challengePostUtilService.checkPageableParam(page, size, sort);
 
         return SuccessResponse.of(
           "",
-          challengePostSearchService.findChallengePostsByMember(id, user.getEmail())
+          challengePostSearchService.findChallengePostsByMember(id, user.getEmail(), pageable)
         );
     }
 
@@ -59,13 +70,17 @@ public class ChallengePostApi {
     // todo : 'challengeEnrollmentId' or 'memberId' 등 멤버 식별할 수 있는 데이터를 받아야 함
     @GetMapping("/api/challenges/{id}/posts/member")
     public SuccessResponse<List<PostViewResponse>> getChallengePostsByMember(
-            @PathVariable Long id) {
+            @PathVariable Long id,
+            @RequestParam(defaultValue = "0") int page,
+            @RequestParam(defaultValue = "5") int size,
+            @RequestParam(defaultValue = "asc") String[] sort) {
 
         String memberEmail = "otherMember@email.address"; // todo : 임시
+        Pageable pageable = challengePostUtilService.checkPageableParam(page, size, sort);
 
         return SuccessResponse.of(
                 "",
-                challengePostSearchService.findChallengePostsByMember(id, memberEmail)
+                challengePostSearchService.findChallengePostsByMember(id, memberEmail, pageable)
         );
     }
     // -------------------------------------------------------------------------------

--- a/src/main/java/com/habitpay/habitpay/domain/challengepost/api/ChallengePostApi.java
+++ b/src/main/java/com/habitpay/habitpay/domain/challengepost/api/ChallengePostApi.java
@@ -25,6 +25,10 @@ public class ChallengePostApi {
     private final ChallengePostDeleteService challengePostDeleteService;
     private final ChallengePostUtilService challengePostUtilService;
 
+    private static final String DEFAULT_PAGE = "0";
+    private static final String DEFAULT_SIZE = "5";
+    private static final String DEFAULT_SORT = "asc";
+
     @GetMapping("/api/posts/{id}")
     public SuccessResponse<PostViewResponse> getPost(@PathVariable Long id) {
 
@@ -37,9 +41,9 @@ public class ChallengePostApi {
     @GetMapping("/api/challenges/{id}/posts")
     public SuccessResponse<List<PostViewResponse>> getChallengePosts(
             @PathVariable Long id,
-            @RequestParam(defaultValue = "0") int page,
-            @RequestParam(defaultValue = "5") int size,
-            @RequestParam(defaultValue = "asc") String[] sort) {
+            @RequestParam(defaultValue = DEFAULT_PAGE) int page,
+            @RequestParam(defaultValue = DEFAULT_SIZE) int size,
+            @RequestParam(defaultValue = DEFAULT_SORT) String[] sort) {
 
         Pageable pageable = challengePostUtilService.makePageable(page, size, sort);
 
@@ -53,9 +57,9 @@ public class ChallengePostApi {
     public SuccessResponse<List<PostViewResponse>> getChallengePostsByMe(
             @PathVariable Long id,
             @AuthenticationPrincipal CustomUserDetails user,
-            @RequestParam(defaultValue = "0") int page,
-            @RequestParam(defaultValue = "5") int size,
-            @RequestParam(defaultValue = "asc") String[] sort) {
+            @RequestParam(defaultValue = DEFAULT_PAGE) int page,
+            @RequestParam(defaultValue = DEFAULT_SIZE) int size,
+            @RequestParam(defaultValue = DEFAULT_SORT) String[] sort) {
 
         Pageable pageable = challengePostUtilService.makePageable(page, size, sort);
 
@@ -70,9 +74,9 @@ public class ChallengePostApi {
     @GetMapping("/api/challenges/{id}/posts/member")
     public SuccessResponse<List<PostViewResponse>> getChallengePostsByMember(
             @PathVariable Long id,
-            @RequestParam(defaultValue = "0") int page,
-            @RequestParam(defaultValue = "5") int size,
-            @RequestParam(defaultValue = "asc") String[] sort) {
+            @RequestParam(defaultValue = DEFAULT_PAGE) int page,
+            @RequestParam(defaultValue = DEFAULT_SIZE) int size,
+            @RequestParam(defaultValue = DEFAULT_SORT) String[] sort) {
 
         String memberEmail = "otherMember@email.address"; // todo : 임시
         Pageable pageable = challengePostUtilService.makePageable(page, size, sort);

--- a/src/main/java/com/habitpay/habitpay/domain/challengepost/application/ChallengePostSearchService.java
+++ b/src/main/java/com/habitpay/habitpay/domain/challengepost/application/ChallengePostSearchService.java
@@ -16,6 +16,8 @@ import com.habitpay.habitpay.domain.postphoto.domain.PostPhoto;
 import com.habitpay.habitpay.domain.postphoto.dto.PostPhotoView;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Service;
 
 import java.util.List;
@@ -43,9 +45,9 @@ public class ChallengePostSearchService {
         return new PostViewResponse(challengePost, photoViewList);
     }
 
-    public List<PostViewResponse> findPostViewResponseListByChallengeId(Long challengeId) {
+    public List<PostViewResponse> findPostViewResponseListByChallengeId(Long challengeId, Pageable pageable) {
 
-        return this.findAllByChallengeId(challengeId)
+        return this.findAllByChallengeId(challengeId, pageable)
                 .stream()
                 // .filter(post -> !post.getIsAnnouncement()) // todo
                 // .sorted() // todo : 순서 설정하고 싶을 때
@@ -56,7 +58,7 @@ public class ChallengePostSearchService {
                 .toList();
     }
 
-    public List<PostViewResponse> findChallengePostsByMember(Long challengeId, String email) {
+    public List<PostViewResponse> findChallengePostsByMember(Long challengeId, String email, Pageable pageable) {
         Member member = memberService.findByEmail(email);
         Challenge challenge = challengeSearchService.getChallengeById(challengeId);
         ChallengeEnrollment enrollment = challengeEnrollmentSearchService.findByMemberAndChallenge(member, challenge)
@@ -64,7 +66,7 @@ public class ChallengePostSearchService {
 
         Long challengeEnrollmentId = enrollment.getId();
 
-        return challengePostRepository.findAllByChallengeEnrollmentId(challengeEnrollmentId)
+        return challengePostRepository.findAllByChallengeEnrollmentId(challengeEnrollmentId, pageable)
                 .stream()
                 // .filter(post -> !post.getIsAnnouncement()) // todo
                 // .sorted() // todo : 순서 설정하고 싶을 때
@@ -81,8 +83,8 @@ public class ChallengePostSearchService {
     }
 
     // todo : 각 챌린지 별로 findAll 해주는 메서드
-    public List<ChallengePost> findAllByChallengeId(Long challengeId) {
-        return challengePostRepository.findAllByChallengeEnrollmentId(1L); // todo : 임시값
+    public List<ChallengePost> findAllByChallengeId(Long challengeId, Pageable pageable) {
+        return challengePostRepository.findAllByChallengeEnrollmentId(1L, pageable); // todo : 임시값
 
         // 방법 1 :
         // 챌린지 아이디를 이용해 챌린지를 찾는다 (DB 검색1)

--- a/src/main/java/com/habitpay/habitpay/domain/challengepost/application/ChallengePostUtilService.java
+++ b/src/main/java/com/habitpay/habitpay/domain/challengepost/application/ChallengePostUtilService.java
@@ -11,6 +11,9 @@ import com.habitpay.habitpay.domain.refreshtoken.exception.CustomJwtException;
 import com.habitpay.habitpay.global.error.CustomJwtErrorInfo;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.Sort;
 import org.springframework.http.HttpStatus;
 import org.springframework.security.core.context.SecurityContextHolder;
 import org.springframework.stereotype.Service;
@@ -28,6 +31,12 @@ public class ChallengePostUtilService {
     private final ChallengeParticipationRecordCreationService challengeParticipationRecordCreationService;
     private final ChallengeParticipationRecordSearchService challengeParticipationRecordSearchService;
 
+    private static final int DEFAULT_PAGE = 0;
+    private static final int DEFAULT_SIZE = 5;
+    private static final int MAX_SIZE = 100;
+    private static final String DEFAULT_SORT = "asc";
+
+
     public void authorizePostWriter(ChallengePost post, String memberEmail) {
         if (!post.getWriter().getEmail().equals(memberEmail)) {
             throw new CustomJwtException(HttpStatus.UNAUTHORIZED, CustomJwtErrorInfo.UNAUTHORIZED, "해당 포스트의 작성자가 아닙니다.");
@@ -41,6 +50,25 @@ public class ChallengePostUtilService {
     public boolean isChallengeHost(Challenge challenge, String email) {
         String hostEmail = challenge.getHost().getEmail();
         return hostEmail.equals(email);
+    }
+
+    public Pageable checkPageableParam(int page, int size, String[] sort) {
+
+        if (page < 0) {
+            page = DEFAULT_PAGE;
+        }
+
+        if (size < 1) {
+            size = DEFAULT_SIZE;
+        } else if (size > MAX_SIZE) {
+            size = MAX_SIZE;
+        }
+
+        // todo : sort 제공할 것인지
+//        if (sort.length > 1) {
+//        }
+
+        return PageRequest.of(page, size);
     }
 
     public void verifyChallengePostForRecord(ChallengePost post) {

--- a/src/main/java/com/habitpay/habitpay/domain/challengepost/application/ChallengePostUtilService.java
+++ b/src/main/java/com/habitpay/habitpay/domain/challengepost/application/ChallengePostUtilService.java
@@ -13,9 +13,7 @@ import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.data.domain.PageRequest;
 import org.springframework.data.domain.Pageable;
-import org.springframework.data.domain.Sort;
 import org.springframework.http.HttpStatus;
-import org.springframework.security.core.context.SecurityContextHolder;
 import org.springframework.stereotype.Service;
 
 import java.time.DayOfWeek;
@@ -52,7 +50,7 @@ public class ChallengePostUtilService {
         return hostEmail.equals(email);
     }
 
-    public Pageable checkPageableParam(int page, int size, String[] sort) {
+    public Pageable makePageable(int page, int size, String[] sort) {
 
         if (page < 0) {
             page = DEFAULT_PAGE;

--- a/src/main/java/com/habitpay/habitpay/domain/challengepost/dao/ChallengePostRepository.java
+++ b/src/main/java/com/habitpay/habitpay/domain/challengepost/dao/ChallengePostRepository.java
@@ -3,6 +3,8 @@ package com.habitpay.habitpay.domain.challengepost.dao;
 import com.habitpay.habitpay.domain.challenge.domain.Challenge;
 import com.habitpay.habitpay.domain.challengeenrollment.domain.ChallengeEnrollment;
 import com.habitpay.habitpay.domain.challengepost.domain.ChallengePost;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.repository.query.Param;
 
@@ -10,5 +12,6 @@ import java.util.List;
 import java.util.Optional;
 
 public interface ChallengePostRepository extends JpaRepository<ChallengePost, Long> {
-    List<ChallengePost> findAllByChallengeEnrollmentId(Long challengeEnrollmentId);
+    // todo : Page, Slice, List 중에 선택하기
+    List<ChallengePost> findAllByChallengeEnrollmentId(Long challengeEnrollmentId, Pageable pageable);
 }

--- a/src/main/resources/application.yaml
+++ b/src/main/resources/application.yaml
@@ -35,3 +35,12 @@ spring:
 spring:
   profiles:
     active: prod
+---
+spring:
+  data:
+    web:
+      pageable:
+        page-parameter: page
+        size-parameter: size
+        default-page-size: 5
+        max-page-size: 100

--- a/src/main/resources/application.yaml
+++ b/src/main/resources/application.yaml
@@ -35,12 +35,3 @@ spring:
 spring:
   profiles:
     active: prod
----
-spring:
-  data:
-    web:
-      pageable:
-        page-parameter: page
-        size-parameter: size
-        default-page-size: 5
-        max-page-size: 100


### PR DESCRIPTION
### 작업 개요

* 무한 스크롤 페이지네이션 적용을 위한 백엔드 코드 초안을 작성했습니다.
* 현재 페이지네이션 코드가 적용된 메서드는,
`ChallengePost` 컨트롤러의 `getChallengePosts`, `getChallengePostsByMe`, `getChallengePostsByMember`
  이렇게 n개의 포스트를 불러올 수 있는 세 개 메서드입니다.
* 페이지네이션 설정을 위한 `Pageable 객체`는, `@RequsetParam`으로 인자를 받은 후
   값을 검증해 `PageRequest.of()`를 이용해 생성합니다.

---

### 코드 내용

* 인자를 받아 적용하는 방식은 세 메서드가 동일해서 아래 메서드를 대표로 설명하겠습니다.
```java
@GetMapping("/api/challenges/{id}/posts")
    public SuccessResponse<List<PostViewResponse>> getChallengePosts(
            @PathVariable Long id,
            @RequestParam(defaultValue = DEFAULT_PAGE) int page,
            @RequestParam(defaultValue = DEFAULT_SIZE) int size,
            @RequestParam(defaultValue = DEFAULT_SORT) String[] sort) {

        Pageable pageable = challengePostUtilService.makePageable(page, size, sort);

        return SuccessResponse.of(
                "",
                challengePostSearchService.findPostViewResponseListByChallengeId(id, pageable)
        );
    }
```

* 인자는 `@RequestParam`을 이용해 받습니다.
* `makePageable()` 메서드에 인자를 넣어 `Pageable 객체`를 생성합니다.
* `Pageable 객체`를 서비스 메서드에 인자로 주고 `repository`로 전달해 목적에 맞는 `List<>`를 불러옵니다.

```java
// ChallengePostRepository.java

List<ChallengePost> findAllByChallengeEnrollmentId(Long challengeEnrollmentId, Pageable pageable);
```

* 현재는 기본 형태인 `List<>`를 반환하도록 했으나,
   프론트엔드와  연결 후 필요하다면 `Page<>` or `Slice<>` 등으로 반환 타입을 변경할 수 있습니다.

---

* `Pageable 객체`를 생성하는 `makePageable` 메서드입니다.

```java
public Pageable makePageable(int page, int size, String[] sort) {

        if (page < 0) {
            page = DEFAULT_PAGE;
        }

        if (size < 1) {
            size = DEFAULT_SIZE;
        } else if (size > MAX_SIZE) {
            size = MAX_SIZE;
        }

        // todo : sort 제공할 것인지
//        if (sort.length > 1) {
//        }

        return PageRequest.of(page, size);
    }
```

* 처음에는 컨트롤러 메서드에서 바로 `Pageable 객체`로 받고자 했습니다.
* 그러나 `Pageable 객체`는 getter로 설정값은 확인 가능하나,
   setter가 없는 불변(immutable) 객체여서,, 값 변경이 불가했습니다🥹
* 예외 처리할 값이 들어오면, 결국 `PageRequest.of()`로 새로 객체를 생성해야 합니다.
* 그래서 깔끔하게 인자만 받아 값을 검증 후 `PageRequest.of()`로 객체 생성하는 방향을 선택했습니다.

---

* `page`, `size`에 대해서는 기본적인 값 검증을 합니다.
* `sort`(ex. 이름 순으로 정렬, 역순으로 정렬 등)의 경우, 검증 방법에 대해 개인적으로 빨리 이해하지 못했고,
    and 현재까지는 `전체 포스트 보기`와 `내가 쓴 포스트만 보기` 기능만 제공하고 있기에,
    우선 기본적인 코드 초안을 사용하고자 주석처리하고 `page, size` 정보만 적용한 `Pageable 객체`를 생성합니다.

---

### 기타

* 컨트롤러 메서드에서 `Pageable`로 인자를 받으면 테스트 코드 작성이 쉽다는 장점이 있습니다.
* 테스트 코드 작성하다가 어려워지면,,
   컨트롤러 메서드에서 `Pageable`를 인자로 받고, `makePageable`을 수정하는 방향으로 갈 수도 있겠습니다.