### PR TITLE
[Feat] 챌린지 내 모든 포스트 불러오는 메서드 작성 -> ChallengePost에 Challenge 외래키 연결 #174

### DIFF
--- a/src/main/java/com/habitpay/habitpay/domain/challengepost/api/ChallengePostApi.java
+++ b/src/main/java/com/habitpay/habitpay/domain/challengepost/api/ChallengePostApi.java
@@ -9,7 +9,6 @@ import com.habitpay.habitpay.global.response.SuccessResponse;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.data.domain.Pageable;
-import org.springframework.data.web.PageableDefault;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.*;
 
@@ -43,7 +42,7 @@ public class ChallengePostApi {
             @PathVariable Long id,
             @AuthenticationPrincipal CustomUserDetails user, Pageable pageable) {
 
-        return challengePostSearchService.findChallengePostsByMember(id, user.getMember(), pageable);
+        return challengePostSearchService.findAllChallengePostsByMember(id, user.getMember(), pageable);
     }
 
     // -----------------------------------------------------------------------------

--- a/src/main/java/com/habitpay/habitpay/domain/challengepost/api/ChallengePostApi.java
+++ b/src/main/java/com/habitpay/habitpay/domain/challengepost/api/ChallengePostApi.java
@@ -46,7 +46,7 @@ public class ChallengePostApi {
             @AuthenticationPrincipal CustomUserDetails user,
             @PageableDefault(sort = "id", direction = Sort.Direction.DESC) Pageable pageable) {
 
-        return challengePostSearchService.findAllChallengePostsByMember(id, user.getMember(), pageable);
+        return challengePostSearchService.findPostViewResponseListByMember(id, user.getMember(), pageable);
     }
 
     // -----------------------------------------------------------------------------

--- a/src/main/java/com/habitpay/habitpay/domain/challengepost/api/ChallengePostApi.java
+++ b/src/main/java/com/habitpay/habitpay/domain/challengepost/api/ChallengePostApi.java
@@ -9,6 +9,8 @@ import com.habitpay.habitpay.global.response.SuccessResponse;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.Sort;
+import org.springframework.data.web.PageableDefault;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.*;
 
@@ -32,7 +34,8 @@ public class ChallengePostApi {
 
     @GetMapping("/api/challenges/{id}/posts")
     public SuccessResponse<List<PostViewResponse>> getChallengePosts(
-            @PathVariable Long id, Pageable pageable) {
+            @PathVariable Long id,
+            @PageableDefault(sort = "id", direction = Sort.Direction.DESC) Pageable pageable) {
 
         return challengePostSearchService.findPostViewResponseListByChallengeId(id, pageable);
     }
@@ -40,7 +43,8 @@ public class ChallengePostApi {
     @GetMapping("/api/challenges/{id}/posts/me")
     public SuccessResponse<List<PostViewResponse>> getChallengePostsByMe(
             @PathVariable Long id,
-            @AuthenticationPrincipal CustomUserDetails user, Pageable pageable) {
+            @AuthenticationPrincipal CustomUserDetails user,
+            @PageableDefault(sort = "id", direction = Sort.Direction.DESC) Pageable pageable) {
 
         return challengePostSearchService.findAllChallengePostsByMember(id, user.getMember(), pageable);
     }
@@ -49,7 +53,8 @@ public class ChallengePostApi {
     // todo : 'challengeEnrollmentId' or 'memberId' 등 멤버 식별할 수 있는 데이터를 받아야 함
 //    @GetMapping("/api/challenges/{id}/posts/member")
 //    public SuccessResponse<List<PostViewResponse>> getChallengePostsByMember(
-//            @PathVariable Long id, Pageable pageable) {
+//            @PathVariable Long id,
+//            @PageableDefault(sort = "id", direction = Sort.Direction.DESC) Pageable pageable) {
 //
 //        String memberEmail = "otherMember@email.address"; // todo : 임시
 //

--- a/src/main/java/com/habitpay/habitpay/domain/challengepost/application/ChallengePostCreationService.java
+++ b/src/main/java/com/habitpay/habitpay/domain/challengepost/application/ChallengePostCreationService.java
@@ -60,7 +60,7 @@ public class ChallengePostCreationService {
             }
         }
 
-        return challengePostRepository.save(request.toEntity(enrollment));
+        return challengePostRepository.save(request.toEntity(challenge, enrollment));
     }
 
 }

--- a/src/main/java/com/habitpay/habitpay/domain/challengepost/application/ChallengePostDeleteService.java
+++ b/src/main/java/com/habitpay/habitpay/domain/challengepost/application/ChallengePostDeleteService.java
@@ -27,7 +27,7 @@ public class ChallengePostDeleteService {
     @Transactional
     public SuccessResponse<Long> deletePost(Long postId, Member member) {
         ChallengePost post = challengePostSearchService.getChallengePostById(postId);
-        Challenge challenge = challengePostSearchService.getChallengeByPostId(postId);
+        Challenge challenge = post.getChallenge();
 
         if (post.getIsAnnouncement()) {
             if (!challengePostUtilService.isChallengeHost(challenge, member)) {

--- a/src/main/java/com/habitpay/habitpay/domain/challengepost/application/ChallengePostSearchService.java
+++ b/src/main/java/com/habitpay/habitpay/domain/challengepost/application/ChallengePostSearchService.java
@@ -97,36 +97,11 @@ public class ChallengePostSearchService {
     // todo : 각 챌린지 별로 findAll 해주는 메서드
     public List<ChallengePost> findAllByChallengeId(Long challengeId, Pageable pageable) {
         return challengePostRepository.findAllByChallengeEnrollmentId(1L, pageable); // todo : 임시값
-
-        // 방법 1 :
-        // 챌린지 아이디를 이용해 챌린지를 찾는다 (DB 검색1)
-        // 챌린지 등록 레포에서 해당 챌린지에 맞는 등록 객체 리스트를 얻는다 (DB 검색2)
-        // 각 등록 객체를 기반으로 포스트 목록을 불러온다 (DB 검색3)
-        // 이걸 또 시간이나 id 순서로 재정렬,,
-
-        // 방법 2 :
-        // 포스트 도메인에 챌린지도 외래키로 연결한다
-        // 챌린지 아이디로 모든 포스트를 찾는다! (DB 검색1)
-
-        // 방법 3 :
-        // DB View 사용하기 (잘 몰라서 학습 필요)
-
-        // 방법 1로 하려고 처음에 DB를 구성했지만, DB 검색을 3번이나 거치는 비용 + 멤버 별 포스트 목록을 각각 불러온 다음 다시 순서대로 리스트업 하는 비용이 클 듯함
-        // 특히 포스트는 아마 전체 도메인 중 가장 많은 DB 객체가 생성되는 도메인이 될 것임
-        // 조회도 자주 발생할 것이라, 많은 양을 자주 조회하는 DB가 될 것,,
-
-        // 조회 성능과 데이터 정합성 중에 선택의 기로
-
-        // 각각 만들어보고 처리 시간 비교해보고 이것저것 고민해야 할 듯 하다
     }
 
     public Challenge getChallengeByPostId(Long postId) {
         ChallengePost post = getChallengePostById(postId);
-        // todo : enrollment service에 findById() 메서드 만들기
-        ChallengeEnrollment enrollment = challengeEnrollmentRepository
-                .findById(post.getChallengeEnrollment().getId())
-                .orElseThrow(() -> new NoSuchElementException("포스트 소속 정보를 찾을 수 없습니다."));
-        return enrollment.getChallenge();
+        return post.getChallenge();
     }
 
 }

--- a/src/main/java/com/habitpay/habitpay/domain/challengepost/application/ChallengePostSearchService.java
+++ b/src/main/java/com/habitpay/habitpay/domain/challengepost/application/ChallengePostSearchService.java
@@ -3,12 +3,10 @@ package com.habitpay.habitpay.domain.challengepost.application;
 import com.habitpay.habitpay.domain.challenge.application.ChallengeSearchService;
 import com.habitpay.habitpay.domain.challenge.domain.Challenge;
 import com.habitpay.habitpay.domain.challengeenrollment.application.ChallengeEnrollmentSearchService;
-import com.habitpay.habitpay.domain.challengeenrollment.dao.ChallengeEnrollmentRepository;
 import com.habitpay.habitpay.domain.challengeenrollment.domain.ChallengeEnrollment;
 import com.habitpay.habitpay.domain.challengepost.dao.ChallengePostRepository;
 import com.habitpay.habitpay.domain.challengepost.domain.ChallengePost;
 import com.habitpay.habitpay.domain.challengepost.dto.PostViewResponse;
-import com.habitpay.habitpay.domain.member.application.MemberService;
 import com.habitpay.habitpay.domain.member.domain.Member;
 import com.habitpay.habitpay.domain.postphoto.application.PostPhotoSearchService;
 import com.habitpay.habitpay.domain.postphoto.application.PostPhotoUtilService;
@@ -17,10 +15,7 @@ import com.habitpay.habitpay.domain.postphoto.dto.PostPhotoView;
 import com.habitpay.habitpay.global.response.SuccessResponse;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
-import org.springframework.data.domain.Page;
-import org.springframework.data.domain.PageRequest;
 import org.springframework.data.domain.Pageable;
-import org.springframework.data.web.PageableHandlerMethodArgumentResolver;
 import org.springframework.stereotype.Service;
 
 import java.util.List;
@@ -51,10 +46,8 @@ public class ChallengePostSearchService {
 
     public SuccessResponse<List<PostViewResponse>> findPostViewResponseListByChallengeId(Long challengeId, Pageable pageable) {
 
-        List<PostViewResponse> postViewResponseList = this.findAllByChallengeId(challengeId, pageable)
+        List<PostViewResponse> postViewResponseList = this.findAllChallengePostsByChallengeId(challengeId, pageable)
                 .stream()
-                // .filter(post -> !post.getIsAnnouncement()) // todo
-                // .sorted() // todo : 순서 설정하고 싶을 때
                 .map(post -> {
                     List<PostPhotoView> photoViewList = postPhotoUtilService.makePhotoViewList(postPhotoSearchService.findAllByPost(post));
                     return new PostViewResponse(post, photoViewList);
@@ -67,7 +60,7 @@ public class ChallengePostSearchService {
         );
     }
 
-    public SuccessResponse<List<PostViewResponse>> findChallengePostsByMember(Long challengeId, Member member, Pageable pageable) {
+    public SuccessResponse<List<PostViewResponse>> findAllChallengePostsByMember(Long challengeId, Member member, Pageable pageable) {
         Challenge challenge = challengeSearchService.getChallengeById(challengeId);
         ChallengeEnrollment enrollment = challengeEnrollmentSearchService.findByMemberAndChallenge(member, challenge)
                 .orElseThrow(() -> new NoSuchElementException("챌린지에 등록된 멤버가 아닙니다."));
@@ -76,8 +69,6 @@ public class ChallengePostSearchService {
 
         List<PostViewResponse> postViewResponseList =  challengePostRepository.findAllByChallengeEnrollmentId(challengeEnrollmentId, pageable)
                 .stream()
-                // .filter(post -> !post.getIsAnnouncement()) // todo
-                // .sorted() // todo : 순서 설정하고 싶을 때
                 .map(post -> {
                     List<PostPhotoView> photoViewList = postPhotoUtilService.makePhotoViewList(postPhotoSearchService.findAllByPost(post));
                     return new PostViewResponse(post, photoViewList);
@@ -95,7 +86,7 @@ public class ChallengePostSearchService {
                 .orElseThrow(() -> new NoSuchElementException("포스트를 찾을 수 없습니다."));
     }
 
-    public List<ChallengePost> findAllByChallengeId(Long challengeId, Pageable pageable) {
+    public List<ChallengePost> findAllChallengePostsByChallengeId(Long challengeId, Pageable pageable) {
         return challengePostRepository.findAllByChallengeId(challengeId, pageable);
     }
 

--- a/src/main/java/com/habitpay/habitpay/domain/challengepost/application/ChallengePostSearchService.java
+++ b/src/main/java/com/habitpay/habitpay/domain/challengepost/application/ChallengePostSearchService.java
@@ -46,7 +46,7 @@ public class ChallengePostSearchService {
 
     public SuccessResponse<List<PostViewResponse>> findPostViewResponseListByChallengeId(Long challengeId, Pageable pageable) {
 
-        List<PostViewResponse> postViewResponseList = this.findAllChallengePostsByChallengeId(challengeId, pageable)
+        List<PostViewResponse> postViewResponseList = challengePostRepository.findAllByChallengeId(challengeId, pageable)
                 .stream()
                 .map(post -> {
                     List<PostPhotoView> photoViewList = postPhotoUtilService.makePhotoViewList(postPhotoSearchService.findAllByPost(post));
@@ -84,10 +84,6 @@ public class ChallengePostSearchService {
     public ChallengePost getChallengePostById(Long id) {
         return challengePostRepository.findById(id)
                 .orElseThrow(() -> new NoSuchElementException("포스트를 찾을 수 없습니다."));
-    }
-
-    public List<ChallengePost> findAllChallengePostsByChallengeId(Long challengeId, Pageable pageable) {
-        return challengePostRepository.findAllByChallengeId(challengeId, pageable);
     }
 
     public Challenge getChallengeByPostId(Long postId) {

--- a/src/main/java/com/habitpay/habitpay/domain/challengepost/application/ChallengePostSearchService.java
+++ b/src/main/java/com/habitpay/habitpay/domain/challengepost/application/ChallengePostSearchService.java
@@ -18,7 +18,9 @@ import com.habitpay.habitpay.global.response.SuccessResponse;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageRequest;
 import org.springframework.data.domain.Pageable;
+import org.springframework.data.web.PageableHandlerMethodArgumentResolver;
 import org.springframework.stereotype.Service;
 
 import java.util.List;
@@ -35,7 +37,6 @@ public class ChallengePostSearchService {
     private final ChallengeSearchService challengeSearchService;
 
     private final ChallengePostRepository challengePostRepository;
-    private final ChallengeEnrollmentRepository challengeEnrollmentRepository;
 
     public SuccessResponse<PostViewResponse> getPostViewResponseByPostId(Long postId) {
         ChallengePost challengePost = this.getChallengePostById(postId);
@@ -94,9 +95,8 @@ public class ChallengePostSearchService {
                 .orElseThrow(() -> new NoSuchElementException("포스트를 찾을 수 없습니다."));
     }
 
-    // todo : 각 챌린지 별로 findAll 해주는 메서드
     public List<ChallengePost> findAllByChallengeId(Long challengeId, Pageable pageable) {
-        return challengePostRepository.findAllByChallengeEnrollmentId(1L, pageable); // todo : 임시값
+        return challengePostRepository.findAllByChallengeId(challengeId, pageable);
     }
 
     public Challenge getChallengeByPostId(Long postId) {

--- a/src/main/java/com/habitpay/habitpay/domain/challengepost/application/ChallengePostSearchService.java
+++ b/src/main/java/com/habitpay/habitpay/domain/challengepost/application/ChallengePostSearchService.java
@@ -60,7 +60,7 @@ public class ChallengePostSearchService {
         );
     }
 
-    public SuccessResponse<List<PostViewResponse>> findAllChallengePostsByMember(Long challengeId, Member member, Pageable pageable) {
+    public SuccessResponse<List<PostViewResponse>> findPostViewResponseListByMember(Long challengeId, Member member, Pageable pageable) {
         Challenge challenge = challengeSearchService.getChallengeById(challengeId);
         ChallengeEnrollment enrollment = challengeEnrollmentSearchService.findByMemberAndChallenge(member, challenge)
                 .orElseThrow(() -> new NoSuchElementException("챌린지에 등록된 멤버가 아닙니다."));

--- a/src/main/java/com/habitpay/habitpay/domain/challengepost/dao/ChallengePostRepository.java
+++ b/src/main/java/com/habitpay/habitpay/domain/challengepost/dao/ChallengePostRepository.java
@@ -14,4 +14,5 @@ import java.util.Optional;
 public interface ChallengePostRepository extends JpaRepository<ChallengePost, Long> {
     // todo : Page, Slice, List 중에 선택하기
     List<ChallengePost> findAllByChallengeEnrollmentId(Long challengeEnrollmentId, Pageable pageable);
+    List<ChallengePost> findAllByChallengeId(Long challengeId, Pageable pageable);
 }

--- a/src/main/java/com/habitpay/habitpay/domain/challengepost/domain/ChallengePost.java
+++ b/src/main/java/com/habitpay/habitpay/domain/challengepost/domain/ChallengePost.java
@@ -1,5 +1,6 @@
 package com.habitpay.habitpay.domain.challengepost.domain;
 
+import com.habitpay.habitpay.domain.challenge.domain.Challenge;
 import com.habitpay.habitpay.domain.challengeenrollment.domain.ChallengeEnrollment;
 import com.habitpay.habitpay.domain.member.domain.Member;
 import com.habitpay.habitpay.domain.model.BaseTime;
@@ -11,14 +12,18 @@ import lombok.NoArgsConstructor;
 import org.springframework.data.jpa.domain.support.AuditingEntityListener;
 
 @EntityListeners(AuditingEntityListener.class)
-@Getter
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 @Entity
+@Getter
 @Table(name = "challenge_post")
 public class ChallengePost extends BaseTime {
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;
+
+    @ManyToOne
+    @JoinColumn(name = "challenge_id")
+    private Challenge challenge;
 
     @ManyToOne
     @JoinColumn(name = "challenge_enrollment_id")
@@ -31,7 +36,12 @@ public class ChallengePost extends BaseTime {
     private Boolean isAnnouncement;
 
     @Builder
-    public ChallengePost(ChallengeEnrollment enrollment, String content, boolean isAnnouncement) {
+    public ChallengePost(
+            Challenge challenge,
+            ChallengeEnrollment enrollment,
+            String content,
+            boolean isAnnouncement) {
+        this.challenge = challenge;
         this.challengeEnrollment = enrollment;
         this.content = content;
         this.isAnnouncement = isAnnouncement;

--- a/src/main/java/com/habitpay/habitpay/domain/challengepost/dto/AddPostRequest.java
+++ b/src/main/java/com/habitpay/habitpay/domain/challengepost/dto/AddPostRequest.java
@@ -1,5 +1,6 @@
 package com.habitpay.habitpay.domain.challengepost.dto;
 
+import com.habitpay.habitpay.domain.challenge.domain.Challenge;
 import com.habitpay.habitpay.domain.challengeenrollment.domain.ChallengeEnrollment;
 import com.habitpay.habitpay.domain.challengepost.domain.ChallengePost;
 import com.habitpay.habitpay.domain.postphoto.dto.AddPostPhotoData;
@@ -19,10 +20,11 @@ public class AddPostRequest {
     private Boolean isAnnouncement;
     private List<AddPostPhotoData> photos;
 
-    public ChallengePost toEntity(ChallengeEnrollment enrollment) {
+    public ChallengePost toEntity(Challenge challenge, ChallengeEnrollment enrollment) {
         return ChallengePost.builder()
                 .content(content)
                 .isAnnouncement(isAnnouncement)
+                .challenge(challenge)
                 .enrollment(enrollment)
                 .build();
     }

--- a/src/test/java/com/habitpay/habitpay/domain/challegepost/api/ChallengePostApiTest.java
+++ b/src/test/java/com/habitpay/habitpay/domain/challegepost/api/ChallengePostApiTest.java
@@ -194,7 +194,7 @@ public class ChallengePostApiTest extends AbstractRestDocsTests {
                         .photoViewList(List.of(new PostPhotoView(2L, 2L, "https://picsum.photos/id/40/200/300")))
                         .build());
 
-        given(challengePostSearchService.findAllChallengePostsByMember(anyLong(), any(Member.class), any(Pageable.class)))
+        given(challengePostSearchService.findPostViewResponseListByMember(anyLong(), any(Member.class), any(Pageable.class)))
                 .willReturn(SuccessResponse.of("", mockPostViewResponseList));
 
         // when

--- a/src/test/java/com/habitpay/habitpay/domain/challegepost/api/ChallengePostApiTest.java
+++ b/src/test/java/com/habitpay/habitpay/domain/challegepost/api/ChallengePostApiTest.java
@@ -194,7 +194,7 @@ public class ChallengePostApiTest extends AbstractRestDocsTests {
                         .photoViewList(List.of(new PostPhotoView(2L, 2L, "https://picsum.photos/id/40/200/300")))
                         .build());
 
-        given(challengePostSearchService.findChallengePostsByMember(anyLong(), any(Member.class), any(Pageable.class)))
+        given(challengePostSearchService.findAllChallengePostsByMember(anyLong(), any(Member.class), any(Pageable.class)))
                 .willReturn(SuccessResponse.of("", mockPostViewResponseList));
 
         // when


### PR DESCRIPTION
### 작업 개요

* `ChallengePost` 도메인에 `Challenge` 도메인을 외래키로 연결했습니다.
    (`Challenge id` 외래키를 이용해 DB에서 빠르게 조회하기 위한 목적)
* 챌린지 내 모든 포스트를 불러오는 메서드인  `findAllChallengePostsByChallengeId`를 수정했습니다.

---

### 코드 주요 내용

* 챌린지 포스트 도메인에 챌린지 도메인을 외래키로 연결

```java
public class ChallengePost extends BaseTime {
    ...
    @ManyToOne
    @JoinColumn(name = "challenge_id")
    private Challenge challenge;
    ...
}
```
* 도메인 변경으로 수정이 필요한 연관 코드도 손봤습니다.
---

* 챌린지 도메인이 외래키로 연결된 덕분에, `Challenge Id` 기준으로 DB 조회가 쉬워졌습니다.

```java
public interface ChallengePostRepository extends JpaRepository<ChallengePost, Long> {
    ....
    List<ChallengePost> findAllByChallengeId(Long challengeId, Pageable pageable);
}
```

---

* 챌린지 내 전체 포스트를 불러오는 메서드는, 위의 repository 메서드를 활용하도록 수정했습니다.

```java
public SuccessResponse<List<PostViewResponse>> findPostViewResponseListByChallengeId(Long challengeId, Pageable pageable) {

    List<PostViewResponse> postViewResponseList = challengePostRepository.findAllByChallengeId(challengeId, pageable)
            .stream()
            ...
            .toList();

    return SuccessResponse.of(
            "",
            postViewResponseList
    );
}
```

---

### 기타

* 데이터 반환 타입을 반영하지 못하는 메서드 이름을 맞게 수정했습니다.

```java
@GetMapping("/api/challenges/{id}/posts/me")
public SuccessResponse<List<PostViewResponse>> getChallengePostsByMe(...) {

    // before
    return challengePostSearchService.findChallengePostsByMember(...);

    // after
    return challengePostSearchService.findPostViewResponseListByMember(...);
    }
```

---

* `Pageable`에 `챌린지 포스트 id`를 기준으로 `내림차순`해서 정렬하도록 디폴트 값을 설정했습니다.

```java
@GetMapping("/api/challenges/{id}/posts")
public SuccessResponse<List<PostViewResponse>> getChallengePosts(
        @PathVariable Long id,
        @PageableDefault(sort = "id", direction = Sort.Direction.DESC) Pageable pageable) {
    ...
    }
```