### PR TITLE
Feat/나의 챌린지 참여 목록 기능 구현#156

### DIFF
--- a/src/docs/asciidoc/api/challenge.adoc
+++ b/src/docs/asciidoc/api/challenge.adoc
@@ -7,6 +7,12 @@
 
 챌린지 정보 조회, 챌린지 생성, 챌린지 정보 수정을 수행하는 API 목록입니다.
 
+=== 나의 챌린지 참여 목록 조회
+
+현재 접속한 사용자가 참여하고 있는 챌린지 목록을 반환합니다.
+
+operation::challenge/get-my-challenge-list[snippets='http-request,http-response,response-fields']
+
 === 챌린지 상세 정보 조회
 
 첼린지의 상세 정보를 조회합니다.

--- a/src/main/java/com/habitpay/habitpay/domain/challenge/api/ChallengeApi.java
+++ b/src/main/java/com/habitpay/habitpay/domain/challenge/api/ChallengeApi.java
@@ -3,6 +3,7 @@ package com.habitpay.habitpay.domain.challenge.api;
 import com.habitpay.habitpay.domain.challenge.application.ChallengeCreationService;
 import com.habitpay.habitpay.domain.challenge.application.ChallengeDetailsService;
 import com.habitpay.habitpay.domain.challenge.application.ChallengePatchService;
+import com.habitpay.habitpay.domain.challenge.application.ChallengeSearchService;
 import com.habitpay.habitpay.domain.challenge.dto.*;
 import com.habitpay.habitpay.global.config.auth.CustomUserDetails;
 import com.habitpay.habitpay.global.response.SuccessResponse;
@@ -19,6 +20,13 @@ public class ChallengeApi {
     private final ChallengeCreationService challengeCreationService;
     private final ChallengePatchService challengePatchService;
     private final ChallengeDetailsService challengeDetailsService;
+    private final ChallengeSearchService challengeSearchService;
+
+    @GetMapping("/challenges/me")
+    public SuccessResponse<ChallengeEnrolledListItemResponse[]> getEnrolledChallengeList(
+            @AuthenticationPrincipal CustomUserDetails user) {
+        return challengeSearchService.getEnrolledChallengeList(user.getMember());
+    }
 
     @GetMapping("/challenges/{id}")
     public SuccessResponse<ChallengeDetailsResponse> getChallengeDetails(@PathVariable("id") Long id,
@@ -29,7 +37,7 @@ public class ChallengeApi {
     @PostMapping("/challenges")
     public SuccessResponse<ChallengeCreationResponse> createChallenge(@RequestBody ChallengeCreationRequest challengeCreationRequest,
                                                                       @AuthenticationPrincipal CustomUserDetails user) {
-        return challengeCreationService.createChallenge(challengeCreationRequest, user.getId());
+        return challengeCreationService.createChallenge(challengeCreationRequest, user.getMember());
     }
 
     @PatchMapping("/challenges/{id}")

--- a/src/main/java/com/habitpay/habitpay/domain/challenge/api/ChallengeApi.java
+++ b/src/main/java/com/habitpay/habitpay/domain/challenge/api/ChallengeApi.java
@@ -12,6 +12,8 @@ import lombok.extern.slf4j.Slf4j;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.*;
 
+import java.util.List;
+
 @RestController
 @RequestMapping("/api")
 @RequiredArgsConstructor
@@ -23,7 +25,7 @@ public class ChallengeApi {
     private final ChallengeSearchService challengeSearchService;
 
     @GetMapping("/challenges/me")
-    public SuccessResponse<ChallengeEnrolledListItemResponse[]> getEnrolledChallengeList(
+    public SuccessResponse<List<ChallengeEnrolledListItemResponse>> getEnrolledChallengeList(
             @AuthenticationPrincipal CustomUserDetails user) {
         return challengeSearchService.getEnrolledChallengeList(user.getMember());
     }

--- a/src/main/java/com/habitpay/habitpay/domain/challenge/application/ChallengeCreationService.java
+++ b/src/main/java/com/habitpay/habitpay/domain/challenge/application/ChallengeCreationService.java
@@ -4,11 +4,14 @@ import com.habitpay.habitpay.domain.challenge.dao.ChallengeRepository;
 import com.habitpay.habitpay.domain.challenge.domain.Challenge;
 import com.habitpay.habitpay.domain.challenge.dto.ChallengeCreationRequest;
 import com.habitpay.habitpay.domain.challenge.dto.ChallengeCreationResponse;
+import com.habitpay.habitpay.domain.challengeenrollment.dao.ChallengeEnrollmentRepository;
+import com.habitpay.habitpay.domain.challengeenrollment.domain.ChallengeEnrollment;
 import com.habitpay.habitpay.domain.member.application.MemberSearchService;
 import com.habitpay.habitpay.domain.member.domain.Member;
 import com.habitpay.habitpay.global.response.SuccessResponse;
 import lombok.AllArgsConstructor;
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
 
 import java.time.ZonedDateTime;
 
@@ -17,20 +20,25 @@ import java.time.ZonedDateTime;
 public class ChallengeCreationService {
     private final MemberSearchService memberSearchService;
     private final ChallengeRepository challengeRepository;
+    private final ChallengeEnrollmentRepository challengeEnrollmentRepository;
 
-    public SuccessResponse<ChallengeCreationResponse> createChallenge(ChallengeCreationRequest challengeCreationRequest, Long id) {
-        Member host = memberSearchService.getMemberById(id);
+    @Transactional
+    public SuccessResponse<ChallengeCreationResponse> createChallenge(ChallengeCreationRequest challengeCreationRequest, Member member) {
         if (isStartDateBeforeNow(challengeCreationRequest.getStartDate())) {
             // TODO: 예외 처리 공통 응답 적용하기
             throw new IllegalArgumentException("챌린지 시작 시간은 현재 시간 이후만 가능합니다.");
         }
 
-        Challenge newChallenge = Challenge.of(host, challengeCreationRequest);
-        challengeRepository.save(newChallenge);
+        Challenge challenge = Challenge.of(member, challengeCreationRequest);
+        challenge.setNumberOfParticipants(challenge.getNumberOfParticipants() + 1);
+        challengeRepository.save(challenge);
+
+        ChallengeEnrollment challengeEnrollment = ChallengeEnrollment.of(member, challenge);
+        challengeEnrollmentRepository.save(challengeEnrollment);
 
         return SuccessResponse.of(
                 "챌린지가 생성되었습니다.",
-                ChallengeCreationResponse.of(host, newChallenge)
+                ChallengeCreationResponse.of(member, challenge)
         );
     }
 

--- a/src/main/java/com/habitpay/habitpay/domain/challenge/application/ChallengeSearchService.java
+++ b/src/main/java/com/habitpay/habitpay/domain/challenge/application/ChallengeSearchService.java
@@ -2,19 +2,48 @@ package com.habitpay.habitpay.domain.challenge.application;
 
 import com.habitpay.habitpay.domain.challenge.dao.ChallengeRepository;
 import com.habitpay.habitpay.domain.challenge.domain.Challenge;
+import com.habitpay.habitpay.domain.challenge.dto.ChallengeEnrolledListItemResponse;
+import com.habitpay.habitpay.domain.challengeenrollment.dao.ChallengeEnrollmentRepository;
+import com.habitpay.habitpay.domain.challengeenrollment.domain.ChallengeEnrollment;
+import com.habitpay.habitpay.domain.challengeparticipationrecord.dao.ChallengeParticipationRecordRepository;
+import com.habitpay.habitpay.domain.member.domain.Member;
+import com.habitpay.habitpay.global.response.SuccessResponse;
 import lombok.AllArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
+import java.util.List;
+
+@Slf4j
 @Service
 @AllArgsConstructor
 public class ChallengeSearchService {
     private final ChallengeRepository challengeRepository;
+    private final ChallengeEnrollmentRepository challengeEnrollmentRepository;
+    private final ChallengeParticipationRecordRepository challengeParticipationRecordRepository;
+
+    public SuccessResponse<ChallengeEnrolledListItemResponse[]> getEnrolledChallengeList(Member member) {
+        List<ChallengeEnrollment> challengeEnrollmentList = challengeEnrollmentRepository.findAllByMember(member);
+        ChallengeEnrolledListItemResponse[] responseArray = challengeEnrollmentList.stream()
+                .map(this::mapToResponse)
+                .toArray(ChallengeEnrolledListItemResponse[]::new);
+
+        return SuccessResponse.of("", responseArray);
+    }
 
     @Transactional(readOnly = true)
     public Challenge getChallengeById(Long id) {
         // TODO: 공통 예외처리 적용하기
         return challengeRepository.findById(id)
                 .orElseThrow(() -> new IllegalArgumentException("존재하는 챌린지가 아닙니다."));
+    }
+
+    private ChallengeEnrolledListItemResponse mapToResponse(ChallengeEnrollment challengeEnrollment) {
+        Challenge challenge = challengeEnrollment.getChallenge();
+        boolean isParticipatedToday = challengeParticipationRecordRepository
+                .findByChallengeEnrollment(challengeEnrollment)
+                .isPresent();
+        return ChallengeEnrolledListItemResponse.of(challenge, challengeEnrollment, isParticipatedToday);
     }
 }

--- a/src/main/java/com/habitpay/habitpay/domain/challenge/application/ChallengeSearchService.java
+++ b/src/main/java/com/habitpay/habitpay/domain/challenge/application/ChallengeSearchService.java
@@ -23,13 +23,13 @@ public class ChallengeSearchService {
     private final ChallengeEnrollmentRepository challengeEnrollmentRepository;
     private final ChallengeParticipationRecordRepository challengeParticipationRecordRepository;
 
-    public SuccessResponse<ChallengeEnrolledListItemResponse[]> getEnrolledChallengeList(Member member) {
+    public SuccessResponse<List<ChallengeEnrolledListItemResponse>> getEnrolledChallengeList(Member member) {
         List<ChallengeEnrollment> challengeEnrollmentList = challengeEnrollmentRepository.findAllByMember(member);
-        ChallengeEnrolledListItemResponse[] responseArray = challengeEnrollmentList.stream()
+        List<ChallengeEnrolledListItemResponse> response = challengeEnrollmentList.stream()
                 .map(this::mapToResponse)
-                .toArray(ChallengeEnrolledListItemResponse[]::new);
+                .toList();
 
-        return SuccessResponse.of("", responseArray);
+        return SuccessResponse.of("", response);
     }
 
     @Transactional(readOnly = true)

--- a/src/main/java/com/habitpay/habitpay/domain/challenge/domain/Challenge.java
+++ b/src/main/java/com/habitpay/habitpay/domain/challenge/domain/Challenge.java
@@ -10,6 +10,7 @@ import lombok.Getter;
 import lombok.NoArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 
+import java.time.DayOfWeek;
 import java.time.ZonedDateTime;
 
 @Getter
@@ -82,5 +83,15 @@ public class Challenge extends BaseTime {
 
     public void patch(ChallengePatchRequest challengePatchRequest) {
         this.description = challengePatchRequest.getDescription();
+    }
+
+    public void setNumberOfParticipants(int numberOfParticipants) {
+        this.numberOfParticipants += numberOfParticipants;
+    }
+
+    public boolean isTodayParticipatingDay() {
+        DayOfWeek today = ZonedDateTime.now().getDayOfWeek();
+        int todayBitPosition = 6 - (today.getValue() - 1);
+        return (this.participatingDays & (1 << todayBitPosition)) != 0;
     }
 }

--- a/src/main/java/com/habitpay/habitpay/domain/challenge/dto/ChallengeDetailsResponse.java
+++ b/src/main/java/com/habitpay/habitpay/domain/challenge/dto/ChallengeDetailsResponse.java
@@ -14,8 +14,11 @@ public class ChallengeDetailsResponse {
     private String description;
     private ZonedDateTime startDate;
     private ZonedDateTime endDate;
+    private ZonedDateTime stopDate;
+    private int numberOfParticipants;
     private int participatingDays;
     private int feePerAbsence;
+    private Boolean isPaidAll;
     private String hostNickname;
     private String hostProfileImage;
     private Boolean isHost;
@@ -27,6 +30,9 @@ public class ChallengeDetailsResponse {
                 .description(challenge.getDescription())
                 .startDate(challenge.getStartDate())
                 .endDate(challenge.getEndDate())
+                .stopDate(challenge.getStopDate())
+                .numberOfParticipants(challenge.getNumberOfParticipants())
+                .isPaidAll(challenge.isPaidAll())
                 .participatingDays(challenge.getParticipatingDays())
                 .feePerAbsence(challenge.getFeePerAbsence())
                 .hostNickname(challenge.getHost().getNickname())

--- a/src/main/java/com/habitpay/habitpay/domain/challenge/dto/ChallengeEnrolledListItemResponse.java
+++ b/src/main/java/com/habitpay/habitpay/domain/challenge/dto/ChallengeEnrolledListItemResponse.java
@@ -1,0 +1,46 @@
+package com.habitpay.habitpay.domain.challenge.dto;
+
+import com.habitpay.habitpay.domain.challenge.domain.Challenge;
+import com.habitpay.habitpay.domain.challengeenrollment.domain.ChallengeEnrollment;
+import lombok.Builder;
+import lombok.Getter;
+
+import java.time.ZonedDateTime;
+
+@Getter
+@Builder
+public class ChallengeEnrolledListItemResponse {
+    private String title;
+    private String description;
+    private ZonedDateTime startDate;
+    private ZonedDateTime endDate;
+    private ZonedDateTime stopDate;
+    private int numberOfParticipants;
+    private int participatingDays;
+    private int totalFee;
+    private Boolean isPaidAll;
+    private String hostProfileImage;
+    private Boolean isMemberGivenUp;
+    private int successCount;
+    private Boolean isTodayParticipatingDay;
+    private Boolean isParticipatedToday;
+
+    public static ChallengeEnrolledListItemResponse of(Challenge challenge, ChallengeEnrollment challengeEnrollment, boolean isParticipatedToday) {
+        return ChallengeEnrolledListItemResponse.builder()
+                .title(challenge.getTitle())
+                .description(challenge.getDescription())
+                .startDate(challenge.getStartDate())
+                .endDate(challenge.getEndDate())
+                .stopDate(challenge.getStopDate())
+                .numberOfParticipants(challenge.getNumberOfParticipants())
+                .isPaidAll(challenge.isPaidAll())
+                .participatingDays(challenge.getParticipatingDays())
+                .totalFee(challengeEnrollment.getTotalFee())
+                .hostProfileImage(challenge.getHost().getImageFileName())
+                .isMemberGivenUp(challengeEnrollment.isGivenUp())
+                .successCount(challengeEnrollment.getSuccessCount())
+                .isTodayParticipatingDay(challenge.isTodayParticipatingDay())
+                .isParticipatedToday(isParticipatedToday)
+                .build();
+    }
+}

--- a/src/main/java/com/habitpay/habitpay/domain/challengeenrollment/application/ChallengeEnrollmentSearchService.java
+++ b/src/main/java/com/habitpay/habitpay/domain/challengeenrollment/application/ChallengeEnrollmentSearchService.java
@@ -13,11 +13,7 @@ import java.util.Optional;
 @RequiredArgsConstructor
 public class ChallengeEnrollmentSearchService {
     private final ChallengeEnrollmentRepository challengeEnrollmentRepository;
-
-    public Optional<ChallengeEnrollment> findByMember(Member member) {
-        return challengeEnrollmentRepository.findByMember(member);
-    }
-
+    
     public Optional<ChallengeEnrollment> findByMemberAndChallenge(Member member, Challenge challenge) {
         return challengeEnrollmentRepository.findByMemberAndChallenge(member, challenge);
     }

--- a/src/main/java/com/habitpay/habitpay/domain/challengeenrollment/application/ChallengeEnrollmentService.java
+++ b/src/main/java/com/habitpay/habitpay/domain/challengeenrollment/application/ChallengeEnrollmentService.java
@@ -27,11 +27,13 @@ public class ChallengeEnrollmentService {
         validateChallengeEnrollmentTime(challenge);
 
         Member member = memberSearchService.getMemberById(userId);
-        challengeEnrollmentRepository.findByMember(member)
+        challengeEnrollmentRepository.findByMemberAndChallenge(member, challenge)
                 .ifPresent(entity -> {
                     // TODO: 공통 예외 처리 추가하기
                     throw new IllegalStateException("이미 참여한 챌린지입니다.");
                 });
+
+        challenge.setNumberOfParticipants(challenge.getNumberOfParticipants() + 1);
 
         ChallengeEnrollment challengeEnrollment = ChallengeEnrollment.of(member, challenge);
         challengeEnrollmentRepository.save(challengeEnrollment);

--- a/src/main/java/com/habitpay/habitpay/domain/challengeenrollment/dao/ChallengeEnrollmentRepository.java
+++ b/src/main/java/com/habitpay/habitpay/domain/challengeenrollment/dao/ChallengeEnrollmentRepository.java
@@ -5,9 +5,13 @@ import com.habitpay.habitpay.domain.challengeenrollment.domain.ChallengeEnrollme
 import com.habitpay.habitpay.domain.member.domain.Member;
 import org.springframework.data.jpa.repository.JpaRepository;
 
+import java.util.List;
 import java.util.Optional;
 
 public interface ChallengeEnrollmentRepository extends JpaRepository<ChallengeEnrollment, Long> {
     Optional<ChallengeEnrollment> findByMember(Member member);
+
     Optional<ChallengeEnrollment> findByMemberAndChallenge(Member member, Challenge challenge);
+
+    List<ChallengeEnrollment> findAllByMember(Member member);
 }

--- a/src/main/java/com/habitpay/habitpay/domain/challengeparticipationrecord/dao/ChallengeParticipationRecordRepository.java
+++ b/src/main/java/com/habitpay/habitpay/domain/challengeparticipationrecord/dao/ChallengeParticipationRecordRepository.java
@@ -10,5 +10,8 @@ import java.util.Optional;
 
 public interface ChallengeParticipationRecordRepository extends JpaRepository<ChallengeParticipationRecord, Long> {
     Optional<List<ChallengeParticipationRecord>> findAllByChallengeEnrollment(ChallengeEnrollment enrollment);
+
+    Optional<ChallengeParticipationRecord> findByChallengeEnrollment(ChallengeEnrollment challengeEnrollment);
+
     Optional<ChallengeParticipationRecord> findByChallengeEnrollmentAndCreatedAtBetween(ChallengeEnrollment enrollment, LocalDateTime startOfDay, LocalDateTime endOfDay);
 }

--- a/src/main/java/com/habitpay/habitpay/global/config/auth/CustomOAuth2LoginSuccessHandler.java
+++ b/src/main/java/com/habitpay/habitpay/global/config/auth/CustomOAuth2LoginSuccessHandler.java
@@ -5,7 +5,6 @@ import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
-import org.springframework.beans.factory.annotation.Value;
 import org.springframework.http.ResponseCookie;
 import org.springframework.security.core.Authentication;
 import org.springframework.security.oauth2.core.user.OAuth2User;
@@ -22,8 +21,7 @@ import static com.habitpay.habitpay.global.config.jwt.TokenService.REFRESH_TOKEN
 @RequiredArgsConstructor
 public class CustomOAuth2LoginSuccessHandler extends SimpleUrlAuthenticationSuccessHandler {
 
-    @Value("${application.origin-url}")
-    private String redirectUrl;
+    private final String redirectUrl = "http://localhost:3000";
 
     private final TokenService tokenService;
 

--- a/src/main/java/com/habitpay/habitpay/global/config/auth/SecurityConfig.java
+++ b/src/main/java/com/habitpay/habitpay/global/config/auth/SecurityConfig.java
@@ -3,7 +3,6 @@ package com.habitpay.habitpay.global.config.auth;
 import com.habitpay.habitpay.global.config.jwt.JwtAuthenticationFilter;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
-import org.springframework.beans.factory.annotation.Value;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.security.config.annotation.web.builders.HttpSecurity;
@@ -21,8 +20,7 @@ import java.util.Collections;
 @RequiredArgsConstructor
 @Slf4j
 public class SecurityConfig {
-    @Value("${application.origin-url}")
-    private String originUrl;
+    private final String originUrl = "http://localhost:3000";
 
     private final CustomOAuth2UserService customOAuth2UserService;
     private final CustomOAuth2LoginSuccessHandler customOAuth2LoginSuccessHandler;

--- a/src/test/java/com/habitpay/habitpay/domain/challenge/api/ChallengeApiTest.java
+++ b/src/test/java/com/habitpay/habitpay/domain/challenge/api/ChallengeApiTest.java
@@ -5,6 +5,7 @@ import com.habitpay.habitpay.docs.springrestdocs.AbstractRestDocsTests;
 import com.habitpay.habitpay.domain.challenge.application.ChallengeCreationService;
 import com.habitpay.habitpay.domain.challenge.application.ChallengeDetailsService;
 import com.habitpay.habitpay.domain.challenge.application.ChallengePatchService;
+import com.habitpay.habitpay.domain.challenge.application.ChallengeSearchService;
 import com.habitpay.habitpay.domain.challenge.dto.*;
 import com.habitpay.habitpay.domain.member.domain.Member;
 import com.habitpay.habitpay.global.config.jwt.TokenProvider;
@@ -50,6 +51,9 @@ public class ChallengeApiTest extends AbstractRestDocsTests {
     ChallengePatchService challengePatchService;
 
     @MockBean
+    ChallengeSearchService challengeSearchService;
+
+    @MockBean
     TokenService tokenService;
 
     @MockBean
@@ -66,11 +70,14 @@ public class ChallengeApiTest extends AbstractRestDocsTests {
                 .description("챌린지 설명")
                 .startDate(ZonedDateTime.now())
                 .endDate(ZonedDateTime.now().plusDays(5))
+                .stopDate(null)
+                .numberOfParticipants(1)
+                .participatingDays(1 << 2)
+                .feePerAbsence(1000)
+                .isPaidAll(false)
                 .hostNickname("챌린지 주최자 닉네임")
                 .hostProfileImage("챌린지 주최자 프로필 이미지")
                 .isHost(true)
-                .participatingDays(1 << 2)
-                .feePerAbsence(1000)
                 .isMemberEnrolledInChallenge(true)
                 .build();
 
@@ -93,8 +100,11 @@ public class ChallengeApiTest extends AbstractRestDocsTests {
                                 fieldWithPath("data.description").description("챌린지 설명"),
                                 fieldWithPath("data.startDate").description("챌린지 시작 일시"),
                                 fieldWithPath("data.endDate").description("챌린지 종료 일시"),
+                                fieldWithPath("data.stopDate").description("챌린지 중단 일시"),
+                                fieldWithPath("data.numberOfParticipants").description("챌린지 참여 인"),
                                 fieldWithPath("data.participatingDays").description("챌린지 참여 요일"),
                                 fieldWithPath("data.feePerAbsence").description("미참여 1회당 벌금"),
+                                fieldWithPath("data.isPaidAll").description("최종 정산 여부"),
                                 fieldWithPath("data.hostNickname").description("챌린지 주최자 닉네임"),
                                 fieldWithPath("data.hostProfileImage").description("챌린지 주최자 프로필 이미지"),
                                 fieldWithPath("data.isHost").description("현재 접속한 사용자 == 챌린지 주최자"),

--- a/src/test/java/com/habitpay/habitpay/domain/challenge/api/ChallengeApiTest.java
+++ b/src/test/java/com/habitpay/habitpay/domain/challenge/api/ChallengeApiTest.java
@@ -22,6 +22,7 @@ import org.springframework.http.MediaType;
 import org.springframework.test.web.servlet.ResultActions;
 
 import java.time.ZonedDateTime;
+import java.util.List;
 
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyLong;
@@ -58,6 +59,62 @@ public class ChallengeApiTest extends AbstractRestDocsTests {
 
     @MockBean
     TokenProvider tokenProvider;
+
+    @Test
+    @WithMockOAuth2User
+    @DisplayName("나의 챌린지 참여 목록 조회")
+    void getEnrolledChallengeList() throws Exception {
+
+        // given
+        ChallengeEnrolledListItemResponse response = ChallengeEnrolledListItemResponse.builder()
+                .title("챌린지 제목")
+                .description("챌린지 설명")
+                .startDate(ZonedDateTime.now())
+                .endDate(ZonedDateTime.now().plusDays(5))
+                .stopDate(null)
+                .numberOfParticipants(1)
+                .participatingDays(1 << 2)
+                .totalFee(1000)
+                .isPaidAll(false)
+                .hostProfileImage("챌린지 주최자 프로필 이미지")
+                .isMemberGivenUp(false)
+                .successCount(4)
+                .isTodayParticipatingDay(true)
+                .isParticipatedToday(false)
+                .build();
+
+        given(challengeSearchService.getEnrolledChallengeList(any(Member.class)))
+                .willReturn(SuccessResponse.of("", List.of(response)));
+
+        // when
+        ResultActions result = mockMvc.perform(get("/api/challenges/me")
+                .header(HttpHeaders.AUTHORIZATION, AUTHORIZATION_HEADER_PREFIX + "ACCESS_TOKEN"));
+
+        // then
+        result.andExpect(status().isOk())
+                .andDo(document("challenge/get-my-challenge-list",
+                        requestHeaders(
+                                headerWithName(HttpHeaders.AUTHORIZATION).description("액세스 토큰")
+                        ),
+                        responseFields(
+                                fieldWithPath("message").description("메세지"),
+                                fieldWithPath("data[].title").description("챌린지 제목"),
+                                fieldWithPath("data[].description").description("챌린지 설명"),
+                                fieldWithPath("data[].startDate").description("챌린지 시작 일시"),
+                                fieldWithPath("data[].endDate").description("챌린지 종료 일시"),
+                                fieldWithPath("data[].stopDate").description("챌린지 중단 일시"),
+                                fieldWithPath("data[].numberOfParticipants").description("챌린지 참여 인"),
+                                fieldWithPath("data[].participatingDays").description("챌린지 참여 요일"),
+                                fieldWithPath("data[].totalFee").description("나의 벌금 합계"),
+                                fieldWithPath("data[].isPaidAll").description("최종 정산 여부"),
+                                fieldWithPath("data[].hostProfileImage").description("챌린지 주최자 프로필 이미지"),
+                                fieldWithPath("data[].isMemberGivenUp").description("현재 사용자의 챌린지 포기 여부"),
+                                fieldWithPath("data[].successCount").description("챌린지 인증 성공 횟수"),
+                                fieldWithPath("data[].isTodayParticipatingDay").description("오늘 요일 == 챌린지 참여 요일"),
+                                fieldWithPath("data[].isParticipatedToday").description("오늘 챌린지 참여 여부")
+                        )
+                ));
+    }
 
     @Test
     @WithMockOAuth2User

--- a/src/test/java/com/habitpay/habitpay/domain/challenge/api/ChallengeApiTest.java
+++ b/src/test/java/com/habitpay/habitpay/domain/challenge/api/ChallengeApiTest.java
@@ -6,6 +6,7 @@ import com.habitpay.habitpay.domain.challenge.application.ChallengeCreationServi
 import com.habitpay.habitpay.domain.challenge.application.ChallengeDetailsService;
 import com.habitpay.habitpay.domain.challenge.application.ChallengePatchService;
 import com.habitpay.habitpay.domain.challenge.dto.*;
+import com.habitpay.habitpay.domain.member.domain.Member;
 import com.habitpay.habitpay.global.config.jwt.TokenProvider;
 import com.habitpay.habitpay.global.config.jwt.TokenService;
 import com.habitpay.habitpay.global.response.SuccessResponse;
@@ -127,7 +128,7 @@ public class ChallengeApiTest extends AbstractRestDocsTests {
                 .feePerAbsence(1000)
                 .build();
 
-        given(challengeCreationService.createChallenge(any(ChallengeCreationRequest.class), anyLong()))
+        given(challengeCreationService.createChallenge(any(ChallengeCreationRequest.class), any(Member.class)))
                 .willReturn(SuccessResponse.of("챌린지가 생성되었습니다.", challengeCreationResponse));
 
         // when


### PR DESCRIPTION
# 작업 개요

1. 현재 접속한 사용자가 참여 중인 챌린지 목록을 반환하는 `GET /challenges/me` 컨트롤러를 구현했습니다. 
2. 해당 컨트롤러의 테스트 코드를 작성했습니다.


# 작업 상세 내용

## 1. `GET /challenges/me` 컨트롤러 구현

컨트롤러가 반환하는 DTO 에는 오늘이 챌린지 참여 날짜인지 알려주는 `isTodayParticipatingDay` 변수가 있습니다.
해당 변수에 값을 넣기 위해 `isTodayParticipatingDay()` 메서드를 정의했습니다.

```java
public boolean isTodayParticipatingDay() {
    DayOfWeek today = ZonedDateTime.now().getDayOfWeek();
    int todayBitPosition = 6 - (today.getValue() - 1);
    return (this.participatingDays & (1 << todayBitPosition)) != 0;
}
```

위의 메서드에서는 오늘이 챌린지 참여 날짜인지 확인하기 위해 비트 연산을 합니다.

java 에서는 요일이 enum 으로 정의되어 있습니다. 
enum 의 값은 월요일(정수 1)부터 일요일(정수 7)까지 정의되어있습니다. 
챌린지 참여 날짜는 총 7개의 비트를 사용하는데, 좌측부터 월요일입니다.
예를 들어, `1000000` 라면 월요일만 챌린지에 참여하는 것입니다.

위의 코드에서 오늘이 월요일이라면 `today.getValue()` 의 값은 `1` 이 되고, `todayBitPosition` 은 `6` 이 됩니다.
`1 << 6` 을 수행하면 `1000000` 이 되고, AND 연산(&)을 수행하면 결과는 `1000000` 이 됩니다.
해당 값은 0(`0000000`) 이 아니기 때문에 오늘이 참여 요일이 되는 것입니다. 

## 2. 테스트 코드 작성

`SecurityConfig` 와 `CustomOAuth2LoginSuccessHandler` 에서 String 값을 `@Value` 어노테이션을 이용해서 환경변수로 부터 값을 주입 받았었는데요.

```java
public class SecurityConfig {
    @Value("${application.origin-url}")
    private String originUrl;
```

하지만 WebMvcTest 에서는 해당 어노테이션에 대한 값을 제대로 불러오지 못하는 문제가 있었습니다.
해당 값은 가능하면 `application.yaml` 파일에서 한 번에 관리할 수 있으면 좋을 것 같은데, 아직 해결 방법을 찾지 못해서 하드 코딩한 상태입니다.

```java
public class SecurityConfig {
    private final String originUrl = "http://localhost:3000";
```

해결 방법을 찾게 되면 수정하도록 하겠습니다. 