### PR TITLE
[test, feat] 리프레시 토큰 테스트 코드 작성, 리프레시 토큰 작은 리팩토링 #172

### DIFF
--- a/src/docs/asciidoc/api/refreshToken.adoc
+++ b/src/docs/asciidoc/api/refreshToken.adoc
@@ -1,0 +1,20 @@
+== 리프레시 토큰 API
+:doctype: book
+:source-highlighter: highlightjs
+:toc: left
+:toclevels: 2
+:seclinks:
+
+클라이언트가 토큰 리프레시를 요청하면, 새로운 액세스 토큰과 리프레스 토큰을 발급합니다.
+
+보통 액세스 토큰 만료될 경우 요청이 발생하기 때문에,
+다른 대부분의 요청과 달리 Request Header에 액세스 토큰을 담아 보낼 필요가 없습니다.
+
+=== 토큰 리프레시 요청
+
+Request Body에 클라이언트가 가지고 있던 리프레시 토큰을 담아 형식에 맞게 요청합니다.
+리프레시 토큰이 유효하고 적절하다면, 새로운 액세스 토큰과 함께 새로운 리프레시 토큰을 세트로 발급합니다.
+
+이때 "grantType" 속성은 "refreshToken"으로 정확히 보내야 합니다.
+
+operation::refreshToken/create-new-access-token-and-new-refresh-token[snippets='http-request,http-response,response-fields']

--- a/src/docs/asciidoc/api/refreshToken.adoc
+++ b/src/docs/asciidoc/api/refreshToken.adoc
@@ -15,6 +15,7 @@
 Request Body에 클라이언트가 가지고 있던 리프레시 토큰을 담아 형식에 맞게 요청합니다.
 리프레시 토큰이 유효하고 적절하다면, 새로운 액세스 토큰과 함께 새로운 리프레시 토큰을 세트로 발급합니다.
 
-이때 "grantType" 속성은 "refreshToken"으로 정확히 보내야 합니다.
+이때 "grantType" 속성은 "refreshToken"으로 보내면 됩니다.
+(대소문자를 구분하지 않고, "refresh_token" 스네이크 케이싱도 정상 인자로 받습니다.)
 
 operation::refreshToken/create-new-access-token-and-new-refresh-token[snippets='http-request,http-response,response-fields']

--- a/src/main/java/com/habitpay/habitpay/domain/refreshtoken/application/RefreshTokenCreationService.java
+++ b/src/main/java/com/habitpay/habitpay/domain/refreshtoken/application/RefreshTokenCreationService.java
@@ -39,9 +39,15 @@ public class RefreshTokenCreationService {
 
     public SuccessResponse<CreateAccessTokenResponse> createNewAccessTokenAndNewRefreshToken(CreateAccessTokenRequest requestBody) {
 
-        Optional<String> optionalGrantType = Optional.ofNullable(requestBody.getGrantType());
-        if (optionalGrantType.isEmpty() || !requestBody.getGrantType().equals("refreshToken")) {
-            throw new CustomJwtException(HttpStatus.BAD_REQUEST, CustomJwtErrorInfo.BAD_REQUEST, "Request was missing the 'grantType' parameter.");
+        String grantType = requestBody.getGrantType();
+
+        if (grantType == null) {
+            throw new CustomJwtException(HttpStatus.BAD_REQUEST, CustomJwtErrorInfo.BAD_REQUEST, "인증 방법을 알 수 없습니다.");
+        }
+
+        if (!grantType.equalsIgnoreCase("refreshToken")
+                && !grantType.equalsIgnoreCase("refresh_token")) {
+            throw new CustomJwtException(HttpStatus.BAD_REQUEST, CustomJwtErrorInfo.BAD_REQUEST, "인증 방법을 알 수 없습니다.");
         }
 
         String newAccessToken = this.createNewAccessToken(requestBody.getRefreshToken());

--- a/src/main/java/com/habitpay/habitpay/domain/refreshtoken/application/RefreshTokenCreationService.java
+++ b/src/main/java/com/habitpay/habitpay/domain/refreshtoken/application/RefreshTokenCreationService.java
@@ -40,7 +40,7 @@ public class RefreshTokenCreationService {
     public SuccessResponse<CreateAccessTokenResponse> createNewAccessTokenAndNewRefreshToken(CreateAccessTokenRequest requestBody) {
 
         Optional<String> optionalGrantType = Optional.ofNullable(requestBody.getGrantType());
-        if (optionalGrantType.isEmpty() || !requestBody.getGrantType().equals("refresh_token")) {
+        if (optionalGrantType.isEmpty() || !requestBody.getGrantType().equals("refreshToken")) {
             throw new CustomJwtException(HttpStatus.BAD_REQUEST, CustomJwtErrorInfo.BAD_REQUEST, "Request was missing the 'grantType' parameter.");
         }
 

--- a/src/main/java/com/habitpay/habitpay/domain/refreshtoken/dto/CreateAccessTokenRequest.java
+++ b/src/main/java/com/habitpay/habitpay/domain/refreshtoken/dto/CreateAccessTokenRequest.java
@@ -1,10 +1,12 @@
 package com.habitpay.habitpay.domain.refreshtoken.dto;
 
+import lombok.Builder;
 import lombok.Getter;
 import lombok.Setter;
 
 @Getter
 @Setter
+@Builder
 public class CreateAccessTokenRequest {
     private String grantType;
     private String refreshToken;

--- a/src/main/java/com/habitpay/habitpay/domain/refreshtoken/dto/CreateAccessTokenResponse.java
+++ b/src/main/java/com/habitpay/habitpay/domain/refreshtoken/dto/CreateAccessTokenResponse.java
@@ -1,11 +1,13 @@
 package com.habitpay.habitpay.domain.refreshtoken.dto;
 
 import lombok.AllArgsConstructor;
+import lombok.Builder;
 import lombok.Getter;
 import lombok.Setter;
 
 @AllArgsConstructor
 @Getter
+@Builder
 public class CreateAccessTokenResponse {
     private String accessToken;
     private String tokenType;

--- a/src/test/java/com/habitpay/habitpay/domain/challegepost/api/ChallengePostApiTest.java
+++ b/src/test/java/com/habitpay/habitpay/domain/challegepost/api/ChallengePostApiTest.java
@@ -144,9 +144,6 @@ public class ChallengePostApiTest extends AbstractRestDocsTests {
 
         // when
         ResultActions result = mockMvc.perform(get("/api/challenges/{id}/posts", 1L)
-                        .param("page", "0")
-                        .param("size", "10")
-                        .param("sort", "")
                 .header(HttpHeaders.AUTHORIZATION, AUTHORIZATION_HEADER_PREFIX + "ACCESS_TOKEN"));
 
         //then
@@ -202,9 +199,6 @@ public class ChallengePostApiTest extends AbstractRestDocsTests {
 
         // when
         ResultActions result = mockMvc.perform(get("/api/challenges/{id}/posts/me", 1L)
-                .param("page", "0")
-                .param("size", "10")
-                .param("sort", "")
                 .header(HttpHeaders.AUTHORIZATION, AUTHORIZATION_HEADER_PREFIX + "ACCESS_TOKEN"));
 
         //then

--- a/src/test/java/com/habitpay/habitpay/domain/challegepost/api/ChallengePostApiTest.java
+++ b/src/test/java/com/habitpay/habitpay/domain/challegepost/api/ChallengePostApiTest.java
@@ -20,7 +20,6 @@ import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
 import org.springframework.boot.test.mock.mockito.MockBean;
-import org.springframework.data.domain.PageRequest;
 import org.springframework.data.domain.Pageable;
 import org.springframework.http.HttpHeaders;
 import org.springframework.http.MediaType;
@@ -30,16 +29,13 @@ import java.time.LocalDateTime;
 import java.util.List;
 
 import static org.mockito.ArgumentMatchers.anyLong;
-import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.BDDMockito.given;
-import static org.mockito.Mockito.doNothing;
 import static org.mockito.Mockito.*;
 import static org.springframework.restdocs.headers.HeaderDocumentation.headerWithName;
 import static org.springframework.restdocs.headers.HeaderDocumentation.requestHeaders;
 import static org.springframework.restdocs.mockmvc.MockMvcRestDocumentation.document;
 import static org.springframework.restdocs.mockmvc.RestDocumentationRequestBuilders.*;
 import static org.springframework.restdocs.payload.PayloadDocumentation.*;
-import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.content;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
 @WebMvcTest(ChallengePostApi.class)

--- a/src/test/java/com/habitpay/habitpay/domain/refreshtoken/api/RefreshTokenApiTest.java
+++ b/src/test/java/com/habitpay/habitpay/domain/refreshtoken/api/RefreshTokenApiTest.java
@@ -14,10 +14,12 @@ import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
 import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.test.web.servlet.ResultActions;
 
 import java.time.Duration;
 
 import static org.mockito.BDDMockito.given;
+import static org.springframework.restdocs.mockmvc.RestDocumentationRequestBuilders.post;
 
 @WebMvcTest(TokenApi.class)
 public class RefreshTokenApiTest extends AbstractRestDocsTests {
@@ -59,6 +61,12 @@ public class RefreshTokenApiTest extends AbstractRestDocsTests {
                 .build();
 
         given(refreshTokenCreationService.createNewAccessTokenAndNewRefreshToken(tokenRequest))
-                .willReturn(SuccessResponse.of("새로운 액세스 토큰 및 리프레시 토큰이 성공적으로 발급되었습니다.", ));
+                .willReturn(SuccessResponse.of("새로운 액세스 토큰 및 리프레시 토큰이 성공적으로 발급되었습니다.", tokenResponse));
+
+        //when
+        ResultActions result = mockMvc.perform(post("/token"))
+                .content(objectMapper.writeValueAsString(tokenRequest))
+                .contentType();
+
     }
 }

--- a/src/test/java/com/habitpay/habitpay/domain/refreshtoken/api/RefreshTokenApiTest.java
+++ b/src/test/java/com/habitpay/habitpay/domain/refreshtoken/api/RefreshTokenApiTest.java
@@ -19,6 +19,7 @@ import org.springframework.test.web.servlet.ResultActions;
 
 import java.time.Duration;
 
+import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.BDDMockito.given;
 import static org.springframework.restdocs.mockmvc.MockMvcRestDocumentation.document;
 import static org.springframework.restdocs.mockmvc.RestDocumentationRequestBuilders.*;
@@ -55,17 +56,17 @@ public class RefreshTokenApiTest extends AbstractRestDocsTests {
 
         CreateAccessTokenRequest tokenRequest = CreateAccessTokenRequest.builder()
                 .grantType("refreshToken")
-                .refreshToken(tokenProvider.generateRefreshToken(mockMember, Duration.ofHours(2)))
+                .refreshToken("eyJhbGciOiJIUzI1NiJ9.eyJ1c2VyIjoiYWxpY2UifQ.DUMMY_SIGNATURE2")
                 .build();
 
         CreateAccessTokenResponse tokenResponse = CreateAccessTokenResponse.builder()
-                .accessToken(tokenProvider.generateToken(mockMember, Duration.ofMinutes(30)))
+                .accessToken("eyJhbGciOiJIUzI1NiJ9.eyJzdWIiOiIxMjM0In0.DUMMY_SIGNATURE1")
                 .tokenType("Bearer")
                 .expiresIn(Duration.ofMinutes(30).toMillis())
-                .refreshToken(tokenProvider.generateRefreshToken(mockMember, Duration.ofHours(2)))
+                .refreshToken("eyJhbGciOiJIUzI1NiJ9.eyJ1c2VyIjoiYWxpY2UifQ.DUMMY_SIGNATURE3")
                 .build();
 
-        given(refreshTokenCreationService.createNewAccessTokenAndNewRefreshToken(tokenRequest))
+        given(refreshTokenCreationService.createNewAccessTokenAndNewRefreshToken(any(CreateAccessTokenRequest.class)))
                 .willReturn(SuccessResponse.of("새로운 액세스 토큰 및 리프레시 토큰이 성공적으로 발급되었습니다.", tokenResponse));
 
         //when
@@ -81,10 +82,11 @@ public class RefreshTokenApiTest extends AbstractRestDocsTests {
                                 fieldWithPath("refreshToken").description("클라이언트가 보관하던 리프레시 토큰")
                         ),
                         responseFields(
-                                fieldWithPath("accessToken").description("새로 발급한 액세스 토큰"),
-                                fieldWithPath("tokenType").description("발급한 토큰의 유형. \"Bearer\""),
-                                fieldWithPath("expiresIn").description("액세스 토큰의 유효 기간"),
-                                fieldWithPath("refreshToken").description("새로 발급한 리프레시 토큰. 추후 새 액세스 토큰 발급 시 이용된다.")
+                                fieldWithPath("message").description("메시지"),
+                                fieldWithPath("data.accessToken").description("새로 발급한 액세스 토큰"),
+                                fieldWithPath("data.tokenType").description("발급한 토큰의 유형. \"Bearer\""),
+                                fieldWithPath("data.expiresIn").description("액세스 토큰의 유효 기간"),
+                                fieldWithPath("data.refreshToken").description("새로 발급한 리프레시 토큰. 추후 새 액세스 토큰 발급 시 이용된다.")
                         )
                 ));
 

--- a/src/test/java/com/habitpay/habitpay/domain/refreshtoken/api/RefreshTokenApiTest.java
+++ b/src/test/java/com/habitpay/habitpay/domain/refreshtoken/api/RefreshTokenApiTest.java
@@ -47,7 +47,7 @@ public class RefreshTokenApiTest extends AbstractRestDocsTests {
                 .build();
 
         CreateAccessTokenRequest tokenRequest = CreateAccessTokenRequest.builder()
-                .grantType("refresh_token")
+                .grantType("refreshToken")
                 .refreshToken(tokenProvider.generateRefreshToken(mockMember, Duration.ofHours(2)))
                 .build();
 

--- a/src/test/java/com/habitpay/habitpay/domain/refreshtoken/api/RefreshTokenApiTest.java
+++ b/src/test/java/com/habitpay/habitpay/domain/refreshtoken/api/RefreshTokenApiTest.java
@@ -1,0 +1,64 @@
+package com.habitpay.habitpay.domain.refreshtoken.api;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.habitpay.habitpay.docs.springrestdocs.AbstractRestDocsTests;
+import com.habitpay.habitpay.domain.member.domain.Member;
+import com.habitpay.habitpay.domain.refreshtoken.application.RefreshTokenCreationService;
+import com.habitpay.habitpay.domain.refreshtoken.dto.CreateAccessTokenRequest;
+import com.habitpay.habitpay.domain.refreshtoken.dto.CreateAccessTokenResponse;
+import com.habitpay.habitpay.global.config.jwt.TokenProvider;
+import com.habitpay.habitpay.global.config.jwt.TokenService;
+import com.habitpay.habitpay.global.response.SuccessResponse;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
+
+import java.time.Duration;
+
+import static org.mockito.BDDMockito.given;
+
+@WebMvcTest(TokenApi.class)
+public class RefreshTokenApiTest extends AbstractRestDocsTests {
+
+    @Autowired
+    ObjectMapper objectMapper;
+
+    @MockBean
+    RefreshTokenCreationService refreshTokenCreationService;
+
+    @MockBean
+    TokenProvider tokenProvider;
+
+    @MockBean
+    TokenService tokenService;
+
+
+    @Test
+    @DisplayName("")
+    void createNewAccessTokenAndNewRefreshToken() throws Exception {
+
+        //given
+        Member mockMember = Member.builder()
+                .id(1L)
+                .nickname("test user")
+                .email("test_user@test.com")
+                .build();
+
+        CreateAccessTokenRequest tokenRequest = CreateAccessTokenRequest.builder()
+                .grantType("refresh_token")
+                .refreshToken(tokenProvider.generateRefreshToken(mockMember, Duration.ofHours(2)))
+                .build();
+
+        CreateAccessTokenResponse tokenResponse = CreateAccessTokenResponse.builder()
+                .accessToken(tokenProvider.generateToken(mockMember, Duration.ofMinutes(30)))
+                .tokenType("Bearer")
+                .expiresIn(Duration.ofMinutes(30).toMillis())
+                .refreshToken(tokenProvider.generateRefreshToken(mockMember, Duration.ofHours(2)))
+                .build();
+
+        given(refreshTokenCreationService.createNewAccessTokenAndNewRefreshToken(tokenRequest))
+                .willReturn(SuccessResponse.of("새로운 액세스 토큰 및 리프레시 토큰이 성공적으로 발급되었습니다.", ));
+    }
+}


### PR DESCRIPTION
### 작업 개요

* 리프레시 토큰 API를 위한 테스트 코드를 작성했습니다.
* 그 테스트 코드에 맞는 restDocs 문서를 작성했습니다.
* 그 과정에서, 리프레시 토큰 요청을 확인하는 메서드를 리팩토링 했습니다.

---

### 리팩토링 내용

* Optional은 비용이 많이 든다고 알고 있어서, 요청 Json 객체의 String을 바로 확인하기 쉬운 부분의 Optional을 제거했습니다. (그런데 이거 아니면 다시 알려주십시오,, 수정하겠습니다.)
* 인증 방법을 뜻하는 `grantType` 속성의 값이 `refreshToken`과 `refresh_token`인 경우 모두 정상 처리하도록 했습니다.
(RFC 문서에는 스네이크 케이싱 기준으로 표현해서 `refresh_token`로 표현합니다.
저희는 변수명에 카멜 케이싱을 사용하기에 그 일관성을 지키면서,
일반적인 값도 받을 수 있어야 할 것만 같아 그렇게 했습니다.)
* RFC 문서에 대소문자 값을 구분한다는 이야기가 없어 `equalsIgnoreCase()` 메서드로 교체했습니다.

```java
// before
 Optional<String> optionalGrantType = Optional.ofNullable(requestBody.getGrantType());
    if (optionalGrantType.isEmpty() || !requestBody.getGrantType().equals("refresh_token")) {
        throw new CustomJwtException(HttpStatus.BAD_REQUEST, CustomJwtErrorInfo.BAD_REQUEST, "Request was missing the 'grantType' parameter.");
```

```java
// after
String grantType = requestBody.getGrantType();

    if (grantType == null) {
        throw new CustomJwtException(HttpStatus.BAD_REQUEST, CustomJwtErrorInfo.BAD_REQUEST, "인증 방법을 알 수 없습니다.");
    }

    if (!grantType.equalsIgnoreCase("refreshToken")
            && !grantType.equalsIgnoreCase("refresh_token")) {
        throw new CustomJwtException(HttpStatus.BAD_REQUEST, CustomJwtErrorInfo.BAD_REQUEST, "인증 방법을 알 수 없습니다.");
    }
```

---

### 기타

* ChallengePost API 테스트 코드에서 지난 코드에 남아있던 흔적을 삭제했습니다.
(Pageable 생성을 위한 쿼리 스트링 받는 테스트 코드 삭제)