### PR TITLE
[Test] 리프레시 토큰으로 재발급 요청 시 발생하는 에러에 대한 테스트 코드 작성 #188

### DIFF
--- a/src/docs/asciidoc/api/refreshToken.adoc
+++ b/src/docs/asciidoc/api/refreshToken.adoc
@@ -19,3 +19,9 @@ Request Body에 클라이언트가 가지고 있던 리프레시 토큰을 담�
 (대소문자를 구분하지 않고, "refresh_token" 스네이크 케이싱도 정상 인자로 받습니다.)
 
 operation::refreshToken/create-new-access-token-and-new-refresh-token[snippets='http-request,http-response,response-fields']
+
+=== 토큰 리프레시 실패 : 400 Bad Request
+
+토큰 리프레시 요청 시 파라미터 값이 비어있거나 지원하는 않는 값 등 잘못된 요청일 경우 발생합니다.
+
+operation::refreshToken/return-400-when-invalid-request[snippets='http-request,http-response,response-fields']

--- a/src/docs/asciidoc/api/refreshToken.adoc
+++ b/src/docs/asciidoc/api/refreshToken.adoc
@@ -25,3 +25,22 @@ operation::refreshToken/create-new-access-token-and-new-refresh-token[snippets='
 토큰 리프레시 요청 시 파라미터 값이 비어있거나 지원하는 않는 값 등 잘못된 요청일 경우 발생합니다.
 
 operation::refreshToken/return-400-when-invalid-request[snippets='http-request,http-response,response-fields']
+
+=== 토큰 리프레시 실패 : 401 Unauthorized
+
+토큰이 만료되거나 값이 변형되는 등 정상적으로 사용할 수 없는 토큰일 경우 발생합니다.
+
+토큰 리프레시 요청 시 이 응답을 받았다면 리프레시 토큰이 만료되었을 가능성이 큽니다. 이 경우 재로그인이 필요합니다.
+
+그러나 일반 "/api" 요청 중 위와 같은 401 상태 코드를 받았다면, 액세스 토큰이 만료된 것으로 보고 클라이언트는 토큰 재발급, 즉 토큰 리프레시("/token")를 요청해야 합니다.
+
+(중요한 점은, 401 이외의 상태 코드로는 클라이언트가 토큰 재발급을 요청할 수 없다는 것입니다.)
+
+operation::refreshToken/return-401-when-invalid-token[snippets='http-request,http-response,response-fields']
+
+=== 토큰 리프레시 실패 : 403 Forbidden
+
+액세스 토큰이 제공하는 권한보다 더 높은 권한을 요구할 때 발생합니다.
+예를 들면 일반 사용자가 관리자 페이지에 접근하는 경우르 들 수 있습니다.
+
+operation::refreshToken/return-403-when-insufficient-scope[snippets='http-request,http-response,response-fields']

--- a/src/docs/asciidoc/api/refreshToken.adoc
+++ b/src/docs/asciidoc/api/refreshToken.adoc
@@ -41,6 +41,6 @@ operation::refreshToken/return-401-when-invalid-token[snippets='http-request,htt
 === 토큰 리프레시 실패 : 403 Forbidden
 
 액세스 토큰이 제공하는 권한보다 더 높은 권한을 요구할 때 발생합니다.
-예를 들면 일반 사용자가 관리자 페이지에 접근하는 경우르 들 수 있습니다.
+예를 들면 일반 사용자가 관리자 페이지에 접근하는 경우를 들 수 있습니다.
 
 operation::refreshToken/return-403-when-insufficient-scope[snippets='http-request,http-response,response-fields']

--- a/src/docs/asciidoc/api/refreshToken.adoc
+++ b/src/docs/asciidoc/api/refreshToken.adoc
@@ -40,7 +40,9 @@ operation::refreshToken/return-401-when-invalid-token[snippets='http-request,htt
 
 === 토큰 리프레시 실패 : 403 Forbidden
 
-액세스 토큰이 제공하는 권한보다 더 높은 권한을 요구할 때 발생합니다.
+토큰이 제공하는 권한보다 더 높은 권한을 요구할 때 발생합니다.
 예를 들면 일반 사용자가 관리자 페이지에 접근하는 경우를 들 수 있습니다.
+
+해빗페이에서 권한 문제가 발생하는 대상은 액세스 토큰이기 때문에, (토큰 리프레시 API 문서이지만) 액세스 토큰의 권한이 부족할 때 발생하는 상태 코드로 이해하면 되겠습니다.
 
 operation::refreshToken/return-403-when-insufficient-scope[snippets='http-request,http-response,response-fields']

--- a/src/test/java/com/habitpay/habitpay/domain/refreshtoken/api/RefreshTokenApiTest.java
+++ b/src/test/java/com/habitpay/habitpay/domain/refreshtoken/api/RefreshTokenApiTest.java
@@ -6,14 +6,17 @@ import com.habitpay.habitpay.domain.member.domain.Member;
 import com.habitpay.habitpay.domain.refreshtoken.application.RefreshTokenCreationService;
 import com.habitpay.habitpay.domain.refreshtoken.dto.CreateAccessTokenRequest;
 import com.habitpay.habitpay.domain.refreshtoken.dto.CreateAccessTokenResponse;
+import com.habitpay.habitpay.domain.refreshtoken.exception.CustomJwtException;
 import com.habitpay.habitpay.global.config.jwt.TokenProvider;
 import com.habitpay.habitpay.global.config.jwt.TokenService;
+import com.habitpay.habitpay.global.error.CustomJwtErrorInfo;
 import com.habitpay.habitpay.global.response.SuccessResponse;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
 import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.http.HttpStatus;
 import org.springframework.http.MediaType;
 import org.springframework.test.web.servlet.ResultActions;
 
@@ -44,7 +47,7 @@ public class RefreshTokenApiTest extends AbstractRestDocsTests {
 
 
     @Test
-    @DisplayName("")
+    @DisplayName("토큰 리프레시 요청")
     void createNewAccessTokenAndNewRefreshToken() throws Exception {
 
         //given
@@ -81,6 +84,33 @@ public class RefreshTokenApiTest extends AbstractRestDocsTests {
                                 fieldWithPath("data.tokenType").description("발급한 토큰의 유형. \"Bearer\""),
                                 fieldWithPath("data.expiresIn").description("액세스 토큰의 유효 기간"),
                                 fieldWithPath("data.refreshToken").description("새로 발급한 리프레시 토큰. 추후 새 액세스 토큰 발급 시 이용된다.")
+                        )
+                ));
+
+    }
+
+    @Test
+    @DisplayName("토큰 리프레시 실패 : 400 Bad Request")
+    void return400WhenInvalidRequest() throws Exception {
+
+        //given
+        CreateAccessTokenRequest tokenRequest = CreateAccessTokenRequest.builder()
+                .build();
+
+        given(refreshTokenCreationService.createNewAccessTokenAndNewRefreshToken(any(CreateAccessTokenRequest.class)))
+                .willThrow(new CustomJwtException(HttpStatus.BAD_REQUEST, CustomJwtErrorInfo.BAD_REQUEST, "인증 방법을 알 수 없습니다."));
+
+        //when
+        ResultActions result = mockMvc.perform(post("/token")
+                .content(objectMapper.writeValueAsString(tokenRequest))
+                .contentType(MediaType.APPLICATION_JSON));
+
+        //then
+        result.andExpect(status().isBadRequest())
+                .andDo(document("refreshToken/return-400-when-invalid-request",
+                        responseFields(
+                                fieldWithPath("error").description("에러 메시지"),
+                                fieldWithPath("errorDescription").description("에러 발생 이유")
                         )
                 ));
 


### PR DESCRIPTION
### 작업 개요

* `/token`로 토큰 재발급 요청 시 발생할 수 있는 `400, 401, 403 상태 코드`에 대한 테스트 코드를 작성했습니다.
* 관련된 `RestDocs` 문서를 작성했습니다.

---

### 주요 내용

* 예외를 처리하거나 다른 상태 코드를 확인하는 테스트 코드는 기존 정상 응답 테스트 코드에서 2가지만 신경 쓰면 됩니다.
* 첫 번째는 예상 응답이 `throw` 되는 `Exception`임을 밝히는 것입니다.

```java
given(refreshTokenCreationService.createNewAccessTokenAndNewRefreshToken(any(CreateAccessTokenRequest.class)))
  .willThrow(new CustomJwtException(HttpStatus.BAD_REQUEST, CustomJwtErrorInfo.BAD_REQUEST, "인증 방법을 알 수 없습니다.")); 
```

* `willReturn` 대신 `WillThrow` 메서드를 사용합니다.
* 정상 응답 타압인 `SuccessResponse` 대신 `Exception`을 인자로 넣어주면 됩니다.

---

* 두 번째는 `ResultActions`의 기대값을 변경하는 것입니다.

```java
result.andExpect(status().isBadRequest())
                .andDo(...);
```

* `andExpect`의 상태 코드 예상값을 `isOk()` 대신 필요한 값으로 변경하면 됩니다.

---

### 기타

* 공통 예외 처리 응답 클래스가 만들어지면 그에 맞추어 변경할 예정입니다.
* 현재는 이전에 만들어 둔 기본 형태를 사용하고 있습니다.
```java
// ex

{
  "error" : "invalid_request",
  "errorDescription" : "인증 방법을 알 수 없습니다."
}
```

---

* `403 Forbidden`의 경우, 사실 토큰 리프레시 API에서 발생할 일은 없을 듯 합니다.
* 권한 정보가 들어있는 건 액세스 토큰이지, 리프레시 토큰은 아니기 때문입니다.
* 그러나 `/api` 요청에서 발생할 수 있는 `403 상태 코드`에 대한 설명을 문서화하기 위해 우선 RefreshToken 문서에 달아두었습니다.