### PR TITLE
[feat] 챌린지 포스트 삭제 -> SuccessResponse data에 삭제 포스트 id 데이터 반영

### DIFF
--- a/src/main/java/com/habitpay/habitpay/domain/challengepost/api/ChallengePostApi.java
+++ b/src/main/java/com/habitpay/habitpay/domain/challengepost/api/ChallengePostApi.java
@@ -76,13 +76,9 @@ public class ChallengePostApi {
     }
 
     @DeleteMapping("/api/posts/{id}")
-    public SuccessResponse<Void> deletePost(
+    public SuccessResponse<Long> deletePost(
             @PathVariable Long id, @AuthenticationPrincipal CustomUserDetails user) {
 
-        challengePostDeleteService.deletePost(id, user.getMember());
-        return SuccessResponse.of(
-                "포스트가 정상적으로 삭제되었습니다.",
-                null
-        );
+        return challengePostDeleteService.deletePost(id, user.getMember());
     }
 }

--- a/src/main/java/com/habitpay/habitpay/domain/challengepost/application/ChallengePostDeleteService.java
+++ b/src/main/java/com/habitpay/habitpay/domain/challengepost/application/ChallengePostDeleteService.java
@@ -7,6 +7,7 @@ import com.habitpay.habitpay.domain.member.domain.Member;
 import com.habitpay.habitpay.domain.postphoto.application.PostPhotoDeleteService;
 import com.habitpay.habitpay.domain.refreshtoken.exception.CustomJwtException;
 import com.habitpay.habitpay.global.error.CustomJwtErrorInfo;
+import com.habitpay.habitpay.global.response.SuccessResponse;
 import jakarta.transaction.Transactional;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
@@ -24,7 +25,7 @@ public class ChallengePostDeleteService {
     private final ChallengePostUtilService challengePostUtilService;
 
     @Transactional
-    public void deletePost(Long postId, Member member) {
+    public SuccessResponse<Long> deletePost(Long postId, Member member) {
         ChallengePost post = challengePostSearchService.getChallengePostById(postId);
         Challenge challenge = challengePostSearchService.getChallengeByPostId(postId);
 
@@ -41,6 +42,11 @@ public class ChallengePostDeleteService {
 
         postPhotoDeleteService.deleteByPost(post);
         challengePostRepository.delete(post);
+
+        return SuccessResponse.of(
+                "포스트가 정상적으로 삭제되었습니다.",
+                postId
+        );
     }
 
 }

--- a/src/test/java/com/habitpay/habitpay/domain/challegepost/api/ChallengePostApiTest.java
+++ b/src/test/java/com/habitpay/habitpay/domain/challegepost/api/ChallengePostApiTest.java
@@ -336,7 +336,8 @@ public class ChallengePostApiTest extends AbstractRestDocsTests {
     void deletePost() throws Exception {
 
         //given
-        doNothing().when(challengePostDeleteService).deletePost(anyLong(), any(Member.class));
+        given(challengePostDeleteService.deletePost(anyLong(), any(Member.class)))
+                .willReturn(SuccessResponse.of("포스트가 정상적으로 삭제되었습니다.", 1L));
 
         //when
         ResultActions result = mockMvc.perform(delete("/api/posts/{id}", 1L)
@@ -350,7 +351,7 @@ public class ChallengePostApiTest extends AbstractRestDocsTests {
                         ),
                         responseFields(
                                 fieldWithPath("message").description("메시지"),
-                                fieldWithPath("data").description("빈 데이터(null)")
+                                fieldWithPath("data").description("삭제된 포스트 id")
                         )
                 ));
     }


### PR DESCRIPTION
### 작업 내용

* ChallengePost API를 통해 포스트를 정상적으로 삭제하면 `SuccessResponse<void>` 값을 반환했습니다.
* `SuccessResponse<void>` 내의 `data` 역시 null이었습니다.

->

* null 값으로 두는 대신, 삭제된 포스트 id 데이터를 담아 `SuccessResponse<Long>` 형태로 반환하는 것으로 바꿨습니다.

```java
public SuccessResponse<Long> deletePost(Long postId, Member member) {
    ...

    return SuccessResponse.of(
            "포스트가 정상적으로 삭제되었습니다.",
            postId
    );
}
```

* 관련된 테스트 코드 역시 수정했습니다.