### PR TITLE
[Feat] 챌린지 내 공지 포스트만 불러오는 메서드 및 테스트 코드 작성 #178

### DIFF
--- a/src/docs/asciidoc/api/challengePost.adoc
+++ b/src/docs/asciidoc/api/challengePost.adoc
@@ -22,6 +22,13 @@ operation::challengePost/get-challenge-post[snippets='http-request,http-response
 
 operation::challengePost/get-challenge-posts[snippets='http-request,http-response,response-fields']
 
+=== 챌린지 내 전체 포스트 중 공지 포스트 조회
+
+경로 변수로 받은 challenge의 id값을 이용해 해당 챌린지 내의 모든 공지 포스트를 조회합니다.
+해당 챌린지에 등록되어 있는 멤버만 조회할 수 있습니다.
+
+operation::challengePost/get-announcement-challenge-posts[snippets='http-request,http-response,response-fields']
+
 === 챌린지 내 본인이 작성한 모든 포스트 조회
 
 경로 변수로 받은 challenge의 id값을 이용해 해당 챌린지 내에서 본인이 작성한 모든 포스트를 조회합니다.

--- a/src/main/java/com/habitpay/habitpay/domain/challengepost/api/ChallengePostApi.java
+++ b/src/main/java/com/habitpay/habitpay/domain/challengepost/api/ChallengePostApi.java
@@ -40,6 +40,15 @@ public class ChallengePostApi {
         return challengePostSearchService.findPostViewResponseListByChallengeId(id, pageable);
     }
 
+    @GetMapping("/api/challenges/{id}/posts/announcement")
+    public SuccessResponse<List<PostViewResponse>> getAnnouncementPosts(
+            @PathVariable Long id,
+            @AuthenticationPrincipal CustomUserDetails user,
+            @PageableDefault(sort = "id", direction = Sort.Direction.DESC) Pageable pageable) {
+
+        return ;
+    }
+
     @GetMapping("/api/challenges/{id}/posts/me")
     public SuccessResponse<List<PostViewResponse>> getChallengePostsByMe(
             @PathVariable Long id,

--- a/src/main/java/com/habitpay/habitpay/domain/challengepost/api/ChallengePostApi.java
+++ b/src/main/java/com/habitpay/habitpay/domain/challengepost/api/ChallengePostApi.java
@@ -29,7 +29,7 @@ public class ChallengePostApi {
     @GetMapping("/api/posts/{id}")
     public SuccessResponse<PostViewResponse> getPost(@PathVariable Long id) {
 
-        return challengePostSearchService.getPostViewResponseByPostId(id);
+        return challengePostSearchService.getPostViewByPostId(id);
     }
 
     @GetMapping("/api/challenges/{id}/posts")
@@ -37,7 +37,7 @@ public class ChallengePostApi {
             @PathVariable Long id,
             @PageableDefault(sort = "id", direction = Sort.Direction.DESC) Pageable pageable) {
 
-        return challengePostSearchService.findPostViewResponseListByChallengeId(id, pageable);
+        return challengePostSearchService.findPostViewListByChallengeId(id, pageable);
     }
 
     @GetMapping("/api/challenges/{id}/posts/announcement")
@@ -45,7 +45,7 @@ public class ChallengePostApi {
             @PathVariable Long id,
             @PageableDefault(sort = "id", direction = Sort.Direction.DESC) Pageable pageable) {
 
-        return challengePostSearchService.findAnnouncementPostViewResponseListByChallengeId(id, pageable);
+        return challengePostSearchService.findAnnouncementPostViewListByChallengeId(id, pageable);
     }
 
     @GetMapping("/api/challenges/{id}/posts/me")
@@ -54,7 +54,7 @@ public class ChallengePostApi {
             @AuthenticationPrincipal CustomUserDetails user,
             @PageableDefault(sort = "id", direction = Sort.Direction.DESC) Pageable pageable) {
 
-        return challengePostSearchService.findPostViewResponseListByMember(id, user.getMember(), pageable);
+        return challengePostSearchService.findPostViewListByMember(id, user.getMember(), pageable);
     }
 
     // -----------------------------------------------------------------------------

--- a/src/main/java/com/habitpay/habitpay/domain/challengepost/api/ChallengePostApi.java
+++ b/src/main/java/com/habitpay/habitpay/domain/challengepost/api/ChallengePostApi.java
@@ -43,10 +43,9 @@ public class ChallengePostApi {
     @GetMapping("/api/challenges/{id}/posts/announcement")
     public SuccessResponse<List<PostViewResponse>> getAnnouncementPosts(
             @PathVariable Long id,
-            @AuthenticationPrincipal CustomUserDetails user,
             @PageableDefault(sort = "id", direction = Sort.Direction.DESC) Pageable pageable) {
 
-        return ;
+        return challengePostSearchService.findAnnouncementPostViewResponseListByChallengeId(id, pageable);
     }
 
     @GetMapping("/api/challenges/{id}/posts/me")

--- a/src/main/java/com/habitpay/habitpay/domain/challengepost/application/ChallengePostSearchService.java
+++ b/src/main/java/com/habitpay/habitpay/domain/challengepost/application/ChallengePostSearchService.java
@@ -33,7 +33,7 @@ public class ChallengePostSearchService {
 
     private final ChallengePostRepository challengePostRepository;
 
-    public SuccessResponse<PostViewResponse> getPostViewResponseByPostId(Long postId) {
+    public SuccessResponse<PostViewResponse> getPostViewByPostId(Long postId) {
         ChallengePost challengePost = this.getChallengePostById(postId);
         List<PostPhoto> photoList = postPhotoSearchService.findAllByPost(challengePost);
         List<PostPhotoView> photoViewList = postPhotoUtilService.makePhotoViewList(photoList);
@@ -44,7 +44,7 @@ public class ChallengePostSearchService {
         );
     }
 
-    public SuccessResponse<List<PostViewResponse>> findPostViewResponseListByChallengeId(Long challengeId, Pageable pageable) {
+    public SuccessResponse<List<PostViewResponse>> findPostViewListByChallengeId(Long challengeId, Pageable pageable) {
 
         List<PostViewResponse> postViewResponseList = challengePostRepository.findAllByChallengeId(challengeId, pageable)
                 .stream()
@@ -60,7 +60,7 @@ public class ChallengePostSearchService {
         );
     }
 
-    public SuccessResponse<List<PostViewResponse>> findAnnouncementPostViewResponseListByChallengeId(Long challengeId, Pageable pageable) {
+    public SuccessResponse<List<PostViewResponse>> findAnnouncementPostViewListByChallengeId(Long challengeId, Pageable pageable) {
 
         List<PostViewResponse> postViewResponseList = challengePostRepository.findAllByChallengeIdAndIsAnnouncementTrue(challengeId, pageable)
                 .stream()
@@ -76,7 +76,7 @@ public class ChallengePostSearchService {
         );
     }
 
-    public SuccessResponse<List<PostViewResponse>> findPostViewResponseListByMember(Long challengeId, Member member, Pageable pageable) {
+    public SuccessResponse<List<PostViewResponse>> findPostViewListByMember(Long challengeId, Member member, Pageable pageable) {
         Challenge challenge = challengeSearchService.getChallengeById(challengeId);
         ChallengeEnrollment enrollment = challengeEnrollmentSearchService.findByMemberAndChallenge(member, challenge)
                 .orElseThrow(() -> new NoSuchElementException("챌린지에 등록된 멤버가 아닙니다."));

--- a/src/main/java/com/habitpay/habitpay/domain/challengepost/application/ChallengePostSearchService.java
+++ b/src/main/java/com/habitpay/habitpay/domain/challengepost/application/ChallengePostSearchService.java
@@ -60,6 +60,22 @@ public class ChallengePostSearchService {
         );
     }
 
+    public SuccessResponse<List<PostViewResponse>> findAnnouncementPostViewResponseListByChallengeId(Long challengeId, Pageable pageable) {
+
+        List<PostViewResponse> postViewResponseList = challengePostRepository.findAllByChallengeIdAndIsAnnouncementTrue(challengeId, pageable)
+                .stream()
+                .map(post -> {
+                    List<PostPhotoView> photoViewList = postPhotoUtilService.makePhotoViewList(postPhotoSearchService.findAllByPost(post));
+                    return new PostViewResponse(post, photoViewList);
+                })
+                .toList();
+
+        return SuccessResponse.of(
+                "",
+                postViewResponseList
+        );
+    }
+
     public SuccessResponse<List<PostViewResponse>> findPostViewResponseListByMember(Long challengeId, Member member, Pageable pageable) {
         Challenge challenge = challengeSearchService.getChallengeById(challengeId);
         ChallengeEnrollment enrollment = challengeEnrollmentSearchService.findByMemberAndChallenge(member, challenge)

--- a/src/main/java/com/habitpay/habitpay/domain/challengepost/dao/ChallengePostRepository.java
+++ b/src/main/java/com/habitpay/habitpay/domain/challengepost/dao/ChallengePostRepository.java
@@ -15,4 +15,5 @@ public interface ChallengePostRepository extends JpaRepository<ChallengePost, Lo
     // todo : Page, Slice, List 중에 선택하기
     List<ChallengePost> findAllByChallengeEnrollmentId(Long challengeEnrollmentId, Pageable pageable);
     List<ChallengePost> findAllByChallengeId(Long challengeId, Pageable pageable);
+    List<ChallengePost> findAllByChallengeIdAndIsAnnouncementTrue(Long challengeId, Pageable pageable);
 }

--- a/src/test/java/com/habitpay/habitpay/domain/challegepost/api/ChallengePostApiTest.java
+++ b/src/test/java/com/habitpay/habitpay/domain/challegepost/api/ChallengePostApiTest.java
@@ -169,6 +169,60 @@ public class ChallengePostApiTest extends AbstractRestDocsTests {
     }
 
     @Test
+    @DisplayName("챌린지 내 전체 포스트 중 공지 포스트 조회")
+    void findAnnouncementPosts() throws Exception {
+
+        // given
+        List<PostViewResponse> mockPostViewResponseList = List.of(
+                PostViewResponse.builder()
+                        .id(1L)
+                        .challengeEnrollmentId(1L)
+                        .content("This is announcement test post 1.")
+                        .writer("test user")
+                        .isAnnouncement(true)
+                        .createdAt(LocalDateTime.now())
+                        .photoViewList(List.of(new PostPhotoView(1L, 1L, "https://picsum.photos/id/40/200/300")))
+                        .build(),
+                PostViewResponse.builder()
+                        .id(2L)
+                        .challengeEnrollmentId(2L)
+                        .content("This is announcement test post 2.")
+                        .writer("test user")
+                        .isAnnouncement(true)
+                        .createdAt(LocalDateTime.now())
+                        .photoViewList(List.of(new PostPhotoView(2L, 2L, "https://picsum.photos/id/40/200/300")))
+                        .build());
+
+        given(challengePostSearchService.findAnnouncementPostViewResponseListByChallengeId(anyLong(), any(Pageable.class)))
+                .willReturn(SuccessResponse.of("", mockPostViewResponseList));
+
+        // when
+        ResultActions result = mockMvc.perform(get("/api/challenges/{id}/posts/announcement", 1L)
+                .header(HttpHeaders.AUTHORIZATION, AUTHORIZATION_HEADER_PREFIX + "ACCESS_TOKEN"));
+
+        //then
+        result.andExpect(status().isOk())
+                .andDo(document("challengePost/get-announcement-challenge-posts",
+                        requestHeaders(
+                                headerWithName(HttpHeaders.AUTHORIZATION).description("액세스 토큰")
+                        ),
+                        responseFields(
+                                fieldWithPath("message").description("메시지"),
+                                fieldWithPath("data.[].id").description("포스트 id"),
+                                fieldWithPath("data.[].challengeEnrollmentId").description("포스트가 소속된 enrollment id"),
+                                fieldWithPath("data.[].content").description("포스트 내용"),
+                                fieldWithPath("data.[].writer").description("작성자"),
+                                fieldWithPath("data.[].isAnnouncement").description("공지글 여부"),
+                                fieldWithPath("data.[].createdAt").description("생성 일시"),
+                                fieldWithPath("data.[].photoViewList").description("포스트 포토(URL 포함) 데이터를 담은 객체 배열"),
+                                fieldWithPath("data.[].photoViewList[].postPhotoId").description("포토 id"),
+                                fieldWithPath("data.[].photoViewList[].viewOrder").description("포스트 내 포토의 순서"),
+                                fieldWithPath("data.[].photoViewList[].imageUrl").description("포스트 포토 url")
+                        )
+                ));
+    }
+
+    @Test
     @WithMockOAuth2User
     @DisplayName("챌린지 내 본인이 작성한 모든 포스트 조회")
     void findChallengePostsByMe() throws Exception {

--- a/src/test/java/com/habitpay/habitpay/domain/challegepost/api/ChallengePostApiTest.java
+++ b/src/test/java/com/habitpay/habitpay/domain/challegepost/api/ChallengePostApiTest.java
@@ -85,7 +85,7 @@ public class ChallengePostApiTest extends AbstractRestDocsTests {
                         new PostPhotoView(2L, 2L, "https://picsum.photos/id/40/200/300")))
                 .build();
 
-        given(challengePostSearchService.getPostViewResponseByPostId(anyLong()))
+        given(challengePostSearchService.getPostViewByPostId(anyLong()))
                 .willReturn(SuccessResponse.of("", mockPostViewResponse));
 
         // when
@@ -139,7 +139,7 @@ public class ChallengePostApiTest extends AbstractRestDocsTests {
                         .photoViewList(List.of(new PostPhotoView(2L, 2L, "https://picsum.photos/id/40/200/300")))
                         .build());
 
-        given(challengePostSearchService.findPostViewResponseListByChallengeId(anyLong(), any(Pageable.class)))
+        given(challengePostSearchService.findPostViewListByChallengeId(anyLong(), any(Pageable.class)))
                 .willReturn(SuccessResponse.of("", mockPostViewResponseList));
 
         // when
@@ -193,7 +193,7 @@ public class ChallengePostApiTest extends AbstractRestDocsTests {
                         .photoViewList(List.of(new PostPhotoView(2L, 2L, "https://picsum.photos/id/40/200/300")))
                         .build());
 
-        given(challengePostSearchService.findAnnouncementPostViewResponseListByChallengeId(anyLong(), any(Pageable.class)))
+        given(challengePostSearchService.findAnnouncementPostViewListByChallengeId(anyLong(), any(Pageable.class)))
                 .willReturn(SuccessResponse.of("", mockPostViewResponseList));
 
         // when
@@ -248,7 +248,7 @@ public class ChallengePostApiTest extends AbstractRestDocsTests {
                         .photoViewList(List.of(new PostPhotoView(2L, 2L, "https://picsum.photos/id/40/200/300")))
                         .build());
 
-        given(challengePostSearchService.findPostViewResponseListByMember(anyLong(), any(Member.class), any(Pageable.class)))
+        given(challengePostSearchService.findPostViewListByMember(anyLong(), any(Member.class), any(Pageable.class)))
                 .willReturn(SuccessResponse.of("", mockPostViewResponseList));
 
         // when


### PR DESCRIPTION
### 작업 개요

* 챌린지 내에서 공지 포스트만 불러오는 API를 작성했습니다.

---

### 코드 주요 내용

* 컨트롤러 메서드는 다음과 같습니다.
* `"/api/challenges/{id}/posts/announcement"` url을 사용합니다.

```java
@GetMapping("/api/challenges/{id}/posts/announcement")
public SuccessResponse<List<PostViewResponse>> getAnnouncementPosts(
        @PathVariable Long id,
        @PageableDefault(sort = "id", direction = Sort.Direction.DESC) Pageable pageable) {

    return challengePostSearchService.findAnnouncementPostViewListByChallengeId(id, pageable);
    }
```

---

* 서비스 메서드인 `findAnnouncementPostViewListByChallengeId`는
   `findPostViewListByChallengeId`과 거의 동일합니다.
    불러오는 레포지토리 메서드만 다릅니다.
* 레포지토리 메서드는 쿼리 메서드를 이용합니다.

```java
public interface ChallengePostRepository extends JpaRepository<ChallengePost, Long> {
    ...
    List<ChallengePost> findAllByChallengeIdAndIsAnnouncementTrue(Long challengeId, Pageable pageable);
}
```

---

### 기타

* `PostViewReponse` 타입을 반환하는 메서드는 이름에 타입명이 full로 들어갔습니다.
* 그런데 점차 메서드명이 길어지며 가독성이 떨어지는 문제가 발생했습니다.
* 그래서 타입의 핵심 단어인 `PostView`만 남기고, `Reponse`는 삭제하는 방식으로 리팩토링 했습니다.

```java
// ex

findPostViewResponseListByChallengeId

=>

findPostViewListByChallengeId
```