### PR TITLE
[Feat] 피드백 반영이자 리팩토링 #180

### DIFF
--- a/src/main/java/com/habitpay/habitpay/domain/refreshtoken/application/RefreshTokenCreationService.java
+++ b/src/main/java/com/habitpay/habitpay/domain/refreshtoken/application/RefreshTokenCreationService.java
@@ -45,9 +45,8 @@ public class RefreshTokenCreationService {
             throw new CustomJwtException(HttpStatus.BAD_REQUEST, CustomJwtErrorInfo.BAD_REQUEST, "인증 방법을 알 수 없습니다.");
         }
 
-        if (!grantType.equalsIgnoreCase("refreshToken")
-                && !grantType.equalsIgnoreCase("refresh_token")) {
-            throw new CustomJwtException(HttpStatus.BAD_REQUEST, CustomJwtErrorInfo.BAD_REQUEST, "인증 방법을 알 수 없습니다.");
+        if (!grantType.equals("refreshToken")) {
+            throw new CustomJwtException(HttpStatus.BAD_REQUEST, CustomJwtErrorInfo.BAD_REQUEST, "취급할 수 없는 인증 방법입니다.");
         }
 
         String newAccessToken = this.createNewAccessToken(requestBody.getRefreshToken());

--- a/src/test/java/com/habitpay/habitpay/domain/refreshtoken/api/RefreshTokenApiTest.java
+++ b/src/test/java/com/habitpay/habitpay/domain/refreshtoken/api/RefreshTokenApiTest.java
@@ -48,12 +48,6 @@ public class RefreshTokenApiTest extends AbstractRestDocsTests {
     void createNewAccessTokenAndNewRefreshToken() throws Exception {
 
         //given
-        Member mockMember = Member.builder()
-                .id(1L)
-                .nickname("test user")
-                .email("test_user@test.com")
-                .build();
-
         CreateAccessTokenRequest tokenRequest = CreateAccessTokenRequest.builder()
                 .grantType("refreshToken")
                 .refreshToken("eyJhbGciOiJIUzI1NiJ9.eyJ1c2VyIjoiYWxpY2UifQ.DUMMY_SIGNATURE2")


### PR DESCRIPTION
### 내용

* 리프레시 토큰 API 테스트 코드에 있던 사용하지 않는 변수인 Member 객체를 삭제했습니다.
* 토큰 리프레시 요청 시 클라이언트가 요청 본문에 담아 보내는 `grant type` 값이 `refreshToken`과 동일할 때만 통과시키도록 변경했습니다.
```java
if (!grantType.equals("refreshToken")) {
    throw new CustomJwtException(HttpStatus.BAD_REQUEST, CustomJwtErrorInfo.BAD_REQUEST, "취급할 수 없는 인증 방법입니다.");
```