### PR TITLE
[Feat] 테스트 코드 수정 및 index.adoc 파일에 새 문서 추가 #186

### DIFF
--- a/src/docs/asciidoc/index.adoc
+++ b/src/docs/asciidoc/index.adoc
@@ -7,3 +7,5 @@
 
 include::api/member.adoc[]
 include::api/challenge.adoc[]
+include::api/challengePost.adoc[]
+include::api/refreshToken.adoc[]

--- a/src/test/java/com/habitpay/habitpay/domain/challegepost/api/ChallengePostApiTest.java
+++ b/src/test/java/com/habitpay/habitpay/domain/challegepost/api/ChallengePostApiTest.java
@@ -197,7 +197,7 @@ public class ChallengePostApiTest extends AbstractRestDocsTests {
                 .willReturn(SuccessResponse.of("", mockPostViewResponseList));
 
         // when
-        ResultActions result = mockMvc.perform(get("/api/challenges/{id}/posts/announcement", 1L)
+        ResultActions result = mockMvc.perform(get("/api/challenges/{id}/posts/announcements", 1L)
                 .header(HttpHeaders.AUTHORIZATION, AUTHORIZATION_HEADER_PREFIX + "ACCESS_TOKEN"));
 
         //then


### PR DESCRIPTION
### 내용

* 컨트롤러 API의 바뀐 url을 반영하지 못했던 ChallengePost 테스트 코드를 수정했습니다. (단수형 -> 복수형)
```java
// before
ResultActions result = mockMvc.perform(get(".../announcement", 1L)

// after
ResultActions result = mockMvc.perform(get("/.../announcements", 1L)
```

---

* `index.adoc` 파일에 챌린지 포스트 및 리프레시 토큰 문서 파일을 추가하여, 정상적으로 RestDocs를 확인할 수 있도록 했습니다.

```java
include::api/challengePost.adoc[]
include::api/refreshToken.adoc[]
```