### PR TITLE
refactor: 챌린지 전체 참여 요일 수 변수명 변경 #182

### DIFF
--- a/src/main/java/com/habitpay/habitpay/domain/challenge/domain/Challenge.java
+++ b/src/main/java/com/habitpay/habitpay/domain/challenge/domain/Challenge.java
@@ -50,7 +50,7 @@ public class Challenge extends BaseTime {
     private byte participatingDays;
 
     @Column(nullable = false)
-    private int totalParticipatingDays;
+    private int totalParticipatingDaysCount;
 
     @Column(nullable = false)
     private int feePerAbsence;
@@ -63,14 +63,14 @@ public class Challenge extends BaseTime {
 
     @Builder
     public Challenge(Member member, String title, String description, ZonedDateTime startDate, ZonedDateTime endDate,
-                     byte participatingDays, int totalParticipatingDays, int feePerAbsence) {
+                     byte participatingDays, int totalParticipatingDaysCount, int feePerAbsence) {
         this.host = member;
         this.title = title;
         this.description = description;
         this.startDate = startDate;
         this.endDate = endDate;
         this.participatingDays = participatingDays;
-        this.totalParticipatingDays = totalParticipatingDays;
+        this.totalParticipatingDaysCount = totalParticipatingDaysCount;
         this.feePerAbsence = feePerAbsence;
     }
 
@@ -82,7 +82,7 @@ public class Challenge extends BaseTime {
                 .startDate(challengeCreationRequest.getStartDate())
                 .endDate(challengeCreationRequest.getEndDate())
                 .participatingDays(challengeCreationRequest.getParticipatingDays())
-                .totalParticipatingDays(calculateTotalParticipatingDays(challengeCreationRequest))
+                .totalParticipatingDaysCount(calculateTotalParticipatingDays(challengeCreationRequest))
                 .feePerAbsence(challengeCreationRequest.getFeePerAbsence())
                 .build();
     }

--- a/src/main/java/com/habitpay/habitpay/domain/challenge/dto/ChallengeEnrolledListItemResponse.java
+++ b/src/main/java/com/habitpay/habitpay/domain/challenge/dto/ChallengeEnrolledListItemResponse.java
@@ -15,7 +15,7 @@ public class ChallengeEnrolledListItemResponse {
     private ZonedDateTime startDate;
     private ZonedDateTime endDate;
     private ZonedDateTime stopDate;
-    private int totalParticipatingDays;
+    private int totalParticipatingDaysCount;
     private int numberOfParticipants;
     private int participatingDays;
     private int totalFee;
@@ -33,7 +33,7 @@ public class ChallengeEnrolledListItemResponse {
                 .startDate(challenge.getStartDate())
                 .endDate(challenge.getEndDate())
                 .stopDate(challenge.getStopDate())
-                .totalParticipatingDays(challenge.getTotalParticipatingDays())
+                .totalParticipatingDaysCount(challenge.getTotalParticipatingDaysCount())
                 .numberOfParticipants(challenge.getNumberOfParticipants())
                 .isPaidAll(challenge.isPaidAll())
                 .participatingDays(challenge.getParticipatingDays())

--- a/src/test/java/com/habitpay/habitpay/domain/challenge/api/ChallengeApiTest.java
+++ b/src/test/java/com/habitpay/habitpay/domain/challenge/api/ChallengeApiTest.java
@@ -72,7 +72,7 @@ public class ChallengeApiTest extends AbstractRestDocsTests {
                 .startDate(ZonedDateTime.now())
                 .endDate(ZonedDateTime.now().plusDays(5))
                 .stopDate(null)
-                .totalParticipatingDays(2)
+                .totalParticipatingDaysCount(2)
                 .numberOfParticipants(1)
                 .participatingDays(1 << 2)
                 .totalFee(1000)


### PR DESCRIPTION
# 작업 개요

Challenge 엔티티에서 챌린지 전체 참여 일수를 의미하는 변수 `totalParticipatingDays` 의 의미를 명확하게 하기 위해 `totalParticipatingDaysCount` 로 변경했습니다. 

```java
// 변경 전
@Column(nullable = false)
private int totalParticipatingDays;

// 변경 후
@Column(nullable = false)
private int totalParticipatingDaysCount;
```