### PR TITLE
Feat/challengeenrollment 도메인 예외처리 공통 응답 클래스 적용#197

### DIFF
--- a/src/docs/asciidoc/api/challenge.adoc
+++ b/src/docs/asciidoc/api/challenge.adoc
@@ -74,3 +74,17 @@ operation::challenge/patch-challenge-forbidden-exception[snippets='http-request,
 사용자를 챌린지 참여자에 등록합니다.
 
 operation::challenge/enroll-challenge[snippets='http-request,http-response,response-fields']
+
+==== 에러 응답
+
+===== 챌린지 등록 시간이 지난 경우 (400 Bad Request)
+
+챌린지 시작 시간이 지나고 나서 등록하는 경우입니다.
+
+operation::challenge/enroll-challenge-invalid-registration-time-exception[snippets='http-request,http-response,response-fields']
+
+===== 이미 참여한 챌린지인 경우 (409 Conflict)
+
+이미 챌린지에 등록한 사용자가 다시 챌린지 등록하는 신청한 경우입니다.
+
+operation::challenge/enroll-challenge-already-enrolled-exception[snippets='http-request,http-response,response-fields']

--- a/src/docs/asciidoc/api/challenge.adoc
+++ b/src/docs/asciidoc/api/challenge.adoc
@@ -96,3 +96,17 @@ operation::challenge/enroll-challenge-already-enrolled-exception[snippets='http-
 취소는 챌린지 시작 시간 이전까지만 가능합니다.
 
 operation::challenge/cancel-challenge-enrollment[snippets='http-request,http-response,response-fields']
+
+==== 에러 응답
+
+===== 챌린지에 참여하지 않은 경우 (400 Bad Request)
+
+참여하지 않은 챌린지를 취소하는 경우입니다.
+
+operation::challenge/cancel-challenge-enrollment-not-enrolled-exception[snippets='http-request,http-response,response-fields']
+
+===== 챌린지 등록 취소 시간을 지난 경우 (400 Bad Request)
+
+챌린지가 시작하고 나서 등록 취소를 하는 경우입니다.
+
+operation::challenge/cancel-challenge-enrollment-invalid-cancellation-time-exception[snippets='http-request,http-response,response-fields']

--- a/src/docs/asciidoc/api/challenge.adoc
+++ b/src/docs/asciidoc/api/challenge.adoc
@@ -88,3 +88,11 @@ operation::challenge/enroll-challenge-invalid-registration-time-exception[snippe
 이미 챌린지에 등록한 사용자가 다시 챌린지 등록하는 신청한 경우입니다.
 
 operation::challenge/enroll-challenge-already-enrolled-exception[snippets='http-request,http-response,response-fields']
+
+=== 챌린지 등록 취소
+
+등록한 챌린지를 취소합니다.
+
+취소는 챌린지 시작 시간 이전까지만 가능합니다.
+
+operation::challenge/cancel-challenge-enrollment[snippets='http-request,http-response,response-fields']

--- a/src/main/java/com/habitpay/habitpay/domain/challengeenrollment/api/ChallengeEnrollmentApi.java
+++ b/src/main/java/com/habitpay/habitpay/domain/challengeenrollment/api/ChallengeEnrollmentApi.java
@@ -4,11 +4,9 @@ import com.habitpay.habitpay.domain.challengeenrollment.application.ChallengeEnr
 import com.habitpay.habitpay.domain.challengeenrollment.application.ChallengeEnrollmentService;
 import com.habitpay.habitpay.domain.challengeenrollment.dto.ChallengeEnrollmentResponse;
 import com.habitpay.habitpay.global.config.auth.CustomUserDetails;
-import com.habitpay.habitpay.global.response.ApiResponse;
 import com.habitpay.habitpay.global.response.SuccessResponse;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
-import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
@@ -29,7 +27,7 @@ public class ChallengeEnrollmentApi {
     }
 
     @PostMapping("/challenges/{id}/cancel")
-    public ResponseEntity<ApiResponse> cancelChallenge(@PathVariable("id") Long id, @AuthenticationPrincipal CustomUserDetails user) {
+    public SuccessResponse<Void> cancelChallenge(@PathVariable("id") Long id, @AuthenticationPrincipal CustomUserDetails user) {
         return challengeEnrollmentCancellationService.cancel(id, user.getMember());
     }
 

--- a/src/main/java/com/habitpay/habitpay/domain/challengeenrollment/api/ChallengeEnrollmentApi.java
+++ b/src/main/java/com/habitpay/habitpay/domain/challengeenrollment/api/ChallengeEnrollmentApi.java
@@ -25,12 +25,12 @@ public class ChallengeEnrollmentApi {
 
     @PostMapping("/challenges/{id}/enroll")
     public SuccessResponse<ChallengeEnrollmentResponse> enrollChallenge(@PathVariable("id") Long id, @AuthenticationPrincipal CustomUserDetails user) {
-        return challengeEnrollmentService.enroll(id, user.getId());
+        return challengeEnrollmentService.enroll(id, user.getMember());
     }
 
     @PostMapping("/challenges/{id}/cancel")
     public ResponseEntity<ApiResponse> cancelChallenge(@PathVariable("id") Long id, @AuthenticationPrincipal CustomUserDetails user) {
-        return challengeEnrollmentCancellationService.cancel(id, user.getId());
+        return challengeEnrollmentCancellationService.cancel(id, user.getMember());
     }
 
 }

--- a/src/main/java/com/habitpay/habitpay/domain/challengeenrollment/application/ChallengeEnrollmentCancellationService.java
+++ b/src/main/java/com/habitpay/habitpay/domain/challengeenrollment/application/ChallengeEnrollmentCancellationService.java
@@ -26,9 +26,8 @@ public class ChallengeEnrollmentCancellationService {
     private final MemberSearchService memberSearchService;
 
     @Transactional
-    public ResponseEntity<ApiResponse> cancel(Long challengeId, Long userId) {
+    public ResponseEntity<ApiResponse> cancel(Long challengeId, Member member) {
         ApiResponse response;
-        Member member = memberSearchService.getMemberById(userId);
         Optional<ChallengeEnrollment> optionalChallengeEnrollment = challengeEnrollmentRepository.findByMember(member);
         if (optionalChallengeEnrollment.isEmpty()) {
             log.error("참여하지 않은 챌린지");

--- a/src/main/java/com/habitpay/habitpay/domain/challengeenrollment/application/ChallengeEnrollmentCancellationService.java
+++ b/src/main/java/com/habitpay/habitpay/domain/challengeenrollment/application/ChallengeEnrollmentCancellationService.java
@@ -4,18 +4,17 @@ import com.habitpay.habitpay.domain.challenge.application.ChallengeSearchService
 import com.habitpay.habitpay.domain.challenge.domain.Challenge;
 import com.habitpay.habitpay.domain.challengeenrollment.dao.ChallengeEnrollmentRepository;
 import com.habitpay.habitpay.domain.challengeenrollment.domain.ChallengeEnrollment;
-import com.habitpay.habitpay.domain.member.application.MemberSearchService;
+import com.habitpay.habitpay.domain.challengeenrollment.exception.NotEnrolledChallengeException;
 import com.habitpay.habitpay.domain.member.domain.Member;
-import com.habitpay.habitpay.global.response.ApiResponse;
+import com.habitpay.habitpay.global.error.exception.BadRequestException;
+import com.habitpay.habitpay.global.error.exception.ErrorCode;
+import com.habitpay.habitpay.global.response.SuccessCode;
+import com.habitpay.habitpay.global.response.SuccessResponse;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
-import org.springframework.http.HttpStatus;
-import org.springframework.http.ResponseEntity;
 import org.springframework.stereotype.Service;
-import org.springframework.transaction.annotation.Transactional;
 
 import java.time.ZonedDateTime;
-import java.util.Optional;
 
 @Slf4j
 @Service
@@ -23,30 +22,23 @@ import java.util.Optional;
 public class ChallengeEnrollmentCancellationService {
     private final ChallengeEnrollmentRepository challengeEnrollmentRepository;
     private final ChallengeSearchService challengeSearchService;
-    private final MemberSearchService memberSearchService;
 
-    @Transactional
-    public ResponseEntity<ApiResponse> cancel(Long challengeId, Member member) {
-        ApiResponse response;
-        Optional<ChallengeEnrollment> optionalChallengeEnrollment = challengeEnrollmentRepository.findByMember(member);
-        if (optionalChallengeEnrollment.isEmpty()) {
-            log.error("참여하지 않은 챌린지");
-            response = ApiResponse.create("참여하지 않은 챌린지입니다.");
-            return ResponseEntity.status(HttpStatus.BAD_REQUEST).body(response);
-        }
+    public SuccessResponse<Void> cancel(Long challengeId, Member member) {
 
+        ChallengeEnrollment challengeEnrollment = challengeEnrollmentRepository.findByMember(member)
+                .orElseThrow(() -> new NotEnrolledChallengeException(challengeId, member.getId()));
+
+        validateCancellationTime(challengeId);
+
+        challengeEnrollmentRepository.delete(challengeEnrollment);
+        return SuccessResponse.<Void>of(SuccessCode.CANCEL_CHALLENGE_ENROLLMENT_SUCCESS);
+    }
+
+    private void validateCancellationTime(Long challengeId) {
         Challenge challenge = challengeSearchService.getChallengeById(challengeId);
         ZonedDateTime now = ZonedDateTime.now();
         if (now.isAfter(challenge.getStartDate())) {
-            log.error("챌린지 취소 시간 초과");
-            response = ApiResponse.create("챌린지 취소 가능한 시간이 지났습니다.");
-            return ResponseEntity.status(HttpStatus.BAD_REQUEST).body(response);
+            throw new BadRequestException(ErrorCode.INVALID_CHALLENGE_CANCELLATION_TIME);
         }
-
-        ChallengeEnrollment challengeEnrollment = optionalChallengeEnrollment.get();
-        challengeEnrollmentRepository.delete(challengeEnrollment);
-        log.info("챌린지 참여 취소");
-        response = ApiResponse.create("정상적으로 챌린지 참여를 취소했습니다.");
-        return ResponseEntity.status(HttpStatus.OK).body(response);
     }
 }

--- a/src/main/java/com/habitpay/habitpay/domain/challengeenrollment/application/ChallengeEnrollmentService.java
+++ b/src/main/java/com/habitpay/habitpay/domain/challengeenrollment/application/ChallengeEnrollmentService.java
@@ -9,6 +9,7 @@ import com.habitpay.habitpay.domain.challengeenrollment.exception.AlreadyEnrolle
 import com.habitpay.habitpay.domain.member.domain.Member;
 import com.habitpay.habitpay.global.error.exception.BadRequestException;
 import com.habitpay.habitpay.global.error.exception.ErrorCode;
+import com.habitpay.habitpay.global.response.SuccessCode;
 import com.habitpay.habitpay.global.response.SuccessResponse;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
@@ -38,7 +39,7 @@ public class ChallengeEnrollmentService {
         challengeEnrollmentRepository.save(challengeEnrollment);
 
         return SuccessResponse.of(
-                "챌린지에 정상적으로 등록했습니다.",
+                SuccessCode.ENROLL_CHALLENGE_SUCCESS,
                 ChallengeEnrollmentResponse.of(
                         challenge, challengeEnrollment, member
                 )

--- a/src/main/java/com/habitpay/habitpay/domain/challengeenrollment/application/ChallengeEnrollmentService.java
+++ b/src/main/java/com/habitpay/habitpay/domain/challengeenrollment/application/ChallengeEnrollmentService.java
@@ -22,11 +22,10 @@ public class ChallengeEnrollmentService {
     private final ChallengeEnrollmentRepository challengeEnrollmentRepository;
     private final ChallengeSearchService challengeSearchService;
 
-    public SuccessResponse<ChallengeEnrollmentResponse> enroll(Long challengeId, Long userId) {
+    public SuccessResponse<ChallengeEnrollmentResponse> enroll(Long challengeId, Member member) {
         Challenge challenge = challengeSearchService.getChallengeById(challengeId);
         validateChallengeEnrollmentTime(challenge);
 
-        Member member = memberSearchService.getMemberById(userId);
         challengeEnrollmentRepository.findByMemberAndChallenge(member, challenge)
                 .ifPresent(entity -> {
                     // TODO: 공통 예외 처리 추가하기

--- a/src/main/java/com/habitpay/habitpay/domain/challengeenrollment/exception/AlreadyEnrolledChallengeException.java
+++ b/src/main/java/com/habitpay/habitpay/domain/challengeenrollment/exception/AlreadyEnrolledChallengeException.java
@@ -1,0 +1,14 @@
+package com.habitpay.habitpay.domain.challengeenrollment.exception;
+
+import com.habitpay.habitpay.global.error.exception.ConflictException;
+import com.habitpay.habitpay.global.error.exception.ErrorCode;
+
+public class AlreadyEnrolledChallengeException extends ConflictException {
+
+    public AlreadyEnrolledChallengeException(Long memberId, Long challengeId) {
+        super(
+                String.format("[Member: %d] is already enrolled in [Challenge: %d]", memberId, challengeId),
+                ErrorCode.ALREADY_ENROLLED_IN_CHALLENGE
+        );
+    }
+}

--- a/src/main/java/com/habitpay/habitpay/domain/challengeenrollment/exception/NotEnrolledChallengeException.java
+++ b/src/main/java/com/habitpay/habitpay/domain/challengeenrollment/exception/NotEnrolledChallengeException.java
@@ -7,7 +7,7 @@ public class NotEnrolledChallengeException extends EntityNotFoundException {
 
     public NotEnrolledChallengeException(Long memberId, Long challengeId) {
         super(
-                String.format("[Member: %d] is already enrolled in [Challenge: %d]", memberId, challengeId),
+                String.format("[Member: %d] is not enrolled in [Challenge: %d]", memberId, challengeId),
                 ErrorCode.NOT_ENROLLED_IN_CHALLENGE
         );
     }

--- a/src/main/java/com/habitpay/habitpay/domain/challengeenrollment/exception/NotEnrolledChallengeException.java
+++ b/src/main/java/com/habitpay/habitpay/domain/challengeenrollment/exception/NotEnrolledChallengeException.java
@@ -1,0 +1,14 @@
+package com.habitpay.habitpay.domain.challengeenrollment.exception;
+
+import com.habitpay.habitpay.global.error.exception.EntityNotFoundException;
+import com.habitpay.habitpay.global.error.exception.ErrorCode;
+
+public class NotEnrolledChallengeException extends EntityNotFoundException {
+
+    public NotEnrolledChallengeException(Long memberId, Long challengeId) {
+        super(
+                String.format("[Member: %d] is already enrolled in [Challenge: %d]", memberId, challengeId),
+                ErrorCode.NOT_ENROLLED_IN_CHALLENGE
+        );
+    }
+}

--- a/src/main/java/com/habitpay/habitpay/global/error/exception/BadRequestException.java
+++ b/src/main/java/com/habitpay/habitpay/global/error/exception/BadRequestException.java
@@ -1,0 +1,16 @@
+package com.habitpay.habitpay.global.error.exception;
+
+public class BadRequestException extends BusinessException {
+
+    public BadRequestException(String message) {
+        super(message, ErrorCode.FORBIDDEN);
+    }
+
+    public BadRequestException(ErrorCode errorCode) {
+        super(errorCode);
+    }
+
+    public BadRequestException(String message, ErrorCode errorCode) {
+        super(message, errorCode);
+    }
+}

--- a/src/main/java/com/habitpay/habitpay/global/error/exception/ConflictException.java
+++ b/src/main/java/com/habitpay/habitpay/global/error/exception/ConflictException.java
@@ -1,0 +1,16 @@
+package com.habitpay.habitpay.global.error.exception;
+
+public class ConflictException extends BusinessException {
+
+    public ConflictException(String message) {
+        super(message, ErrorCode.CONFLICT);
+    }
+
+    public ConflictException(ErrorCode errorCode) {
+        super(errorCode);
+    }
+
+    public ConflictException(String message, ErrorCode errorCode) {
+        super(message, errorCode);
+    }
+}

--- a/src/main/java/com/habitpay/habitpay/global/error/exception/ErrorCode.java
+++ b/src/main/java/com/habitpay/habitpay/global/error/exception/ErrorCode.java
@@ -11,7 +11,9 @@ public enum ErrorCode {
     // Common
     ENTITY_NOT_FOUND(HttpStatus.NOT_FOUND, "Entity Not Found"),
     INVALID_VALUE(HttpStatus.BAD_REQUEST, "Invalid Input Value"),
-    FORBIDDEN(HttpStatus.BAD_REQUEST, "Not Allowed to Access or Modify"),
+    BAD_REQUEST(HttpStatus.BAD_REQUEST, "Bad Request"),
+    FORBIDDEN(HttpStatus.FORBIDDEN, "Not Allowed to Access or Modify"),
+    CONFLICT(HttpStatus.CONFLICT, "Conflict"),
 
     // Member
     USER_NOT_FOUND(HttpStatus.NOT_FOUND, "사용자를 찾을 수 없습니다."),
@@ -24,7 +26,9 @@ public enum ErrorCode {
     CHALLENGE_NOT_FOUND(HttpStatus.NOT_FOUND, "챌린지가 존재하지 않습니다."),
     CHALLENGE_START_TIME_INVALID(HttpStatus.BAD_REQUEST, "챌린지 시작 시간은 현재 시간 이후만 가능합니다."),
     ONLY_HOST_CAN_MODIFY(HttpStatus.FORBIDDEN, "챌린지 주최자만 수정 가능합니다."),
-    DUPLICATED_CHALLENGE_DESCRIPTION(HttpStatus.BAD_REQUEST, "변경 사항이 없습니다.");
+    DUPLICATED_CHALLENGE_DESCRIPTION(HttpStatus.BAD_REQUEST, "변경 사항이 없습니다."),
+    INVALID_CHALLENGE_REGISTRATION_TIME(HttpStatus.BAD_REQUEST, "챌린지 등록 가능 시간이 아닙니다."),
+    ALREADY_ENROLLED_IN_CHALLENGE(HttpStatus.CONFLICT, "이미 참여한 챌린지입니다.");
     private HttpStatus status;
     private final String message;
 

--- a/src/main/java/com/habitpay/habitpay/global/error/exception/ErrorCode.java
+++ b/src/main/java/com/habitpay/habitpay/global/error/exception/ErrorCode.java
@@ -30,7 +30,7 @@ public enum ErrorCode {
     INVALID_CHALLENGE_REGISTRATION_TIME(HttpStatus.BAD_REQUEST, "챌린지 등록 가능 시간이 아닙니다."),
     INVALID_CHALLENGE_CANCELLATION_TIME(HttpStatus.BAD_REQUEST, "챌린지 취소 가능한 시간이 지났습니다."),
     ALREADY_ENROLLED_IN_CHALLENGE(HttpStatus.CONFLICT, "이미 참여한 챌린지 입니다."),
-    NOT_ENROLLED_IN_CHALLENGE(HttpStatus.FORBIDDEN, "참여하지 않은 챌린지 입니다."),
+    NOT_ENROLLED_IN_CHALLENGE(HttpStatus.BAD_REQUEST, "참여하지 않은 챌린지 입니다."),
     ;
     private HttpStatus status;
     private final String message;

--- a/src/main/java/com/habitpay/habitpay/global/error/exception/ErrorCode.java
+++ b/src/main/java/com/habitpay/habitpay/global/error/exception/ErrorCode.java
@@ -28,7 +28,10 @@ public enum ErrorCode {
     ONLY_HOST_CAN_MODIFY(HttpStatus.FORBIDDEN, "챌린지 주최자만 수정 가능합니다."),
     DUPLICATED_CHALLENGE_DESCRIPTION(HttpStatus.BAD_REQUEST, "변경 사항이 없습니다."),
     INVALID_CHALLENGE_REGISTRATION_TIME(HttpStatus.BAD_REQUEST, "챌린지 등록 가능 시간이 아닙니다."),
-    ALREADY_ENROLLED_IN_CHALLENGE(HttpStatus.CONFLICT, "이미 참여한 챌린지입니다.");
+    INVALID_CHALLENGE_CANCELLATION_TIME(HttpStatus.BAD_REQUEST, "챌린지 취소 가능한 시간이 지났습니다."),
+    ALREADY_ENROLLED_IN_CHALLENGE(HttpStatus.CONFLICT, "이미 참여한 챌린지 입니다."),
+    NOT_ENROLLED_IN_CHALLENGE(HttpStatus.FORBIDDEN, "참여하지 않은 챌린지 입니다."),
+    ;
     private HttpStatus status;
     private final String message;
 

--- a/src/main/java/com/habitpay/habitpay/global/response/SuccessCode.java
+++ b/src/main/java/com/habitpay/habitpay/global/response/SuccessCode.java
@@ -9,7 +9,12 @@ public enum SuccessCode {
 
     // Member
     NICKNAME_UPDATE_SUCCESS("닉네임 변경에 성공했습니다."),
-    PROFILE_IMAGE_UPDATE_SUCCESS("프로필 이미지 변경에 성공했습니다.");
+    PROFILE_IMAGE_UPDATE_SUCCESS("프로필 이미지 변경에 성공했습니다."),
+
+    // Challenge
+    ENROLL_CHALLENGE_SUCCESS("정상적으로 챌린지에 등록했습니다."),
+    CANCEL_CHALLENGE_ENROLLMENT_SUCCESS("정상적으로 챌린지 등록을 취소했습니다.");
+
     private final String message;
 
 }

--- a/src/main/java/com/habitpay/habitpay/global/response/SuccessResponse.java
+++ b/src/main/java/com/habitpay/habitpay/global/response/SuccessResponse.java
@@ -6,6 +6,7 @@ import lombok.Getter;
 @Getter
 @Builder
 public class SuccessResponse<T> {
+    // TODO: String 대신 SuccessCode 바꾸기
     private final String message;
     private final T data;
 
@@ -13,6 +14,19 @@ public class SuccessResponse<T> {
         return SuccessResponse.<T>builder()
                 .message(message)
                 .data(data)
+                .build();
+    }
+
+    public static <T> SuccessResponse<T> of(SuccessCode successCode, T data) {
+        return SuccessResponse.<T>builder()
+                .message(successCode.getMessage())
+                .data(data)
+                .build();
+    }
+
+    public static <T> SuccessResponse<T> of(SuccessCode successCode) {
+        return SuccessResponse.<T>builder()
+                .message(successCode.getMessage())
                 .build();
     }
 }

--- a/src/test/java/com/habitpay/habitpay/domain/challengeenrollment/api/ChallengeEnrollmentApiTest.java
+++ b/src/test/java/com/habitpay/habitpay/domain/challengeenrollment/api/ChallengeEnrollmentApiTest.java
@@ -5,9 +5,12 @@ import com.habitpay.habitpay.docs.springrestdocs.AbstractRestDocsTests;
 import com.habitpay.habitpay.domain.challengeenrollment.application.ChallengeEnrollmentCancellationService;
 import com.habitpay.habitpay.domain.challengeenrollment.application.ChallengeEnrollmentService;
 import com.habitpay.habitpay.domain.challengeenrollment.dto.ChallengeEnrollmentResponse;
+import com.habitpay.habitpay.domain.challengeenrollment.exception.AlreadyEnrolledChallengeException;
 import com.habitpay.habitpay.domain.member.domain.Member;
 import com.habitpay.habitpay.global.config.jwt.TokenProvider;
 import com.habitpay.habitpay.global.config.jwt.TokenService;
+import com.habitpay.habitpay.global.error.exception.BadRequestException;
+import com.habitpay.habitpay.global.error.exception.ErrorCode;
 import com.habitpay.habitpay.global.response.SuccessResponse;
 import com.habitpay.habitpay.global.security.WithMockOAuth2User;
 import org.junit.jupiter.api.DisplayName;
@@ -85,5 +88,56 @@ public class ChallengeEnrollmentApiTest extends AbstractRestDocsTests {
                 ));
     }
 
+    @Test
+    @WithMockOAuth2User
+    @DisplayName("챌린지 등록 예외처리 - 이미 참여한 챌린지 (409 Conflict)")
+    void enrollChallengeAlreadyEnrolledException() throws Exception {
+
+        // given
+        given(challengeEnrollmentService.enroll(anyLong(), any(Member.class)))
+                .willThrow(new AlreadyEnrolledChallengeException(anyLong(), anyLong()));
+
+        // when
+        ResultActions result = mockMvc.perform(post("/api/challenges/{id}/enroll", 1L)
+                .header(HttpHeaders.AUTHORIZATION, AUTHORIZATION_HEADER_PREFIX + "ACCESS_TOKEN"));
+
+        // then
+        result.andExpect(status().isConflict())
+                .andDo(document("challenge/enroll-challenge-already-enrolled-exception",
+                        requestHeaders(
+                                headerWithName(HttpHeaders.AUTHORIZATION).description("액세스 토큰")
+                        ),
+                        responseFields(
+                                fieldWithPath("code").description("오류 응답 코드"),
+                                fieldWithPath("message").description("오류 메세지")
+                        )
+                ));
+    }
+
+    @Test
+    @WithMockOAuth2User
+    @DisplayName("챌린지 등록 예외처리 - 챌린지 등록 시간 초과 (400 Bad Request)")
+    void enrollChallengeInvalidRegistrationTimeException() throws Exception {
+
+        // given
+        given(challengeEnrollmentService.enroll(anyLong(), any(Member.class)))
+                .willThrow(new BadRequestException(ErrorCode.INVALID_CHALLENGE_REGISTRATION_TIME));
+
+        // when
+        ResultActions result = mockMvc.perform(post("/api/challenges/{id}/enroll", 1L)
+                .header(HttpHeaders.AUTHORIZATION, AUTHORIZATION_HEADER_PREFIX + "ACCESS_TOKEN"));
+
+        // then
+        result.andExpect(status().isBadRequest())
+                .andDo(document("challenge/enroll-challenge-invalid-registration-time-exception",
+                        requestHeaders(
+                                headerWithName(HttpHeaders.AUTHORIZATION).description("액세스 토큰")
+                        ),
+                        responseFields(
+                                fieldWithPath("code").description("오류 응답 코드"),
+                                fieldWithPath("message").description("오류 메세지")
+                        )
+                ));
+    }
 
 }

--- a/src/test/java/com/habitpay/habitpay/domain/challengeenrollment/api/ChallengeEnrollmentApiTest.java
+++ b/src/test/java/com/habitpay/habitpay/domain/challengeenrollment/api/ChallengeEnrollmentApiTest.java
@@ -11,6 +11,7 @@ import com.habitpay.habitpay.global.config.jwt.TokenProvider;
 import com.habitpay.habitpay.global.config.jwt.TokenService;
 import com.habitpay.habitpay.global.error.exception.BadRequestException;
 import com.habitpay.habitpay.global.error.exception.ErrorCode;
+import com.habitpay.habitpay.global.response.SuccessCode;
 import com.habitpay.habitpay.global.response.SuccessResponse;
 import com.habitpay.habitpay.global.security.WithMockOAuth2User;
 import org.junit.jupiter.api.DisplayName;
@@ -67,7 +68,7 @@ public class ChallengeEnrollmentApiTest extends AbstractRestDocsTests {
                 .build();
 
         given(challengeEnrollmentService.enroll(anyLong(), any(Member.class)))
-                .willReturn(SuccessResponse.of("챌린지에 정상적으로 등록했습니다.", challengeEnrollmentResponse));
+                .willReturn(SuccessResponse.of(SuccessCode.ENROLL_CHALLENGE_SUCCESS, challengeEnrollmentResponse));
 
         // when
         ResultActions result = mockMvc.perform(post("/api/challenges/{id}/enroll", 1L)
@@ -136,6 +137,32 @@ public class ChallengeEnrollmentApiTest extends AbstractRestDocsTests {
                         responseFields(
                                 fieldWithPath("code").description("오류 응답 코드"),
                                 fieldWithPath("message").description("오류 메세지")
+                        )
+                ));
+    }
+
+    @Test
+    @WithMockOAuth2User
+    @DisplayName("챌린지 등록 취소")
+    void cancelChallenge() throws Exception {
+
+        // given
+        given(challengeEnrollmentCancellationService.cancel(anyLong(), any(Member.class)))
+                .willReturn(SuccessResponse.<Void>of(SuccessCode.CANCEL_CHALLENGE_ENROLLMENT_SUCCESS));
+
+        // when
+        ResultActions result = mockMvc.perform(post("/api/challenges/{id}/cancel", 1L)
+                .header(HttpHeaders.AUTHORIZATION, AUTHORIZATION_HEADER_PREFIX + "ACCESS_TOKEN"));
+
+        // then
+        result.andExpect(status().isOk())
+                .andDo(document("challenge/cancel-challenge-enrollment",
+                        requestHeaders(
+                                headerWithName(HttpHeaders.AUTHORIZATION).description("액세스 토큰")
+                        ),
+                        responseFields(
+                                fieldWithPath("message").description("메세지"),
+                                fieldWithPath("data").description("null")
                         )
                 ));
     }

--- a/src/test/java/com/habitpay/habitpay/domain/challengeenrollment/api/ChallengeEnrollmentApiTest.java
+++ b/src/test/java/com/habitpay/habitpay/domain/challengeenrollment/api/ChallengeEnrollmentApiTest.java
@@ -5,6 +5,7 @@ import com.habitpay.habitpay.docs.springrestdocs.AbstractRestDocsTests;
 import com.habitpay.habitpay.domain.challengeenrollment.application.ChallengeEnrollmentCancellationService;
 import com.habitpay.habitpay.domain.challengeenrollment.application.ChallengeEnrollmentService;
 import com.habitpay.habitpay.domain.challengeenrollment.dto.ChallengeEnrollmentResponse;
+import com.habitpay.habitpay.domain.member.domain.Member;
 import com.habitpay.habitpay.global.config.jwt.TokenProvider;
 import com.habitpay.habitpay.global.config.jwt.TokenService;
 import com.habitpay.habitpay.global.response.SuccessResponse;
@@ -19,6 +20,7 @@ import org.springframework.test.web.servlet.ResultActions;
 
 import java.time.ZonedDateTime;
 
+import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyLong;
 import static org.mockito.BDDMockito.given;
 import static org.springframework.restdocs.headers.HeaderDocumentation.headerWithName;
@@ -61,7 +63,7 @@ public class ChallengeEnrollmentApiTest extends AbstractRestDocsTests {
                 .enrolledDate(ZonedDateTime.now())
                 .build();
 
-        given(challengeEnrollmentService.enroll(anyLong(), anyLong()))
+        given(challengeEnrollmentService.enroll(anyLong(), any(Member.class)))
                 .willReturn(SuccessResponse.of("챌린지에 정상적으로 등록했습니다.", challengeEnrollmentResponse));
 
         // when

--- a/src/test/java/com/habitpay/habitpay/domain/challengeenrollment/api/ChallengeEnrollmentApiTest.java
+++ b/src/test/java/com/habitpay/habitpay/domain/challengeenrollment/api/ChallengeEnrollmentApiTest.java
@@ -6,6 +6,7 @@ import com.habitpay.habitpay.domain.challengeenrollment.application.ChallengeEnr
 import com.habitpay.habitpay.domain.challengeenrollment.application.ChallengeEnrollmentService;
 import com.habitpay.habitpay.domain.challengeenrollment.dto.ChallengeEnrollmentResponse;
 import com.habitpay.habitpay.domain.challengeenrollment.exception.AlreadyEnrolledChallengeException;
+import com.habitpay.habitpay.domain.challengeenrollment.exception.NotEnrolledChallengeException;
 import com.habitpay.habitpay.domain.member.domain.Member;
 import com.habitpay.habitpay.global.config.jwt.TokenProvider;
 import com.habitpay.habitpay.global.config.jwt.TokenService;
@@ -91,32 +92,6 @@ public class ChallengeEnrollmentApiTest extends AbstractRestDocsTests {
 
     @Test
     @WithMockOAuth2User
-    @DisplayName("챌린지 등록 예외처리 - 이미 참여한 챌린지 (409 Conflict)")
-    void enrollChallengeAlreadyEnrolledException() throws Exception {
-
-        // given
-        given(challengeEnrollmentService.enroll(anyLong(), any(Member.class)))
-                .willThrow(new AlreadyEnrolledChallengeException(anyLong(), anyLong()));
-
-        // when
-        ResultActions result = mockMvc.perform(post("/api/challenges/{id}/enroll", 1L)
-                .header(HttpHeaders.AUTHORIZATION, AUTHORIZATION_HEADER_PREFIX + "ACCESS_TOKEN"));
-
-        // then
-        result.andExpect(status().isConflict())
-                .andDo(document("challenge/enroll-challenge-already-enrolled-exception",
-                        requestHeaders(
-                                headerWithName(HttpHeaders.AUTHORIZATION).description("액세스 토큰")
-                        ),
-                        responseFields(
-                                fieldWithPath("code").description("오류 응답 코드"),
-                                fieldWithPath("message").description("오류 메세지")
-                        )
-                ));
-    }
-
-    @Test
-    @WithMockOAuth2User
     @DisplayName("챌린지 등록 예외처리 - 챌린지 등록 시간 초과 (400 Bad Request)")
     void enrollChallengeInvalidRegistrationTimeException() throws Exception {
 
@@ -131,6 +106,32 @@ public class ChallengeEnrollmentApiTest extends AbstractRestDocsTests {
         // then
         result.andExpect(status().isBadRequest())
                 .andDo(document("challenge/enroll-challenge-invalid-registration-time-exception",
+                        requestHeaders(
+                                headerWithName(HttpHeaders.AUTHORIZATION).description("액세스 토큰")
+                        ),
+                        responseFields(
+                                fieldWithPath("code").description("오류 응답 코드"),
+                                fieldWithPath("message").description("오류 메세지")
+                        )
+                ));
+    }
+
+    @Test
+    @WithMockOAuth2User
+    @DisplayName("챌린지 등록 예외처리 - 이미 참여한 챌린지 (409 Conflict)")
+    void enrollChallengeAlreadyEnrolledException() throws Exception {
+
+        // given
+        given(challengeEnrollmentService.enroll(anyLong(), any(Member.class)))
+                .willThrow(new AlreadyEnrolledChallengeException(anyLong(), anyLong()));
+
+        // when
+        ResultActions result = mockMvc.perform(post("/api/challenges/{id}/enroll", 1L)
+                .header(HttpHeaders.AUTHORIZATION, AUTHORIZATION_HEADER_PREFIX + "ACCESS_TOKEN"));
+
+        // then
+        result.andExpect(status().isConflict())
+                .andDo(document("challenge/enroll-challenge-already-enrolled-exception",
                         requestHeaders(
                                 headerWithName(HttpHeaders.AUTHORIZATION).description("액세스 토큰")
                         ),
@@ -163,6 +164,58 @@ public class ChallengeEnrollmentApiTest extends AbstractRestDocsTests {
                         responseFields(
                                 fieldWithPath("message").description("메세지"),
                                 fieldWithPath("data").description("null")
+                        )
+                ));
+    }
+
+    @Test
+    @WithMockOAuth2User
+    @DisplayName("챌린지 등록 취소 예외처리 - 참여한 챌린지가 없는 경우 (400 Bad Request)")
+    void cancelChallengeNotEnrolledException() throws Exception {
+
+        // given
+        given(challengeEnrollmentCancellationService.cancel(anyLong(), any(Member.class)))
+                .willThrow(new NotEnrolledChallengeException(anyLong(), anyLong()));
+
+        // when
+        ResultActions result = mockMvc.perform(post("/api/challenges/{id}/cancel", 1L)
+                .header(HttpHeaders.AUTHORIZATION, AUTHORIZATION_HEADER_PREFIX + "ACCESS_TOKEN"));
+
+        // then
+        result.andExpect(status().isBadRequest())
+                .andDo(document("challenge/cancel-challenge-enrollment-not-enrolled-exception",
+                        requestHeaders(
+                                headerWithName(HttpHeaders.AUTHORIZATION).description("액세스 토큰")
+                        ),
+                        responseFields(
+                                fieldWithPath("code").description("오류 응답 코드"),
+                                fieldWithPath("message").description("오류 메세지")
+                        )
+                ));
+    }
+
+    @Test
+    @WithMockOAuth2User
+    @DisplayName("챌린지 등록 취소 예외처리 - 참여한 챌린지가 없는 경우 (400 Bad Request)")
+    void cancelChallengeInvalidCancellationTimeException() throws Exception {
+
+        // given
+        given(challengeEnrollmentCancellationService.cancel(anyLong(), any(Member.class)))
+                .willThrow(new BadRequestException(ErrorCode.INVALID_CHALLENGE_CANCELLATION_TIME));
+
+        // when
+        ResultActions result = mockMvc.perform(post("/api/challenges/{id}/cancel", 1L)
+                .header(HttpHeaders.AUTHORIZATION, AUTHORIZATION_HEADER_PREFIX + "ACCESS_TOKEN"));
+
+        // then
+        result.andExpect(status().isBadRequest())
+                .andDo(document("challenge/cancel-challenge-enrollment-invalid-cancellation-time-exception",
+                        requestHeaders(
+                                headerWithName(HttpHeaders.AUTHORIZATION).description("액세스 토큰")
+                        ),
+                        responseFields(
+                                fieldWithPath("code").description("오류 응답 코드"),
+                                fieldWithPath("message").description("오류 메세지")
                         )
                 ));
     }


### PR DESCRIPTION
# 작업 개요

1. ChallengeEnrollment 도메인의 서비스 메서드에서 예외처리 시 공통 응답 클래스를 적용했습니다. 
2. ChallengeEnrollment 도메인의 예외처리에 대한 테스트 코드를 작성했습니다.
3. DELETE 작업 수행 시 `SuccessResponse` 의 data 에 null 을 넣을 수 있도록 수정했습니다. 

# 작업 상세 내용

## 3. `SuccessResponse` 의 data 에 null 입력.

DELETE 작업 수행 시에는 별도의 정보를 넘겨줄 필요는 없다고 판단해서 `data` 필드에 null 을 넘겨주었습니다.

`SuccessResponse` 의 제네릭으로 `Void` 클래스를 입력합니다.

```java
// ChallengeEnrollmentApi.java

@PostMapping("/challenges/{id}/cancel")
public SuccessResponse<Void> cancelChallenge(@PathVariable("id") Long id, @AuthenticationPrincipal CustomUserDetails user) {
    return challengeEnrollmentCancellationService.cancel(id, user.getMember());
}
```

`SuccessResponse` 의 `of` 메서드를 `data` 필드의 값을 입력하지 않도록 오버로딩 했습니다.

```java
// SuccessResponse.java

public static <T> SuccessResponse<T> of(SuccessCode successCode) {
    return SuccessResponse.<T>builder()
            .message(successCode.getMessage())
            .build();
}
```

서비스 메서드에서는 아래와 같이 작성합니다.

```java
public SuccessResponse<Void> cancel(Long challengeId, Member member) {

    ChallengeEnrollment challengeEnrollment = challengeEnrollmentRepository.findByMember(member)
            .orElseThrow(() -> new NotEnrolledChallengeException(challengeId, member.getId()));

    validateCancellationTime(challengeId);

    challengeEnrollmentRepository.delete(challengeEnrollment);
    return SuccessResponse.<Void>of(SuccessCode.CANCEL_CHALLENGE_ENROLLMENT_SUCCESS);
}
```

응답은 아래와 같이 옵니다. 

```json
{
    "message": "정상적으로 챌린지 등록을 취소했습니다.",
    "data": null
}
```