### PR TITLE
[feat] 공지 포스트 불러오는 메서드와 url 변경 #184

### DIFF
--- a/src/main/java/com/habitpay/habitpay/domain/challengepost/api/ChallengePostApi.java
+++ b/src/main/java/com/habitpay/habitpay/domain/challengepost/api/ChallengePostApi.java
@@ -40,8 +40,8 @@ public class ChallengePostApi {
         return challengePostSearchService.findPostViewListByChallengeId(id, pageable);
     }
 
-    @GetMapping("/api/challenges/{id}/posts/announcement")
-    public SuccessResponse<List<PostViewResponse>> getAnnouncementPosts(
+    @GetMapping("/api/challenges/{id}/posts/announcements")
+    public SuccessResponse<List<PostViewResponse>> getAnnouncements(
             @PathVariable Long id,
             @PageableDefault(sort = "id", direction = Sort.Direction.DESC) Pageable pageable) {
 


### PR DESCRIPTION
### 내용

* 공지 포스트 불러오는 컨트롤러 API의 주소를 변경했습니다.
  (단수 `announcement`에서 복수 `announcements`로)
* 동시에, `Announcements` 명사가 분명히 보이도록 메서드명도 수정했습니다.
```java
//before
@GetMapping("/api/challenges/{id}/posts/announcement")
public SuccessResponse<List<PostViewResponse>> getAnnouncementPosts() {...}

// after
@GetMapping("/api/challenges/{id}/posts/announcements")
public SuccessResponse<List<PostViewResponse>> getAnnouncements() {...}
```