### PR TITLE
[change] refreshToken 발급 메서드 변경

### DIFF
--- a/src/main/java/com/habitpay/habitpay/domain/refreshtoken/application/RefreshTokenCreationService.java
+++ b/src/main/java/com/habitpay/habitpay/domain/refreshtoken/application/RefreshTokenCreationService.java
@@ -19,7 +19,6 @@ import org.springframework.stereotype.Service;
 
 import java.time.Duration;
 import java.util.Objects;
-import java.util.Optional;
 
 @RequiredArgsConstructor
 @Service
@@ -85,7 +84,7 @@ public class RefreshTokenCreationService {
 
     public String createRefreshToken(Long id) {
         Member member = memberSearchService.getMemberById(id);
-        String refreshToken = tokenService.createRefreshToken(id);
+        String refreshToken = tokenService.createRefreshTokenContent(id);
         saveRefreshToken(member, refreshToken);
 
         return refreshToken;

--- a/src/main/java/com/habitpay/habitpay/global/config/auth/CustomOAuth2LoginSuccessHandler.java
+++ b/src/main/java/com/habitpay/habitpay/global/config/auth/CustomOAuth2LoginSuccessHandler.java
@@ -1,5 +1,6 @@
 package com.habitpay.habitpay.global.config.auth;
 
+import com.habitpay.habitpay.domain.refreshtoken.application.RefreshTokenCreationService;
 import com.habitpay.habitpay.global.config.jwt.TokenService;
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
@@ -24,6 +25,7 @@ public class CustomOAuth2LoginSuccessHandler extends SimpleUrlAuthenticationSucc
     private final String redirectUrl = "http://localhost:3000/auth";
 
     private final TokenService tokenService;
+    private final RefreshTokenCreationService refreshTokenCreationService;
 
     @Override
     public void onAuthenticationSuccess(
@@ -37,7 +39,7 @@ public class CustomOAuth2LoginSuccessHandler extends SimpleUrlAuthenticationSucc
             CustomUserDetails customUserDetails = (CustomUserDetails) authentication.getPrincipal();
             Long memberId = customUserDetails.getId();
             String accessToken = tokenService.createAccessToken(memberId);
-            String refreshToken = tokenService.createRefreshToken(memberId);
+            String refreshToken = refreshTokenCreationService.createRefreshToken(memberId);
 
             super.clearAuthenticationAttributes(request);
 

--- a/src/main/java/com/habitpay/habitpay/global/config/jwt/TokenService.java
+++ b/src/main/java/com/habitpay/habitpay/global/config/jwt/TokenService.java
@@ -37,7 +37,7 @@ public class TokenService {
         return tokenProvider.generateToken(member, ACCESS_TOKEN_EXPIRED_AT);
     }
 
-    public String createRefreshToken(Long id) {
+    public String createRefreshTokenContent(Long id) {
         Member member = memberSearchService.getMemberById(id);
 
         return tokenProvider.generateRefreshToken(member, REFRESH_TOKEN_EXPIRED_AT);


### PR DESCRIPTION
### 내용

* 최초 로그인 시 `RefreshToken 엔티티`가 DB에 저장되지 않는 문제 발견

---

* `OAuth2` 로그인 및 최초 회원 가입을 담당하는 `CustomOAuth2LoginSuccessHandler.java`에서 메서드 변경하기

```java
// before
String refreshToken = tokenService.createRefreshToken(memberId);

// after
String refreshToken = refreshTokenCreationService.createRefreshToken(memberId);
```

* `tokenService`의 `createRefreshToken`은 token 자체를 생성해주는 메서드
* `refreshTokenCreationService`의 `createRefreshToken`은 위의 메서드를 이용해 token을 생성하고 repo에 저장까지 해주는 메서드

---

* 이름을 헷갈리게 짓고 제대로 말씀드리지 않은 제 탓입니더.. 흑
* `createRefreshToken`가 더 쓰일 일은 없지만, 혹여나 하는 마음에 token 자체 생성만 해주는 메서드의 이름을 변경했습니다..

```java
// TokenService.java

// after
public String createRefreshToken(Long id) {

// before
public String createRefreshTokenContent(Long id) {
```