### PR TITLE
[Feat] 컨트롤러 메서드에서 Pageable을 바로 인자로 받기 #165

### DIFF
--- a/src/main/java/com/habitpay/habitpay/domain/challengepost/api/ChallengePostApi.java
+++ b/src/main/java/com/habitpay/habitpay/domain/challengepost/api/ChallengePostApi.java
@@ -9,6 +9,7 @@ import com.habitpay.habitpay.global.response.SuccessResponse;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.data.domain.Pageable;
+import org.springframework.data.web.PageableDefault;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.*;
 
@@ -25,9 +26,8 @@ public class ChallengePostApi {
     private final ChallengePostDeleteService challengePostDeleteService;
     private final ChallengePostUtilService challengePostUtilService;
 
-    private static final String DEFAULT_PAGE = "0";
-    private static final String DEFAULT_SIZE = "5";
-    private static final String DEFAULT_SORT = "asc";
+    private static final int DEFAULT_PAGE = 0;
+    private static final int DEFAULT_SIZE = 5;
 
     @GetMapping("/api/posts/{id}")
     public SuccessResponse<PostViewResponse> getPost(@PathVariable Long id) {
@@ -38,11 +38,7 @@ public class ChallengePostApi {
     @GetMapping("/api/challenges/{id}/posts")
     public SuccessResponse<List<PostViewResponse>> getChallengePosts(
             @PathVariable Long id,
-            @RequestParam(defaultValue = DEFAULT_PAGE) int page,
-            @RequestParam(defaultValue = DEFAULT_SIZE) int size,
-            @RequestParam(defaultValue = DEFAULT_SORT) String[] sort) {
-
-        Pageable pageable = challengePostUtilService.makePageable(page, size, sort);
+            @PageableDefault(page = DEFAULT_PAGE, size = DEFAULT_SIZE) Pageable pageable) {
 
         return challengePostSearchService.findPostViewResponseListByChallengeId(id, pageable);
     }
@@ -51,11 +47,7 @@ public class ChallengePostApi {
     public SuccessResponse<List<PostViewResponse>> getChallengePostsByMe(
             @PathVariable Long id,
             @AuthenticationPrincipal CustomUserDetails user,
-            @RequestParam(defaultValue = DEFAULT_PAGE) int page,
-            @RequestParam(defaultValue = DEFAULT_SIZE) int size,
-            @RequestParam(defaultValue = DEFAULT_SORT) String[] sort) {
-
-        Pageable pageable = challengePostUtilService.makePageable(page, size, sort);
+            @PageableDefault(page = DEFAULT_PAGE, size = DEFAULT_SIZE) Pageable pageable) {
 
         return challengePostSearchService.findChallengePostsByMember(id, user.getMember(), pageable);
     }

--- a/src/main/java/com/habitpay/habitpay/domain/challengepost/application/ChallengePostSearchService.java
+++ b/src/main/java/com/habitpay/habitpay/domain/challengepost/application/ChallengePostSearchService.java
@@ -31,9 +31,9 @@ public class ChallengePostSearchService {
 
     private final PostPhotoSearchService postPhotoSearchService;
     private final PostPhotoUtilService postPhotoUtilService;
-    private final MemberService memberService;
     private final ChallengeEnrollmentSearchService challengeEnrollmentSearchService;
     private final ChallengeSearchService challengeSearchService;
+    private final ChallengePostUtilService challengePostUtilService;
 
     private final ChallengePostRepository challengePostRepository;
     private final ChallengeEnrollmentRepository challengeEnrollmentRepository;
@@ -50,6 +50,8 @@ public class ChallengePostSearchService {
     }
 
     public SuccessResponse<List<PostViewResponse>> findPostViewResponseListByChallengeId(Long challengeId, Pageable pageable) {
+
+        pageable = challengePostUtilService.checkPageable(pageable);
 
         List<PostViewResponse> postViewResponseList = this.findAllByChallengeId(challengeId, pageable)
                 .stream()
@@ -74,6 +76,7 @@ public class ChallengePostSearchService {
 
         Long challengeEnrollmentId = enrollment.getId();
 
+        pageable = challengePostUtilService.checkPageable(pageable);
         List<PostViewResponse> postViewResponseList =  challengePostRepository.findAllByChallengeEnrollmentId(challengeEnrollmentId, pageable)
                 .stream()
                 // .filter(post -> !post.getIsAnnouncement()) // todo

--- a/src/main/java/com/habitpay/habitpay/domain/challengepost/application/ChallengePostUtilService.java
+++ b/src/main/java/com/habitpay/habitpay/domain/challengepost/application/ChallengePostUtilService.java
@@ -45,23 +45,22 @@ public class ChallengePostUtilService {
         return challenge.getHost().equals(member);
     }
 
-    public Pageable makePageable(int page, int size, String[] sort) {
+    public Pageable checkPageable(Pageable pageable) {
 
-        if (page < 0) {
-            page = DEFAULT_PAGE;
+        if (pageable.getPageNumber() < 0) {
+            return PageRequest.of(DEFAULT_PAGE, DEFAULT_SIZE);
         }
 
-        if (size < 1) {
-            size = DEFAULT_SIZE;
-        } else if (size > MAX_SIZE) {
-            size = MAX_SIZE;
+        if (pageable.getPageSize() < 1) {
+            return PageRequest.of(DEFAULT_PAGE, DEFAULT_SIZE);
+        } else if (pageable.getPageSize() > MAX_SIZE) {
+            return PageRequest.of(0, MAX_SIZE);
         }
 
-        // todo : sort 제공할 것인지
-//        if (sort.length > 1) {
-//        }
+        // todo: Sort 예외 처리
+        // if (pageable.getSort())
 
-        return PageRequest.of(page, size);
+        return pageable;
     }
 
     public void verifyChallengePostForRecord(ChallengePost post) {


### PR DESCRIPTION
### 작업 개요

* `Pageable 객체`를 생성하기 위해, 이전에는 쿼리 스트링으로 `page, size` 값 등을 따로 받은 후 `PageRequest`를 이용했습니다.
* 테스트 코드 작성 용이, 가독성 높이기, JPA 공식 문서에서 `@PageDefault` 사용 등을 이유로 변경했습니다.
* 컨트롤러 메서드에서 쿼리 스트링을 인자로 받는 대신, `Pageable` 인자를 바로 받습니다.

---

### 코드 주요 내용

```java
// before
public SuccessResponse<List<PostViewResponse>> getChallengePosts(
            @PathVariable Long id,
            @RequestParam(defaultValue = DEFAULT_PAGE) int page,
            @RequestParam(defaultValue = DEFAULT_SIZE) int size,
            @RequestParam(defaultValue = DEFAULT_SORT) String[] sort) {

        Pageable pageable = challengePostUtilService.makePageable(page, size, sort);

        return challengePostSearchService.findPostViewResponseListByChallengeId(id, pageable);
    }
```
* 쿼리 스트링으로 인자가 많아짐에 따라 코드도 길어졌습니다.
* 쿼리 스트링 값 확인 및 `Pageable` 객체 생성을 위한 `makePageable()` 메서드가 컨트롤러단에 있었습니다.
   (모든 인자를 다 넘기면 복잡해진다고 판단하여, 서비스 메서드로 넘기기 전 위치에 두었었습니다.)

---

```java
// after
public SuccessResponse<List<PostViewResponse>> getChallengePosts(
            @PathVariable Long id,
            @PageableDefault(page = DEFAULT_PAGE, size = DEFAULT_SIZE) Pageable pageable) {

        return challengePostSearchService.findPostViewResponseListByChallengeId(id, pageable);
    }
```
* 코드의 가독성이 더 높아진 모습입니다.

---

* `Pageable`의 값을 확인하는 메서드
* `Pageable`을 인자로 받는 메서드에 삽입했습니다.
* 코드는 다음과 같습니다.
```java
public Pageable checkPageable(Pageable pageable) {

        if (pageable.getPageNumber() < 0) {
            return PageRequest.of(DEFAULT_PAGE, DEFAULT_SIZE);
        }

        if (pageable.getPageSize() < 1) {
            return PageRequest.of(DEFAULT_PAGE, DEFAULT_SIZE);
        } else if (pageable.getPageSize() > MAX_SIZE) {
            return PageRequest.of(0, MAX_SIZE);
        }

        return pageable;
    }
```
* 기본적으로 인자로 받은 `pageable`을 사용하되, 한 요소라도 예외 처리해야 할 값이 있으면
  인자 자체가 잘못 들어온 것으로 판단하여 새로운 `Pageable` 객체를 만들어 반환했습니다.
* 혼자 생각해 만든 정책이라, 더 좋은 의견 있다면 적극 반영하겠습니다.