### PR TITLE
Feat/챌린지 상세 정보 조회 시 참여자 프로필 이미지 링크 전송#206

### DIFF
--- a/src/main/java/com/habitpay/habitpay/domain/challenge/application/ChallengeDetailsService.java
+++ b/src/main/java/com/habitpay/habitpay/domain/challenge/application/ChallengeDetailsService.java
@@ -3,17 +3,23 @@ package com.habitpay.habitpay.domain.challenge.application;
 import com.habitpay.habitpay.domain.challenge.domain.Challenge;
 import com.habitpay.habitpay.domain.challenge.dto.ChallengeDetailsResponse;
 import com.habitpay.habitpay.domain.challengeenrollment.dao.ChallengeEnrollmentRepository;
+import com.habitpay.habitpay.domain.challengeenrollment.domain.ChallengeEnrollment;
 import com.habitpay.habitpay.domain.member.application.MemberSearchService;
 import com.habitpay.habitpay.domain.member.domain.Member;
+import com.habitpay.habitpay.global.config.aws.S3FileService;
 import com.habitpay.habitpay.global.response.SuccessResponse;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
 
+import java.util.List;
+import java.util.Optional;
+
 @Slf4j
 @Service
 @RequiredArgsConstructor
 public class ChallengeDetailsService {
+    private final S3FileService s3FileService;
     private final ChallengeSearchService challengeSearchService;
     private final ChallengeEnrollmentRepository challengeEnrollmentRepository;
 
@@ -21,12 +27,22 @@ public class ChallengeDetailsService {
         Challenge challenge = challengeSearchService.getChallengeById(challengeId);
         Boolean isMemberEnrolledInChallenge = challengeEnrollmentRepository.findByMemberAndChallenge(member, challenge)
                 .isPresent();
+        List<ChallengeEnrollment> challengeEnrollmentList = challengeEnrollmentRepository.findTop3ByChallenge(challenge);
+        List<String> enrolledMembersProfileImageList = challengeEnrollmentList.stream()
+                .map((challengeEnrollment) -> {
+                    return Optional.ofNullable(challengeEnrollment.getMember().getImageFileName())
+                            .map((imageFileName) -> s3FileService.getGetPreSignedUrl("profiles", imageFileName))
+                            .orElse("");
+                })
+                .toList();
+
 
         return SuccessResponse.of(
                 "",
                 ChallengeDetailsResponse.of(
                         member,
                         challenge,
+                        enrolledMembersProfileImageList,
                         isMemberEnrolledInChallenge)
         );
     }

--- a/src/main/java/com/habitpay/habitpay/domain/challenge/dto/ChallengeDetailsResponse.java
+++ b/src/main/java/com/habitpay/habitpay/domain/challenge/dto/ChallengeDetailsResponse.java
@@ -6,6 +6,7 @@ import lombok.Builder;
 import lombok.Getter;
 
 import java.time.ZonedDateTime;
+import java.util.List;
 
 @Getter
 @Builder
@@ -20,11 +21,11 @@ public class ChallengeDetailsResponse {
     private int feePerAbsence;
     private Boolean isPaidAll;
     private String hostNickname;
-    private String hostProfileImage;
+    private List<String> enrolledMembersProfileImageList;
     private Boolean isHost;
     private Boolean isMemberEnrolledInChallenge;
 
-    public static ChallengeDetailsResponse of(Member member, Challenge challenge, Boolean isMemberEnrolledInChallenge) {
+    public static ChallengeDetailsResponse of(Member member, Challenge challenge, List<String> enrolledMembersProfileImageList, Boolean isMemberEnrolledInChallenge) {
         return ChallengeDetailsResponse.builder()
                 .title(challenge.getTitle())
                 .description(challenge.getDescription())
@@ -36,7 +37,7 @@ public class ChallengeDetailsResponse {
                 .participatingDays(challenge.getParticipatingDays())
                 .feePerAbsence(challenge.getFeePerAbsence())
                 .hostNickname(challenge.getHost().getNickname())
-                .hostProfileImage(challenge.getHost().getImageFileName())
+                .enrolledMembersProfileImageList(enrolledMembersProfileImageList)
                 .isHost(challenge.getHost().getId().equals(member.getId()))
                 .isMemberEnrolledInChallenge(isMemberEnrolledInChallenge)
                 .build();

--- a/src/main/java/com/habitpay/habitpay/domain/challengeenrollment/dao/ChallengeEnrollmentRepository.java
+++ b/src/main/java/com/habitpay/habitpay/domain/challengeenrollment/dao/ChallengeEnrollmentRepository.java
@@ -14,4 +14,5 @@ public interface ChallengeEnrollmentRepository extends JpaRepository<ChallengeEn
     Optional<ChallengeEnrollment> findByMemberAndChallenge(Member member, Challenge challenge);
 
     List<ChallengeEnrollment> findAllByMember(Member member);
+    List<ChallengeEnrollment> findTop3ByChallenge(Challenge challenge);
 }

--- a/src/test/java/com/habitpay/habitpay/domain/challenge/api/ChallengeApiTest.java
+++ b/src/test/java/com/habitpay/habitpay/domain/challenge/api/ChallengeApiTest.java
@@ -29,8 +29,7 @@ import org.springframework.test.web.servlet.ResultActions;
 import java.time.ZonedDateTime;
 import java.util.List;
 
-import static org.mockito.ArgumentMatchers.any;
-import static org.mockito.ArgumentMatchers.anyLong;
+import static org.mockito.ArgumentMatchers.*;
 import static org.mockito.BDDMockito.given;
 import static org.springframework.restdocs.headers.HeaderDocumentation.headerWithName;
 import static org.springframework.restdocs.headers.HeaderDocumentation.requestHeaders;
@@ -140,7 +139,7 @@ public class ChallengeApiTest extends AbstractRestDocsTests {
                 .feePerAbsence(1000)
                 .isPaidAll(false)
                 .hostNickname("챌린지 주최자 닉네임")
-                .hostProfileImage("챌린지 주최자 프로필 이미지")
+                .enrolledMembersProfileImageList(List.of("imageLink1", "imageLink2", "imageLink3"))
                 .isHost(true)
                 .isMemberEnrolledInChallenge(true)
                 .build();
@@ -170,7 +169,7 @@ public class ChallengeApiTest extends AbstractRestDocsTests {
                                 fieldWithPath("data.feePerAbsence").description("미참여 1회당 벌금"),
                                 fieldWithPath("data.isPaidAll").description("최종 정산 여부"),
                                 fieldWithPath("data.hostNickname").description("챌린지 주최자 닉네임"),
-                                fieldWithPath("data.hostProfileImage").description("챌린지 주최자 프로필 이미지"),
+                                fieldWithPath("data.enrolledMembersProfileImageList").description("챌린지 참여자 프로필 이미지 (최대 3명)"),
                                 fieldWithPath("data.isHost").description("현재 접속한 사용자 == 챌린지 주최자"),
                                 fieldWithPath("data.isMemberEnrolledInChallenge").description("현재 접속한 사용자의 챌린지 참여 여부")
                         )

--- a/src/test/java/com/habitpay/habitpay/domain/challenge/api/ChallengeApiTest.java
+++ b/src/test/java/com/habitpay/habitpay/domain/challenge/api/ChallengeApiTest.java
@@ -71,6 +71,7 @@ public class ChallengeApiTest extends AbstractRestDocsTests {
 
         // given
         ChallengeEnrolledListItemResponse response = ChallengeEnrolledListItemResponse.builder()
+                .challengeId(1L)
                 .title("챌린지 제목")
                 .description("챌린지 설명")
                 .startDate(ZonedDateTime.now())
@@ -103,6 +104,7 @@ public class ChallengeApiTest extends AbstractRestDocsTests {
                         ),
                         responseFields(
                                 fieldWithPath("message").description("메세지"),
+                                fieldWithPath("data[].challengeId").description("챌린지 ID"),
                                 fieldWithPath("data[].title").description("챌린지 제목"),
                                 fieldWithPath("data[].description").description("챌린지 설명"),
                                 fieldWithPath("data[].startDate").description("챌린지 시작 일시"),


### PR DESCRIPTION
# 작업 개요 

챌린지 상세 정보 조회 `GET /challenges/{id}` 요청 시 참여자 프로필 이미지 링크를 전송합니다.

참여자는 최대 3명만 조회합니다. 

참고로 아래의 사진에서 주황색으로 표시된 부분에 넣어줄 프로필 이미지입니다.

<img width="582" alt="image" src="https://github.com/user-attachments/assets/ac5fc256-74ee-41b5-84dd-6888d502ff5d">
