### PR TITLE
Feat/member 도메인 예외처리 공통 응답 처리#193

### DIFF
--- a/src/docs/asciidoc/api/member.adoc
+++ b/src/docs/asciidoc/api/member.adoc
@@ -74,12 +74,3 @@ operation::member/patch-member-image-unsupported-extension-exception[snippets='h
 반환되는 값은 DB 테이블의 Primary Key 에 해당하는 사용자의 ID 입니다.
 
 operation::member/delete-member[snippets='http-request,http-response,response-fields']
-
-==== 에러 응답
-
-====== 404 Not Found
-
-이미 탈퇴한 회원이 만료되지 않은 액세스 토큰으로 회원 탈퇴를 시도한 경우에 에러를 반환합니다.
-
-operation::member/delete-member-exception[snippets='http-request,http-response,response-fields']
-

--- a/src/docs/asciidoc/api/member.adoc
+++ b/src/docs/asciidoc/api/member.adoc
@@ -26,6 +26,20 @@ operation::member/get-member[snippets='http-request,http-response,response-field
 
 operation::member/patch-member-nickname[snippets='http-request,http-response,response-fields']
 
+==== 에러 응답
+
+====== 1. 닉네임 규칙에 맞지 않는 경우 (400 Bad Request)
+
+닉네임 규칙에 맞지 않는 경우입니다.
+
+operation::member/patch-member-nickname-invalid-rule-exception[snippets='http-request,http-response,response-fields']
+
+====== 2. 이전과 동일한 닉네임인 경우 (400 Bad Request)
+
+이전에 사용했던 닉네임과 동일한 닉네임을 사용한 경우입니다.
+
+operation::member/patch-member-nickname-duplicated-nickname-exception[snippets='http-request,http-response,response-fields']
+
 === 사용자 이미지 변경
 
 사용자의 이미지를 변경합니다.

--- a/src/docs/asciidoc/api/member.adoc
+++ b/src/docs/asciidoc/api/member.adoc
@@ -53,6 +53,20 @@ operation::member/patch-member-nickname-duplicated-nickname-exception[snippets='
 
 operation::member/patch-member-image[snippets='http-request,http-response,response-fields']
 
+==== 에러 응답
+
+====== 1. 이미지 크기가 초과한 경우 (400 Bad Request)
+
+이미지 크기가 1MB 초과한 경우입니다.
+
+operation::member/patch-member-image-size-exceeded-exception[snippets='http-request,http-response,response-fields']
+
+====== 2. 허용하지 않는 이미지 확장자인 경우 (400 Bad Request)
+
+허용하는 이미지 확장자가 아닌 경우입니다.
+
+operation::member/patch-member-image-unsupported-extension-exception[snippets='http-request,http-response,response-fields']
+
 === 회원 탈퇴
 
 회원 탈퇴를 진행합니다.

--- a/src/main/java/com/habitpay/habitpay/domain/member/api/MemberApi.java
+++ b/src/main/java/com/habitpay/habitpay/domain/member/api/MemberApi.java
@@ -27,7 +27,7 @@ public class MemberApi {
     @PatchMapping("/member/nickname")
     public SuccessResponse<NicknameDto> patchNickname(@RequestBody NicknameDto nicknameDto,
                                                       @AuthenticationPrincipal CustomUserDetails user) {
-        return memberUpdateService.updateNickname(nicknameDto, user.getId());
+        return memberUpdateService.updateNickname(nicknameDto, user.getMember());
     }
 
     @PatchMapping("/member/image")

--- a/src/main/java/com/habitpay/habitpay/domain/member/api/MemberApi.java
+++ b/src/main/java/com/habitpay/habitpay/domain/member/api/MemberApi.java
@@ -21,7 +21,7 @@ public class MemberApi {
 
     @GetMapping("/member")
     public SuccessResponse<MemberProfileResponse> getMember(@AuthenticationPrincipal CustomUserDetails user) {
-        return memberSearchService.getMemberProfile(user.getId());
+        return memberSearchService.getMemberProfile(user.getMember());
     }
 
     @PatchMapping("/member/nickname")

--- a/src/main/java/com/habitpay/habitpay/domain/member/api/MemberApi.java
+++ b/src/main/java/com/habitpay/habitpay/domain/member/api/MemberApi.java
@@ -33,7 +33,7 @@ public class MemberApi {
     @PatchMapping("/member/image")
     public SuccessResponse<ImageUpdateResponse> patchImage(@RequestBody ImageUpdateRequest imageUpdateRequest,
                                                            @AuthenticationPrincipal CustomUserDetails user) {
-        return memberUpdateService.updateImage(imageUpdateRequest, user.getId());
+        return memberUpdateService.updateImage(imageUpdateRequest, user.getMember());
     }
 
     @DeleteMapping("/member")

--- a/src/main/java/com/habitpay/habitpay/domain/member/api/MemberApi.java
+++ b/src/main/java/com/habitpay/habitpay/domain/member/api/MemberApi.java
@@ -39,6 +39,6 @@ public class MemberApi {
     @DeleteMapping("/member")
     @ResponseStatus(HttpStatus.OK)
     public SuccessResponse<Long> deleteMember(@AuthenticationPrincipal CustomUserDetails user) {
-        return memberDeleteService.delete(user.getId());
+        return memberDeleteService.delete(user.getMember());
     }
 }

--- a/src/main/java/com/habitpay/habitpay/domain/member/application/MemberDeleteService.java
+++ b/src/main/java/com/habitpay/habitpay/domain/member/application/MemberDeleteService.java
@@ -2,12 +2,13 @@ package com.habitpay.habitpay.domain.member.application;
 
 import com.habitpay.habitpay.domain.member.dao.MemberRepository;
 import com.habitpay.habitpay.domain.member.domain.Member;
-import com.habitpay.habitpay.domain.member.exception.MemberNotFoundException;
 import com.habitpay.habitpay.global.config.aws.S3FileService;
 import com.habitpay.habitpay.global.response.SuccessResponse;
 import lombok.AllArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
+
+import java.util.Optional;
 
 @Slf4j
 @Service
@@ -17,21 +18,15 @@ public class MemberDeleteService {
     private final MemberRepository memberRepository;
     private final S3FileService s3FileService;
 
-    public SuccessResponse<Long> delete(Long id) {
-        Member member = memberRepository.findById(id)
-                .filter(Member::isActive)
-                .orElseThrow(() -> new MemberNotFoundException(id));
-
-        String imageFileName = member.getImageFileName();
-        log.info("[DELETE /member] imageFileName: {}", imageFileName);
-        if (imageFileName != null) {
-            s3FileService.deleteImage("profiles", imageFileName);
-        }
+    public SuccessResponse<Long> delete(Member member) {
+        log.info("[DELETE /member] imageFileName: {}", member.getImageFileName());
+        Optional.ofNullable(member.getImageFileName())
+                .ifPresent((imageFileName) -> s3FileService.deleteImage("profiles", imageFileName));
 
         member.clear();
         memberRepository.save(member);
 
-        return SuccessResponse.of("정상적으로 탈퇴되었습니다.", id);
+        return SuccessResponse.of("정상적으로 탈퇴되었습니다.", member.getId());
     }
 
 }

--- a/src/main/java/com/habitpay/habitpay/domain/member/application/MemberSearchService.java
+++ b/src/main/java/com/habitpay/habitpay/domain/member/application/MemberSearchService.java
@@ -19,12 +19,8 @@ public class MemberSearchService {
 
     public SuccessResponse<MemberProfileResponse> getMemberProfile(Member member) {
         String imageFileName = Optional.ofNullable(member.getImageFileName()).orElse("");
-
-        // TODO: 꼭 이미지를 presigned url 로 받아와야 할 필요가 있을까?
-        String imageUrl = "";
-        if (imageFileName.isEmpty() == false) {
-            imageUrl = s3FileService.getGetPreSignedUrl("profiles", imageFileName);
-        }
+        String imageUrl = imageFileName.isEmpty() ? "" : s3FileService.getGetPreSignedUrl("profiles", imageFileName);
+        
         return SuccessResponse.of("", MemberProfileResponse.of(member, imageUrl));
     }
 

--- a/src/main/java/com/habitpay/habitpay/domain/member/application/MemberSearchService.java
+++ b/src/main/java/com/habitpay/habitpay/domain/member/application/MemberSearchService.java
@@ -17,8 +17,7 @@ public class MemberSearchService {
     private final MemberRepository memberRepository;
     private final S3FileService s3FileService;
 
-    public SuccessResponse<MemberProfileResponse> getMemberProfile(Long id) {
-        Member member = getMemberById(id);
+    public SuccessResponse<MemberProfileResponse> getMemberProfile(Member member) {
         String imageFileName = Optional.ofNullable(member.getImageFileName()).orElse("");
 
         // TODO: 꼭 이미지를 presigned url 로 받아와야 할 필요가 있을까?

--- a/src/main/java/com/habitpay/habitpay/domain/member/application/MemberUpdateService.java
+++ b/src/main/java/com/habitpay/habitpay/domain/member/application/MemberUpdateService.java
@@ -30,15 +30,13 @@ public class MemberUpdateService {
     private final String IMAGE_CONTENT_TOO_LARGE = "이미지 파일의 크기가 제한을 초과했습니다.";
     private final String UNSUPPORTED_IMAGE_EXTENSION = "지원하지 않는 이미지 확장자입니다.";
 
-    public SuccessResponse<NicknameDto> updateNickname(NicknameDto nicknameDto, Long id) {
+    public SuccessResponse<NicknameDto> updateNickname(NicknameDto nicknameDto, Member member) {
         String nickname = nicknameDto.getNickname();
         if (isNicknameValidFormat(nickname) == false) {
             // TODO: 422(UNPROCESSABLE_ENTITY) 반환하기
             throw new IllegalArgumentException(INVALID_NICKNAME_RULE);
         }
 
-        Member member = memberRepository.findById(id)
-                .orElseThrow(() -> new IllegalArgumentException("존재하지 않는 사용자 입니다."));
         member.setNickname(nickname);
         memberRepository.save(member);
         String message = Response.PROFILE_UPDATE_SUCCESS.getMessage();

--- a/src/main/java/com/habitpay/habitpay/domain/member/application/MemberUpdateService.java
+++ b/src/main/java/com/habitpay/habitpay/domain/member/application/MemberUpdateService.java
@@ -6,9 +6,9 @@ import com.habitpay.habitpay.domain.member.dto.ImageUpdateRequest;
 import com.habitpay.habitpay.domain.member.dto.ImageUpdateResponse;
 import com.habitpay.habitpay.domain.member.dto.NicknameDto;
 import com.habitpay.habitpay.domain.member.exception.InvalidNicknameException;
-import com.habitpay.habitpay.domain.model.Response;
 import com.habitpay.habitpay.global.config.aws.S3FileService;
 import com.habitpay.habitpay.global.error.exception.ErrorCode;
+import com.habitpay.habitpay.global.error.exception.InvalidValueException;
 import com.habitpay.habitpay.global.response.SuccessCode;
 import com.habitpay.habitpay.global.response.SuccessResponse;
 import com.habitpay.habitpay.global.util.ImageUtil;
@@ -29,9 +29,6 @@ public class MemberUpdateService {
     private final MemberRepository memberRepository;
     private final S3FileService s3FileService;
 
-    private final String IMAGE_CONTENT_TOO_LARGE = "이미지 파일의 크기가 제한을 초과했습니다.";
-    private final String UNSUPPORTED_IMAGE_EXTENSION = "지원하지 않는 이미지 확장자입니다.";
-
     public SuccessResponse<NicknameDto> updateNickname(NicknameDto nicknameDto, Member member) {
         String nickname = nicknameDto.getNickname();
         if (isNicknameValidFormat(nickname) == false) {
@@ -47,45 +44,43 @@ public class MemberUpdateService {
         return SuccessResponse.of(SuccessCode.NICKNAME_UPDATE_SUCCESS.getMessage(), nicknameDto);
     }
 
-    public SuccessResponse<ImageUpdateResponse> updateImage(ImageUpdateRequest imageUpdateRequest, Long id) {
+    public SuccessResponse<ImageUpdateResponse> updateImage(ImageUpdateRequest imageUpdateRequest, Member member) {
         Long contentLength = imageUpdateRequest.getContentLength();
         String extension = imageUpdateRequest.getExtension();
 
-        // 1. 이미지 크기 제한이 넘을 경우
-        if (ImageUtil.isValidFileSize(contentLength) == false) {
-//            String message = ErrorResponse.IMAGE_CONTENT_TOO_LARGE.getMessage();
-            // TODO: 413(PAYLOAD_TOO_LARGE) 반환하기
-            throw new IllegalArgumentException(IMAGE_CONTENT_TOO_LARGE);
-        }
+        validateImageFormat(contentLength, extension);
 
-        // 2. 이미지 확장자가 허용되지 않은 경우
-        if (ImageUtil.isValidImageExtension(extension) == false) {
-            // TODO: 415(UNSUPPORTED_MEDIA_TYPE) 반환하기
-            throw new IllegalArgumentException(UNSUPPORTED_IMAGE_EXTENSION);
-        }
+        // 프로필 이미지가 이미 존재하는 경우 기존 이미지 삭제
+        Optional.ofNullable(member.getImageFileName())
+                .ifPresent((imageFileName) -> s3FileService.deleteImage("profiles", imageFileName));
 
-        Member member = memberRepository.findById(id)
-                .orElseThrow(() -> new IllegalArgumentException("존재하지 않는 사용자 입니다."));
-
-        // 3. 프로필 이미지가 이미 존재하는 경우 기존 이미지 삭제
-        if (Optional.ofNullable(member.getImageFileName()).isPresent()) {
-            s3FileService.deleteImage("profiles", member.getImageFileName());
-        }
-
-        // 4. 프론트엔드에 preSignedUrl 발급
+        //  프론트엔드에 preSignedUrl 발급
         String randomFileName = UUID.randomUUID().toString();
         String savedFileName = String.format("%s.%s", randomFileName, extension);
-        log.info("[PATCH /member] savedFileName: {}", savedFileName);
+        String preSignedUrl = s3FileService.getPutPreSignedUrl("profiles", savedFileName, extension, contentLength);
+        log.info("[PATCH /member/image] savedFileName: {}", savedFileName);
 
         member.setImageFileName(savedFileName);
         memberRepository.save(member);
 
-        String preSignedUrl = s3FileService.getPutPreSignedUrl("profiles", savedFileName, extension, contentLength);
-        String message = Response.PROFILE_UPDATE_SUCCESS.getMessage();
         return SuccessResponse.of(
-                message,
+                SuccessCode.PROFILE_IMAGE_UPDATE_SUCCESS.getMessage(),
                 ImageUpdateResponse.from(preSignedUrl)
         );
+    }
+
+    private void validateImageFormat(Long contentLength, String extension) {
+
+        // 1. 이미지 크기 제한이 넘을 경우
+        if (ImageUtil.isValidFileSize(contentLength) == false) {
+            throw new InvalidValueException(String.format("size: %dMB", contentLength / 1024 / 1024), ErrorCode.PROFILE_IMAGE_SIZE_TOO_LARGE);
+        }
+
+        // 2. 이미지 확장자가 허용되지 않은 경우
+        if (ImageUtil.isValidImageExtension(extension) == false) {
+            throw new InvalidValueException(String.format("extension: %s", extension), ErrorCode.UNSUPPORTED_IMAGE_EXTENSION);
+        }
+
     }
 
     private boolean isNicknameValidFormat(String nickname) {

--- a/src/main/java/com/habitpay/habitpay/domain/member/exception/InvalidNicknameException.java
+++ b/src/main/java/com/habitpay/habitpay/domain/member/exception/InvalidNicknameException.java
@@ -1,0 +1,11 @@
+package com.habitpay.habitpay.domain.member.exception;
+
+import com.habitpay.habitpay.global.error.exception.ErrorCode;
+import com.habitpay.habitpay.global.error.exception.InvalidValueException;
+
+public class InvalidNicknameException extends InvalidValueException {
+
+    public InvalidNicknameException(String nickname, ErrorCode errorCode) {
+        super(String.format("[nickname: %s] is invalid", nickname), errorCode);
+    }
+}

--- a/src/main/java/com/habitpay/habitpay/global/config/jwt/JwtAuthenticationFilter.java
+++ b/src/main/java/com/habitpay/habitpay/global/config/jwt/JwtAuthenticationFilter.java
@@ -26,6 +26,8 @@ public class JwtAuthenticationFilter extends OncePerRequestFilter {
     protected void doFilterInternal(HttpServletRequest request, HttpServletResponse response, FilterChain filterChain) throws ServletException, IOException {
         String accessToken = RequestHeaderUtil.getAccessToken(request);
 
+        log.info("request: [{} {}]", request.getMethod(), request.getRequestURI());
+
         // TODO: 예외처리 추가하기
         if (accessToken == null) {
             log.error("No access token");

--- a/src/main/java/com/habitpay/habitpay/global/error/exception/ErrorCode.java
+++ b/src/main/java/com/habitpay/habitpay/global/error/exception/ErrorCode.java
@@ -15,8 +15,11 @@ public enum ErrorCode {
     // Member
     USER_NOT_FOUND(HttpStatus.NOT_FOUND, "사용자를 찾을 수 없습니다."),
     INVALID_NICKNAME_RULE(HttpStatus.BAD_REQUEST, "닉네임 규칙에 맞지 않습니다. (규칙: 길이 2~15자, 특수문자 제외)"),
-    DUPLICATED_NICKNAME(HttpStatus.BAD_REQUEST, "이전과 동일한 닉네임으로 변경할 수 없습니다.");
+    DUPLICATED_NICKNAME(HttpStatus.BAD_REQUEST, "이전과 동일한 닉네임으로 변경할 수 없습니다."),
+    PROFILE_IMAGE_SIZE_TOO_LARGE(HttpStatus.BAD_REQUEST, "이미지 파일의 크기가 제한을 초과했습니다. (최대 1MB)"),
+    UNSUPPORTED_IMAGE_EXTENSION(HttpStatus.BAD_REQUEST, "지원하지 않는 이미지 확장자입니다. (png, jpg, jpeg 만 가능)"),
 
+    ;
     private HttpStatus status;
     private final String message;
 

--- a/src/main/java/com/habitpay/habitpay/global/error/exception/ErrorCode.java
+++ b/src/main/java/com/habitpay/habitpay/global/error/exception/ErrorCode.java
@@ -10,9 +10,12 @@ public enum ErrorCode {
 
     // Common
     ENTITY_NOT_FOUND(HttpStatus.NOT_FOUND, "Entity Not Found"),
+    INVALID_VALUE(HttpStatus.BAD_REQUEST, "Invalid Input Value"),
 
     // Member
-    USER_NOT_FOUND(HttpStatus.NOT_FOUND, "사용자를 찾을 수 없습니다.");
+    USER_NOT_FOUND(HttpStatus.NOT_FOUND, "사용자를 찾을 수 없습니다."),
+    INVALID_NICKNAME_RULE(HttpStatus.BAD_REQUEST, "닉네임 규칙에 맞지 않습니다. (규칙: 길이 2~15자, 특수문자 제외)"),
+    DUPLICATED_NICKNAME(HttpStatus.BAD_REQUEST, "이전과 동일한 닉네임으로 변경할 수 없습니다.");
 
     private HttpStatus status;
     private final String message;

--- a/src/main/java/com/habitpay/habitpay/global/error/exception/InvalidValueException.java
+++ b/src/main/java/com/habitpay/habitpay/global/error/exception/InvalidValueException.java
@@ -1,0 +1,12 @@
+package com.habitpay.habitpay.global.error.exception;
+
+public class InvalidValueException extends BusinessException {
+
+    public InvalidValueException(String message) {
+        super(message, ErrorCode.ENTITY_NOT_FOUND);
+    }
+
+    public InvalidValueException(String message, ErrorCode errorCode) {
+        super(message, errorCode);
+    }
+}

--- a/src/main/java/com/habitpay/habitpay/global/response/SuccessCode.java
+++ b/src/main/java/com/habitpay/habitpay/global/response/SuccessCode.java
@@ -1,0 +1,15 @@
+package com.habitpay.habitpay.global.response;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+@Getter
+@AllArgsConstructor
+public enum SuccessCode {
+
+    // Member
+    NICKNAME_UPDATE_SUCCESS("닉네임 변경에 성공했습니다.");
+
+    private final String message;
+
+}

--- a/src/main/java/com/habitpay/habitpay/global/response/SuccessCode.java
+++ b/src/main/java/com/habitpay/habitpay/global/response/SuccessCode.java
@@ -8,8 +8,8 @@ import lombok.Getter;
 public enum SuccessCode {
 
     // Member
-    NICKNAME_UPDATE_SUCCESS("닉네임 변경에 성공했습니다.");
-
+    NICKNAME_UPDATE_SUCCESS("닉네임 변경에 성공했습니다."),
+    PROFILE_IMAGE_UPDATE_SUCCESS("프로필 이미지 변경에 성공했습니다.");
     private final String message;
 
 }

--- a/src/test/java/com/habitpay/habitpay/domain/member/api/MemberApiTest.java
+++ b/src/test/java/com/habitpay/habitpay/domain/member/api/MemberApiTest.java
@@ -5,6 +5,7 @@ import com.habitpay.habitpay.docs.springrestdocs.AbstractRestDocsTests;
 import com.habitpay.habitpay.domain.member.application.MemberDeleteService;
 import com.habitpay.habitpay.domain.member.application.MemberSearchService;
 import com.habitpay.habitpay.domain.member.application.MemberUpdateService;
+import com.habitpay.habitpay.domain.member.domain.Member;
 import com.habitpay.habitpay.domain.member.dto.ImageUpdateRequest;
 import com.habitpay.habitpay.domain.member.dto.ImageUpdateResponse;
 import com.habitpay.habitpay.domain.member.dto.MemberProfileResponse;
@@ -75,7 +76,7 @@ public class MemberApiTest extends AbstractRestDocsTests {
                 .imageUrl("https://picsum.photos/id/40/200/300")
                 .build();
 
-        given(memberSearchService.getMemberProfile(anyLong()))
+        given(memberSearchService.getMemberProfile(any(Member.class)))
                 .willReturn(SuccessResponse.of("", memberProfileResponse));
 
         // when

--- a/src/test/java/com/habitpay/habitpay/domain/member/api/MemberApiTest.java
+++ b/src/test/java/com/habitpay/habitpay/domain/member/api/MemberApiTest.java
@@ -11,7 +11,6 @@ import com.habitpay.habitpay.domain.member.dto.ImageUpdateResponse;
 import com.habitpay.habitpay.domain.member.dto.MemberProfileResponse;
 import com.habitpay.habitpay.domain.member.dto.NicknameDto;
 import com.habitpay.habitpay.domain.member.exception.InvalidNicknameException;
-import com.habitpay.habitpay.domain.member.exception.MemberNotFoundException;
 import com.habitpay.habitpay.domain.refreshtoken.application.RefreshTokenCreationService;
 import com.habitpay.habitpay.global.config.aws.S3FileService;
 import com.habitpay.habitpay.global.config.jwt.TokenProvider;
@@ -30,7 +29,7 @@ import org.springframework.http.HttpHeaders;
 import org.springframework.http.MediaType;
 import org.springframework.test.web.servlet.ResultActions;
 
-import static org.mockito.ArgumentMatchers.*;
+import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.BDDMockito.given;
 import static org.springframework.restdocs.headers.HeaderDocumentation.headerWithName;
 import static org.springframework.restdocs.headers.HeaderDocumentation.requestHeaders;
@@ -332,7 +331,7 @@ public class MemberApiTest extends AbstractRestDocsTests {
         // given
         // TODO: 응답 메세지 enum 으로 관리하기
         SuccessResponse<Long> successResponse = SuccessResponse.of("정상적으로 탈퇴되었습니다.", 1L);
-        given(memberDeleteService.delete(anyLong()))
+        given(memberDeleteService.delete(any(Member.class)))
                 .willReturn(successResponse);
 
         // when
@@ -349,33 +348,6 @@ public class MemberApiTest extends AbstractRestDocsTests {
                         responseFields(
                                 fieldWithPath("message").description("메세지"),
                                 fieldWithPath("data").description("Member ID")
-                        )
-                ));
-    }
-
-    @Test
-    @WithMockOAuth2User
-    @DisplayName("회원 탈퇴 예외처리 - 404 Not Found")
-    void deleteMemberException() throws Exception {
-
-        // given
-        given(memberDeleteService.delete(anyLong()))
-                .willThrow(new MemberNotFoundException(anyLong()));
-
-        // when
-        ResultActions result = mockMvc.perform(delete("/api/member")
-                .header(HttpHeaders.AUTHORIZATION, AUTHORIZATION_HEADER_PREFIX + "ACCESS_TOKEN")
-                .contentType(MediaType.APPLICATION_JSON));
-
-        // then
-        result.andExpect(status().isNotFound())
-                .andDo(document("member/delete-member-exception",
-                        requestHeaders(
-                                headerWithName(HttpHeaders.AUTHORIZATION).description("액세스 토큰")
-                        ),
-                        responseFields(
-                                fieldWithPath("code").description("오류 응답 코드"),
-                                fieldWithPath("message").description("오류 메세지")
                         )
                 ));
     }

--- a/src/test/java/com/habitpay/habitpay/domain/member/api/MemberApiTest.java
+++ b/src/test/java/com/habitpay/habitpay/domain/member/api/MemberApiTest.java
@@ -219,7 +219,7 @@ public class MemberApiTest extends AbstractRestDocsTests {
                 .build();
         // TODO: 응답 메세지 enum 으로 관리하기
         SuccessResponse<ImageUpdateResponse> successResponse = SuccessResponse.of("프로필 업데이트에 성공했습니다.", imageUpdateResponse);
-        given(memberUpdateService.updateImage(any(ImageUpdateRequest.class), anyLong()))
+        given(memberUpdateService.updateImage(any(ImageUpdateRequest.class), any(Member.class)))
                 .willReturn(successResponse);
 
         // when

--- a/src/test/java/com/habitpay/habitpay/domain/member/api/MemberApiTest.java
+++ b/src/test/java/com/habitpay/habitpay/domain/member/api/MemberApiTest.java
@@ -108,7 +108,7 @@ public class MemberApiTest extends AbstractRestDocsTests {
                 .build();
         // TODO: 응답 메세지 enum 으로 관리하기
         SuccessResponse<NicknameDto> successResponse = SuccessResponse.of("프로필 업데이트에 성공했습니다.", nicknameDto);
-        given(memberUpdateService.updateNickname(any(NicknameDto.class), anyLong()))
+        given(memberUpdateService.updateNickname(any(NicknameDto.class), any(Member.class)))
                 .willReturn(successResponse);
 
         // when


### PR DESCRIPTION
# 작업 개요

1. 컨트롤러에서 서비스 메서드의 매개변수로 Member ID 대신 Member 객체를 넘기도록 수정했습니다.
2. Member 도메인에서 발생할 수 있는 예외처리에 대해 공통 예외처리 응답을 적용했습니다.
3. 2번에서 추가한 예외처리 응답에 대한 테스트 코드를 작성했습니다. 
4. 200 OK 응답 시 `SuccessCode` enum 에 정의한 메세지가 전송될 수 있도록 enum 클래스를 추가했습니다.