### PR TITLE
Feat/챌린지 주최자 등록 취소 불가 처리#199

### DIFF
--- a/src/docs/asciidoc/api/challenge.adoc
+++ b/src/docs/asciidoc/api/challenge.adoc
@@ -99,6 +99,12 @@ operation::challenge/cancel-challenge-enrollment[snippets='http-request,http-res
 
 ==== 에러 응답
 
+===== 챌린지 주최자가 등록 취소 하는 경우 (400 Bad Request)
+
+챌린지 주최자는 등록을 취소할 수 없습니다.
+
+operation::challenge/cancel-challenge-enrollment-host-not-allowed-exception[snippets='http-request,http-response,response-fields']
+
 ===== 챌린지에 참여하지 않은 경우 (400 Bad Request)
 
 참여하지 않은 챌린지를 취소하는 경우입니다.

--- a/src/main/java/com/habitpay/habitpay/global/error/exception/ErrorCode.java
+++ b/src/main/java/com/habitpay/habitpay/global/error/exception/ErrorCode.java
@@ -31,7 +31,7 @@ public enum ErrorCode {
     INVALID_CHALLENGE_CANCELLATION_TIME(HttpStatus.BAD_REQUEST, "챌린지 취소 가능한 시간이 지났습니다."),
     ALREADY_ENROLLED_IN_CHALLENGE(HttpStatus.CONFLICT, "이미 참여한 챌린지 입니다."),
     NOT_ENROLLED_IN_CHALLENGE(HttpStatus.BAD_REQUEST, "참여하지 않은 챌린지 입니다."),
-    ;
+    NOT_ALLOWED_TO_CANCEL_ENROLLMENT_OF_HOST(HttpStatus.BAD_REQUEST, "챌린지 주최자는 참여 취소가 불가능 합니다.");
     private HttpStatus status;
     private final String message;
 

--- a/src/test/java/com/habitpay/habitpay/domain/challengeenrollment/api/ChallengeEnrollmentApiTest.java
+++ b/src/test/java/com/habitpay/habitpay/domain/challengeenrollment/api/ChallengeEnrollmentApiTest.java
@@ -196,7 +196,33 @@ public class ChallengeEnrollmentApiTest extends AbstractRestDocsTests {
 
     @Test
     @WithMockOAuth2User
-    @DisplayName("챌린지 등록 취소 예외처리 - 참여한 챌린지가 없는 경우 (400 Bad Request)")
+    @DisplayName("챌린지 등록 취소 예외처리 - 챌린지 주최자가 등록 취소 하는 경우 (400 Bad Request)")
+    void cancelChallengeHostNotAllowedException() throws Exception {
+
+        // given
+        given(challengeEnrollmentCancellationService.cancel(anyLong(), any(Member.class)))
+                .willThrow(new BadRequestException(ErrorCode.NOT_ALLOWED_TO_CANCEL_ENROLLMENT_OF_HOST));
+
+        // when
+        ResultActions result = mockMvc.perform(post("/api/challenges/{id}/cancel", 1L)
+                .header(HttpHeaders.AUTHORIZATION, AUTHORIZATION_HEADER_PREFIX + "ACCESS_TOKEN"));
+
+        // then
+        result.andExpect(status().isBadRequest())
+                .andDo(document("challenge/cancel-challenge-enrollment-not-enrolled-exception",
+                        requestHeaders(
+                                headerWithName(HttpHeaders.AUTHORIZATION).description("액세스 토큰")
+                        ),
+                        responseFields(
+                                fieldWithPath("code").description("오류 응답 코드"),
+                                fieldWithPath("message").description("오류 메세지")
+                        )
+                ));
+    }
+
+    @Test
+    @WithMockOAuth2User
+    @DisplayName("챌린지 등록 취소 예외처리 - 챌린지 등록 취소 시간이 지난 경우 (400 Bad Request)")
     void cancelChallengeInvalidCancellationTimeException() throws Exception {
 
         // given

--- a/src/test/java/com/habitpay/habitpay/domain/challengeenrollment/api/ChallengeEnrollmentApiTest.java
+++ b/src/test/java/com/habitpay/habitpay/domain/challengeenrollment/api/ChallengeEnrollmentApiTest.java
@@ -209,7 +209,7 @@ public class ChallengeEnrollmentApiTest extends AbstractRestDocsTests {
 
         // then
         result.andExpect(status().isBadRequest())
-                .andDo(document("challenge/cancel-challenge-enrollment-not-enrolled-exception",
+                .andDo(document("challenge/cancel-challenge-enrollment-host-not-allowed-exception",
                         requestHeaders(
                                 headerWithName(HttpHeaders.AUTHORIZATION).description("액세스 토큰")
                         ),


### PR DESCRIPTION
# 작업 개요

1. 챌린지 주최자는 본인이 생성한 챌린지의 등록 취소는 불가능하도록 수정했습니다. (`POST /challenges/{id}/cancel`)
2. 1번에서 추가한 예외처리에 대한 테스트 코드를 작성했습니다. 