### PR TITLE
feat: 챌린지 총 참여일수 추가 #175

### DIFF
--- a/src/main/java/com/habitpay/habitpay/domain/challenge/dto/ChallengeEnrolledListItemResponse.java
+++ b/src/main/java/com/habitpay/habitpay/domain/challenge/dto/ChallengeEnrolledListItemResponse.java
@@ -15,6 +15,7 @@ public class ChallengeEnrolledListItemResponse {
     private ZonedDateTime startDate;
     private ZonedDateTime endDate;
     private ZonedDateTime stopDate;
+    private int totalParticipatingDays;
     private int numberOfParticipants;
     private int participatingDays;
     private int totalFee;
@@ -32,6 +33,7 @@ public class ChallengeEnrolledListItemResponse {
                 .startDate(challenge.getStartDate())
                 .endDate(challenge.getEndDate())
                 .stopDate(challenge.getStopDate())
+                .totalParticipatingDays(challenge.getTotalParticipatingDays())
                 .numberOfParticipants(challenge.getNumberOfParticipants())
                 .isPaidAll(challenge.isPaidAll())
                 .participatingDays(challenge.getParticipatingDays())

--- a/src/test/java/com/habitpay/habitpay/domain/challenge/api/ChallengeApiTest.java
+++ b/src/test/java/com/habitpay/habitpay/domain/challenge/api/ChallengeApiTest.java
@@ -72,6 +72,7 @@ public class ChallengeApiTest extends AbstractRestDocsTests {
                 .startDate(ZonedDateTime.now())
                 .endDate(ZonedDateTime.now().plusDays(5))
                 .stopDate(null)
+                .totalParticipatingDays(2)
                 .numberOfParticipants(1)
                 .participatingDays(1 << 2)
                 .totalFee(1000)
@@ -103,7 +104,8 @@ public class ChallengeApiTest extends AbstractRestDocsTests {
                                 fieldWithPath("data[].startDate").description("챌린지 시작 일시"),
                                 fieldWithPath("data[].endDate").description("챌린지 종료 일시"),
                                 fieldWithPath("data[].stopDate").description("챌린지 중단 일시"),
-                                fieldWithPath("data[].numberOfParticipants").description("챌린지 참여 인"),
+                                fieldWithPath("data[].totalParticipatingDays").description("챌린지 총 참여 일수"),
+                                fieldWithPath("data[].numberOfParticipants").description("챌린지 참여 인원"),
                                 fieldWithPath("data[].participatingDays").description("챌린지 참여 요일"),
                                 fieldWithPath("data[].totalFee").description("나의 벌금 합계"),
                                 fieldWithPath("data[].isPaidAll").description("최종 정산 여부"),


### PR DESCRIPTION
# 작업 개요

1. POST /challenges 컨트롤러에서 챌린지 생성 시 챌린지 총 참여 일수를 계산합니다.
2. GET /challenges/me 컨트롤러에서 챌린지 조회 시 챌린지 총 참여 일수를 포함해서 응답합니다.