### PR TITLE
[Feat] 정상 응답을 SuccessResponse로 감싸는 과정을 컨트롤러가 아닌 서비스 메서드에서 수행하기 #162

### DIFF
--- a/src/main/java/com/habitpay/habitpay/domain/challengepost/api/ChallengePostApi.java
+++ b/src/main/java/com/habitpay/habitpay/domain/challengepost/api/ChallengePostApi.java
@@ -32,10 +32,7 @@ public class ChallengePostApi {
     @GetMapping("/api/posts/{id}")
     public SuccessResponse<PostViewResponse> getPost(@PathVariable Long id) {
 
-        return SuccessResponse.of(
-                "",
-                challengePostSearchService.getPostViewResponseByPostId(id)
-        );
+        return challengePostSearchService.getPostViewResponseByPostId(id);
     }
 
     @GetMapping("/api/challenges/{id}/posts")
@@ -47,10 +44,7 @@ public class ChallengePostApi {
 
         Pageable pageable = challengePostUtilService.makePageable(page, size, sort);
 
-        return SuccessResponse.of(
-                "",
-                challengePostSearchService.findPostViewResponseListByChallengeId(id, pageable)
-        );
+        return challengePostSearchService.findPostViewResponseListByChallengeId(id, pageable);
     }
 
     @GetMapping("/api/challenges/{id}/posts/me")
@@ -63,10 +57,7 @@ public class ChallengePostApi {
 
         Pageable pageable = challengePostUtilService.makePageable(page, size, sort);
 
-        return SuccessResponse.of(
-          "",
-          challengePostSearchService.findChallengePostsByMember(id, user.getEmail(), pageable)
-        );
+        return challengePostSearchService.findChallengePostsByMember(id, user.getEmail(), pageable);
     }
 
     // -----------------------------------------------------------------------------
@@ -81,10 +72,7 @@ public class ChallengePostApi {
         String memberEmail = "otherMember@email.address"; // todo : 임시
         Pageable pageable = challengePostUtilService.makePageable(page, size, sort);
 
-        return SuccessResponse.of(
-                "",
-                challengePostSearchService.findChallengePostsByMember(id, memberEmail, pageable)
-        );
+        return challengePostSearchService.findChallengePostsByMember(id, memberEmail, pageable);
     }
     // -------------------------------------------------------------------------------
 
@@ -94,20 +82,14 @@ public class ChallengePostApi {
             @PathVariable Long id,
             @AuthenticationPrincipal CustomUserDetails user) {
 
-        return SuccessResponse.of(
-                "포스트가 생성되었습니다.",
-                challengePostCreationService.createPost(request, id, user.getEmail())
-        );
+        return challengePostCreationService.createPost(request, id, user.getEmail());
     }
 
     @PatchMapping("/api/posts/{id}")
     public SuccessResponse<List<String>> patchPost(
             @RequestBody ModifyPostRequest request, @PathVariable Long id, @AuthenticationPrincipal CustomUserDetails user) {
 
-        return SuccessResponse.of(
-                "포스트가 수정되었습니다.",
-                challengePostUpdateService.patchPost(request, id, user.getEmail())
-        );
+        return challengePostUpdateService.patchPost(request, id, user.getEmail());
     }
 
     @DeleteMapping("/api/posts/{id}")

--- a/src/main/java/com/habitpay/habitpay/domain/challengepost/api/ChallengePostApi.java
+++ b/src/main/java/com/habitpay/habitpay/domain/challengepost/api/ChallengePostApi.java
@@ -57,23 +57,24 @@ public class ChallengePostApi {
 
         Pageable pageable = challengePostUtilService.makePageable(page, size, sort);
 
-        return challengePostSearchService.findChallengePostsByMember(id, user.getEmail(), pageable);
+        return challengePostSearchService.findChallengePostsByMember(id, user.getMember(), pageable);
     }
 
     // -----------------------------------------------------------------------------
     // todo : 'challengeEnrollmentId' or 'memberId' 등 멤버 식별할 수 있는 데이터를 받아야 함
-    @GetMapping("/api/challenges/{id}/posts/member")
-    public SuccessResponse<List<PostViewResponse>> getChallengePostsByMember(
-            @PathVariable Long id,
-            @RequestParam(defaultValue = DEFAULT_PAGE) int page,
-            @RequestParam(defaultValue = DEFAULT_SIZE) int size,
-            @RequestParam(defaultValue = DEFAULT_SORT) String[] sort) {
-
-        String memberEmail = "otherMember@email.address"; // todo : 임시
-        Pageable pageable = challengePostUtilService.makePageable(page, size, sort);
-
-        return challengePostSearchService.findChallengePostsByMember(id, memberEmail, pageable);
-    }
+//    @GetMapping("/api/challenges/{id}/posts/member")
+//    public SuccessResponse<List<PostViewResponse>> getChallengePostsByMember(
+//            @PathVariable Long id,
+//            @RequestParam(defaultValue = DEFAULT_PAGE) int page,
+//            @RequestParam(defaultValue = DEFAULT_SIZE) int size,
+//            @RequestParam(defaultValue = DEFAULT_SORT) String[] sort) {
+//
+//        String memberEmail = "otherMember@email.address"; // todo : 임시
+//        Pageable pageable = challengePostUtilService.makePageable(page, size, sort);
+//
+//        // todo: member 객체를 깔끔하게 받을 수 없으면, 추가로 메서드 만들자
+//        return challengePostSearchService.findChallengePostsByMember(id, memberEmail, pageable);
+//    }
     // -------------------------------------------------------------------------------
 
     @PostMapping("/api/challenges/{id}/post")
@@ -82,21 +83,21 @@ public class ChallengePostApi {
             @PathVariable Long id,
             @AuthenticationPrincipal CustomUserDetails user) {
 
-        return challengePostCreationService.createPost(request, id, user.getEmail());
+        return challengePostCreationService.createPost(request, id, user.getMember());
     }
 
     @PatchMapping("/api/posts/{id}")
     public SuccessResponse<List<String>> patchPost(
             @RequestBody ModifyPostRequest request, @PathVariable Long id, @AuthenticationPrincipal CustomUserDetails user) {
 
-        return challengePostUpdateService.patchPost(request, id, user.getEmail());
+        return challengePostUpdateService.patchPost(request, id, user.getMember());
     }
 
     @DeleteMapping("/api/posts/{id}")
     public SuccessResponse<Void> deletePost(
             @PathVariable Long id, @AuthenticationPrincipal CustomUserDetails user) {
 
-        challengePostDeleteService.deletePost(id, user.getEmail());
+        challengePostDeleteService.deletePost(id, user.getMember());
         return SuccessResponse.of(
                 "포스트가 정상적으로 삭제되었습니다.",
                 null

--- a/src/main/java/com/habitpay/habitpay/domain/challengepost/application/ChallengePostCreationService.java
+++ b/src/main/java/com/habitpay/habitpay/domain/challengepost/application/ChallengePostCreationService.java
@@ -36,9 +36,9 @@ public class ChallengePostCreationService {
     private final ChallengePostRepository challengePostRepository;
 
     @Transactional
-    public SuccessResponse<List<String>> createPost(AddPostRequest request, Long challengeId, String email) {
+    public SuccessResponse<List<String>> createPost(AddPostRequest request, Long challengeId, Member member) {
 
-        ChallengePost challengePost = this.savePost(request, challengeId, email);
+        ChallengePost challengePost = this.savePost(request, challengeId, member);
         challengePostUtilService.verifyChallengePostForRecord(challengePost);
         List<String> presignedUrlList = postPhotoCreationService.createPhotoUrlList(challengePost, request.getPhotos());
 
@@ -48,9 +48,8 @@ public class ChallengePostCreationService {
         );
     }
 
-    private ChallengePost savePost(AddPostRequest request, Long challengeId, String email) {
+    private ChallengePost savePost(AddPostRequest request, Long challengeId, Member member) {
 
-        Member member = memberService.findByEmail(email);
         Challenge challenge = challengeSearchService.getChallengeById(challengeId);
         ChallengeEnrollment enrollment = challengeEnrollmentSearchService.findByMemberAndChallenge(member, challenge)
                 .orElseThrow(() -> new NoSuchElementException("챌린지에 등록된 멤버가 아니면 포스트를 작성할 수 없습니다."));

--- a/src/main/java/com/habitpay/habitpay/domain/challengepost/application/ChallengePostCreationService.java
+++ b/src/main/java/com/habitpay/habitpay/domain/challengepost/application/ChallengePostCreationService.java
@@ -12,6 +12,7 @@ import com.habitpay.habitpay.domain.member.domain.Member;
 import com.habitpay.habitpay.domain.postphoto.application.PostPhotoCreationService;
 import com.habitpay.habitpay.domain.refreshtoken.exception.CustomJwtException;
 import com.habitpay.habitpay.global.error.CustomJwtErrorInfo;
+import com.habitpay.habitpay.global.response.SuccessResponse;
 import jakarta.transaction.Transactional;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
@@ -35,11 +36,16 @@ public class ChallengePostCreationService {
     private final ChallengePostRepository challengePostRepository;
 
     @Transactional
-    public List<String> createPost(AddPostRequest request, Long challengeId, String email) {
+    public SuccessResponse<List<String>> createPost(AddPostRequest request, Long challengeId, String email) {
 
         ChallengePost challengePost = this.savePost(request, challengeId, email);
         challengePostUtilService.verifyChallengePostForRecord(challengePost);
-        return postPhotoCreationService.createPhotoUrlList(challengePost, request.getPhotos());
+        List<String> presignedUrlList = postPhotoCreationService.createPhotoUrlList(challengePost, request.getPhotos());
+
+        return SuccessResponse.of(
+                "포스트가 생성되었습니다.",
+                presignedUrlList
+        );
     }
 
     private ChallengePost savePost(AddPostRequest request, Long challengeId, String email) {

--- a/src/main/java/com/habitpay/habitpay/domain/challengepost/application/ChallengePostDeleteService.java
+++ b/src/main/java/com/habitpay/habitpay/domain/challengepost/application/ChallengePostDeleteService.java
@@ -3,6 +3,7 @@ package com.habitpay.habitpay.domain.challengepost.application;
 import com.habitpay.habitpay.domain.challenge.domain.Challenge;
 import com.habitpay.habitpay.domain.challengepost.dao.ChallengePostRepository;
 import com.habitpay.habitpay.domain.challengepost.domain.ChallengePost;
+import com.habitpay.habitpay.domain.member.domain.Member;
 import com.habitpay.habitpay.domain.postphoto.application.PostPhotoDeleteService;
 import com.habitpay.habitpay.domain.refreshtoken.exception.CustomJwtException;
 import com.habitpay.habitpay.global.error.CustomJwtErrorInfo;
@@ -23,12 +24,12 @@ public class ChallengePostDeleteService {
     private final ChallengePostUtilService challengePostUtilService;
 
     @Transactional
-    public void deletePost(Long postId, String email) {
+    public void deletePost(Long postId, Member member) {
         ChallengePost post = challengePostSearchService.getChallengePostById(postId);
         Challenge challenge = challengePostSearchService.getChallengeByPostId(postId);
 
         if (post.getIsAnnouncement()) {
-            if (!challengePostUtilService.isChallengeHost(challenge, email)) {
+            if (!challengePostUtilService.isChallengeHost(challenge, member)) {
                 throw new CustomJwtException(HttpStatus.FORBIDDEN, CustomJwtErrorInfo.FORBIDDEN, "공지 포스트는 챌린지 호스트만 삭제할 수 있습니다.");
             }
         }
@@ -36,7 +37,7 @@ public class ChallengePostDeleteService {
             throw new CustomJwtException(HttpStatus.FORBIDDEN, CustomJwtErrorInfo.FORBIDDEN, "일반 포스트 삭제는 제공되지 않는 기능입니다.");
         }
 
-        challengePostUtilService.authorizePostWriter(post, email);
+        challengePostUtilService.authorizePostWriter(post, member);
 
         postPhotoDeleteService.deleteByPost(post);
         challengePostRepository.delete(post);

--- a/src/main/java/com/habitpay/habitpay/domain/challengepost/application/ChallengePostSearchService.java
+++ b/src/main/java/com/habitpay/habitpay/domain/challengepost/application/ChallengePostSearchService.java
@@ -67,8 +67,7 @@ public class ChallengePostSearchService {
         );
     }
 
-    public SuccessResponse<List<PostViewResponse>> findChallengePostsByMember(Long challengeId, String email, Pageable pageable) {
-        Member member = memberService.findByEmail(email);
+    public SuccessResponse<List<PostViewResponse>> findChallengePostsByMember(Long challengeId, Member member, Pageable pageable) {
         Challenge challenge = challengeSearchService.getChallengeById(challengeId);
         ChallengeEnrollment enrollment = challengeEnrollmentSearchService.findByMemberAndChallenge(member, challenge)
                 .orElseThrow(() -> new NoSuchElementException("챌린지에 등록된 멤버가 아닙니다."));

--- a/src/main/java/com/habitpay/habitpay/domain/challengepost/application/ChallengePostSearchService.java
+++ b/src/main/java/com/habitpay/habitpay/domain/challengepost/application/ChallengePostSearchService.java
@@ -14,6 +14,7 @@ import com.habitpay.habitpay.domain.postphoto.application.PostPhotoSearchService
 import com.habitpay.habitpay.domain.postphoto.application.PostPhotoUtilService;
 import com.habitpay.habitpay.domain.postphoto.domain.PostPhoto;
 import com.habitpay.habitpay.domain.postphoto.dto.PostPhotoView;
+import com.habitpay.habitpay.global.response.SuccessResponse;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.data.domain.Page;
@@ -37,17 +38,20 @@ public class ChallengePostSearchService {
     private final ChallengePostRepository challengePostRepository;
     private final ChallengeEnrollmentRepository challengeEnrollmentRepository;
 
-    public PostViewResponse getPostViewResponseByPostId(Long postId) {
+    public SuccessResponse<PostViewResponse> getPostViewResponseByPostId(Long postId) {
         ChallengePost challengePost = this.getChallengePostById(postId);
         List<PostPhoto> photoList = postPhotoSearchService.findAllByPost(challengePost);
         List<PostPhotoView> photoViewList = postPhotoUtilService.makePhotoViewList(photoList);
 
-        return new PostViewResponse(challengePost, photoViewList);
+        return SuccessResponse.of(
+                "",
+                new PostViewResponse(challengePost, photoViewList)
+        );
     }
 
-    public List<PostViewResponse> findPostViewResponseListByChallengeId(Long challengeId, Pageable pageable) {
+    public SuccessResponse<List<PostViewResponse>> findPostViewResponseListByChallengeId(Long challengeId, Pageable pageable) {
 
-        return this.findAllByChallengeId(challengeId, pageable)
+        List<PostViewResponse> postViewResponseList = this.findAllByChallengeId(challengeId, pageable)
                 .stream()
                 // .filter(post -> !post.getIsAnnouncement()) // todo
                 // .sorted() // todo : 순서 설정하고 싶을 때
@@ -56,9 +60,14 @@ public class ChallengePostSearchService {
                     return new PostViewResponse(post, photoViewList);
                 })
                 .toList();
+
+        return SuccessResponse.of(
+                "",
+                postViewResponseList
+        );
     }
 
-    public List<PostViewResponse> findChallengePostsByMember(Long challengeId, String email, Pageable pageable) {
+    public SuccessResponse<List<PostViewResponse>> findChallengePostsByMember(Long challengeId, String email, Pageable pageable) {
         Member member = memberService.findByEmail(email);
         Challenge challenge = challengeSearchService.getChallengeById(challengeId);
         ChallengeEnrollment enrollment = challengeEnrollmentSearchService.findByMemberAndChallenge(member, challenge)
@@ -66,7 +75,7 @@ public class ChallengePostSearchService {
 
         Long challengeEnrollmentId = enrollment.getId();
 
-        return challengePostRepository.findAllByChallengeEnrollmentId(challengeEnrollmentId, pageable)
+        List<PostViewResponse> postViewResponseList =  challengePostRepository.findAllByChallengeEnrollmentId(challengeEnrollmentId, pageable)
                 .stream()
                 // .filter(post -> !post.getIsAnnouncement()) // todo
                 // .sorted() // todo : 순서 설정하고 싶을 때
@@ -75,6 +84,11 @@ public class ChallengePostSearchService {
                     return new PostViewResponse(post, photoViewList);
                 })
                 .toList();
+
+        return SuccessResponse.of(
+                "",
+                postViewResponseList
+        );
     }
 
     public ChallengePost getChallengePostById(Long id) {

--- a/src/main/java/com/habitpay/habitpay/domain/challengepost/application/ChallengePostUpdateService.java
+++ b/src/main/java/com/habitpay/habitpay/domain/challengepost/application/ChallengePostUpdateService.java
@@ -10,6 +10,7 @@ import com.habitpay.habitpay.domain.postphoto.application.PostPhotoDeleteService
 import com.habitpay.habitpay.domain.postphoto.application.PostPhotoUtilService;
 import com.habitpay.habitpay.domain.refreshtoken.exception.CustomJwtException;
 import com.habitpay.habitpay.global.error.CustomJwtErrorInfo;
+import com.habitpay.habitpay.global.response.SuccessResponse;
 import jakarta.transaction.Transactional;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
@@ -32,7 +33,7 @@ public class ChallengePostUpdateService {
     private final ChallengePostRepository challengePostRepository;
 
     @Transactional
-    public List<String> patchPost(ModifyPostRequest request, Long postId, String memberEmail) {
+    public SuccessResponse<List<String>> patchPost(ModifyPostRequest request, Long postId, String memberEmail) {
         ChallengePost post = challengePostSearchService.getChallengePostById(postId);
         challengePostUtilService.authorizePostWriter(post, memberEmail);
 
@@ -42,7 +43,14 @@ public class ChallengePostUpdateService {
         postPhotoDeleteService.deleteByIds(postId, request.getDeletedPhotoIds());
         request.getModifiedPhotos().forEach(photo -> postPhotoUtilService.changeViewOrder(photo.getPhotoId(), photo.getViewOrder()));
 
-        return postPhotoCreationService.createPhotoUrlList(challengePostSearchService.getChallengePostById(postId), request.getNewPhotos());
+        List<String> presignedUrlList = postPhotoCreationService.createPhotoUrlList(
+                challengePostSearchService.getChallengePostById(postId), request.getNewPhotos()
+        );
+
+        return SuccessResponse.of(
+                "포스트가 수정되었습니다.",
+                presignedUrlList
+        );
     }
 
     private void patchContent(ChallengePost post, String content) {

--- a/src/main/java/com/habitpay/habitpay/domain/challengepost/application/ChallengePostUpdateService.java
+++ b/src/main/java/com/habitpay/habitpay/domain/challengepost/application/ChallengePostUpdateService.java
@@ -33,9 +33,9 @@ public class ChallengePostUpdateService {
     private final ChallengePostRepository challengePostRepository;
 
     @Transactional
-    public SuccessResponse<List<String>> patchPost(ModifyPostRequest request, Long postId, String memberEmail) {
+    public SuccessResponse<List<String>> patchPost(ModifyPostRequest request, Long postId, Member member) {
         ChallengePost post = challengePostSearchService.getChallengePostById(postId);
-        challengePostUtilService.authorizePostWriter(post, memberEmail);
+        challengePostUtilService.authorizePostWriter(post, member);
 
         patchContent(post, request.getContent());
         patchIsAnnouncement(post, request.getIsAnnouncement());

--- a/src/main/java/com/habitpay/habitpay/domain/challengepost/application/ChallengePostUtilService.java
+++ b/src/main/java/com/habitpay/habitpay/domain/challengepost/application/ChallengePostUtilService.java
@@ -35,19 +35,14 @@ public class ChallengePostUtilService {
     private static final String DEFAULT_SORT = "asc";
 
 
-    public void authorizePostWriter(ChallengePost post, String memberEmail) {
-        if (!post.getWriter().getEmail().equals(memberEmail)) {
+    public void authorizePostWriter(ChallengePost post, Member member) {
+        if (!post.getWriter().equals(member)) {
             throw new CustomJwtException(HttpStatus.UNAUTHORIZED, CustomJwtErrorInfo.UNAUTHORIZED, "해당 포스트의 작성자가 아닙니다.");
         }
     }
 
     public boolean isChallengeHost(Challenge challenge, Member member) {
         return challenge.getHost().equals(member);
-    }
-
-    public boolean isChallengeHost(Challenge challenge, String email) {
-        String hostEmail = challenge.getHost().getEmail();
-        return hostEmail.equals(email);
     }
 
     public Pageable makePageable(int page, int size, String[] sort) {

--- a/src/main/java/com/habitpay/habitpay/domain/refreshtoken/api/TokenApi.java
+++ b/src/main/java/com/habitpay/habitpay/domain/refreshtoken/api/TokenApi.java
@@ -23,9 +23,6 @@ public class TokenApi {
     public SuccessResponse<CreateAccessTokenResponse> createNewAccessTokenAndNewRefreshToken(
             @RequestBody CreateAccessTokenRequest requestBody) {
 
-        return SuccessResponse.of(
-                "새로운 액세스 토큰 및 리프레시 토큰이 성공적으로 발급되었습니다.",
-                refreshTokenCreationService.createNewAccessTokenAndNewRefreshToken(requestBody)
-        );
+        return refreshTokenCreationService.createNewAccessTokenAndNewRefreshToken(requestBody);
     }
 }

--- a/src/main/java/com/habitpay/habitpay/domain/refreshtoken/application/RefreshTokenCreationService.java
+++ b/src/main/java/com/habitpay/habitpay/domain/refreshtoken/application/RefreshTokenCreationService.java
@@ -11,6 +11,7 @@ import com.habitpay.habitpay.domain.refreshtoken.exception.CustomJwtException;
 import com.habitpay.habitpay.global.config.jwt.TokenProvider;
 import com.habitpay.habitpay.global.config.jwt.TokenService;
 import com.habitpay.habitpay.global.error.CustomJwtErrorInfo;
+import com.habitpay.habitpay.global.response.SuccessResponse;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.http.HttpStatus;
@@ -36,7 +37,7 @@ public class RefreshTokenCreationService {
     private final RefreshTokenRepository refreshTokenRepository;
 
 
-    public CreateAccessTokenResponse createNewAccessTokenAndNewRefreshToken(CreateAccessTokenRequest requestBody) {
+    public SuccessResponse<CreateAccessTokenResponse> createNewAccessTokenAndNewRefreshToken(CreateAccessTokenRequest requestBody) {
 
         Optional<String> optionalGrantType = Optional.ofNullable(requestBody.getGrantType());
         if (optionalGrantType.isEmpty() || !requestBody.getGrantType().equals("refresh_token")) {
@@ -46,11 +47,16 @@ public class RefreshTokenCreationService {
         String newAccessToken = this.createNewAccessToken(requestBody.getRefreshToken());
         String refreshToken = this.createRefreshToken(tokenService.getUserId(newAccessToken));
 
-        return new CreateAccessTokenResponse(
+        CreateAccessTokenResponse tokenResponse = new CreateAccessTokenResponse(
                 newAccessToken,
                 "Bearer",
                 tokenService.getAccessTokenExpiresInToMillis(),
                 refreshToken);
+
+        return SuccessResponse.of(
+                "새로운 액세스 토큰 및 리프레시 토큰이 성공적으로 발급되었습니다.",
+                tokenResponse
+        );
     }
 
     private String createNewAccessToken(String refreshToken) {


### PR DESCRIPTION
### 작업 개요

* API에서 정상응답일 경우, `SuccessResponse`로 래핑해 데이터를 리턴하게 됩니다. (`ChallengePost`, `RefreshToken` API)
* 이전에는 컨트롤러 메서드에서 래핑 과정을 수행했으나,
    서비스 메서드에서 래핑 과정을 수행하는 것으로 변경했습니다.
* 가장 큰 이유는 테스트 코드에서 서비스  메서드의 반환 타입을 이용해 RestDocs 내용을 완성하는데,
    `SuccessResponse`를 반영해야 프론트엔드에 정확한 API 문서를 제공할 수 있기 때문입니다.

---

### 코드 변경 방식

```java
// before
@GetMapping("/api/posts/{id}")
    public SuccessResponse<PostViewResponse> getPost(@PathVariable Long id) {

        return SuccessResponse.of(
                "",
                challengePostSearchService.getPostViewResponseByPostId(id)
        );
    }
```
* 이전에는 컨트롤러 메서드에서 래핑 과정을 수행했습니다.

---

```java
// after

@GetMapping("/api/posts/{id}")
    public SuccessResponse<PostViewResponse> getPost(@PathVariable Long id) {

        return challengePostSearchService.getPostViewResponseByPostId(id);
    }
```

* 이제는 서비스 메서드에서 래핑 과정을 수행한 후 컨트롤러에 반환합니다.

---

* 자연스레 서비스 메서드의 반환 타입 관련된 코드에도 관련된 변화가 생겼습니다.

```java
// before

public PostViewResponse getPostViewResponseByPostId(Long postId) {
        ...

        return new PostViewResponse(challengePost, photoViewList);
    }
```

```java
// after

public SuccessResponse<PostViewResponse> getPostViewResponseByPostId(Long postId) {
        ...

        return SuccessResponse.of(
                "",
                new PostViewResponse(challengePost, photoViewList)
        );
    }
```
* 서비스 메서드의 반환 타입에 `SuccessResponse<>`가 추가되었습니다.
* return에서 래핑 과정을 수행합니다.

---

* 컨트롤러가 인자를 통해 얻은 사용자 정보를 `String email`이 아닌 `user.getMember()`를 이용해 `Member 객체`로 넘기기
* 해당 내용과 관련된 코드를 수정했습니다.