### PR TITLE
Fix/챌린지 등록 시 참여 인원 계산 문제 수정#204

### DIFF
--- a/src/main/java/com/habitpay/habitpay/domain/challenge/domain/Challenge.java
+++ b/src/main/java/com/habitpay/habitpay/domain/challenge/domain/Challenge.java
@@ -91,7 +91,7 @@ public class Challenge extends BaseTime {
     }
 
     public void setNumberOfParticipants(int numberOfParticipants) {
-        this.numberOfParticipants += numberOfParticipants;
+        this.numberOfParticipants = numberOfParticipants;
     }
 
     public boolean isTodayParticipatingDay() {

--- a/src/main/java/com/habitpay/habitpay/domain/challengeenrollment/application/ChallengeEnrollmentCancellationService.java
+++ b/src/main/java/com/habitpay/habitpay/domain/challengeenrollment/application/ChallengeEnrollmentCancellationService.java
@@ -10,6 +10,7 @@ import com.habitpay.habitpay.global.error.exception.BadRequestException;
 import com.habitpay.habitpay.global.error.exception.ErrorCode;
 import com.habitpay.habitpay.global.response.SuccessCode;
 import com.habitpay.habitpay.global.response.SuccessResponse;
+import jakarta.transaction.Transactional;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
@@ -23,6 +24,7 @@ public class ChallengeEnrollmentCancellationService {
     private final ChallengeEnrollmentRepository challengeEnrollmentRepository;
     private final ChallengeSearchService challengeSearchService;
 
+    @Transactional
     public SuccessResponse<Void> cancel(Long challengeId, Member member) {
 
         ChallengeEnrollment challengeEnrollment = challengeEnrollmentRepository.findByMember(member)
@@ -33,6 +35,7 @@ public class ChallengeEnrollmentCancellationService {
         validateChallengeHost(member, challenge);
         validateCancellationTime(challenge);
 
+        challenge.setNumberOfParticipants(challenge.getNumberOfParticipants() - 1);
         challengeEnrollmentRepository.delete(challengeEnrollment);
         return SuccessResponse.<Void>of(SuccessCode.CANCEL_CHALLENGE_ENROLLMENT_SUCCESS);
     }

--- a/src/main/java/com/habitpay/habitpay/domain/challengeenrollment/application/ChallengeEnrollmentService.java
+++ b/src/main/java/com/habitpay/habitpay/domain/challengeenrollment/application/ChallengeEnrollmentService.java
@@ -11,6 +11,7 @@ import com.habitpay.habitpay.global.error.exception.BadRequestException;
 import com.habitpay.habitpay.global.error.exception.ErrorCode;
 import com.habitpay.habitpay.global.response.SuccessCode;
 import com.habitpay.habitpay.global.response.SuccessResponse;
+import jakarta.transaction.Transactional;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
@@ -24,6 +25,7 @@ public class ChallengeEnrollmentService {
     private final ChallengeEnrollmentRepository challengeEnrollmentRepository;
     private final ChallengeSearchService challengeSearchService;
 
+    @Transactional
     public SuccessResponse<ChallengeEnrollmentResponse> enroll(Long challengeId, Member member) {
         Challenge challenge = challengeSearchService.getChallengeById(challengeId);
         validateChallengeEnrollmentTime(challenge);


### PR DESCRIPTION
# 작업 개요

1. 챌린지 등록 및 취소 시 인원이 1명이 아닌 2명씩 증감하는 문제를 수정했습니다. 
2. 챌린지 등록, 챌린지 정보 수정 작업이 모두 보장되어야 하는 메서드에 트랜잭션을 적용했습니다. 