### PR TITLE
[Feat] 필터에서 발생한 JWT 예외 처리하기 #202

### DIFF
--- a/src/main/java/com/habitpay/habitpay/domain/refreshtoken/application/RefreshTokenCreationService.java
+++ b/src/main/java/com/habitpay/habitpay/domain/refreshtoken/application/RefreshTokenCreationService.java
@@ -63,14 +63,16 @@ public class RefreshTokenCreationService {
 
     private String createNewAccessToken(String refreshToken) {
 
-        tokenProvider.validateToken(refreshToken);
+        if (!tokenProvider.validateToken(refreshToken)) {
+            throw new CustomJwtException(HttpStatus.UNAUTHORIZED, CustomJwtErrorInfo.UNAUTHORIZED, "JWT 토큰 검증에 실패했습니다.");
+        }
 
         String requestIp = refreshTokenUtilService.getClientIpAddress();
         String loginIp = refreshTokenSearchService.findByRefreshToken(refreshToken).getLoginIp();
         log.info("[Client new request IP] {}", requestIp);
         log.info("[Client old login IP] {}", loginIp);
         if (!Objects.equals(requestIp, loginIp)) {
-            throw new CustomJwtException(HttpStatus.BAD_REQUEST, CustomJwtErrorInfo.BAD_REQUEST, "request IP address is different from login IP address.");
+            throw new CustomJwtException(HttpStatus.BAD_REQUEST, CustomJwtErrorInfo.BAD_REQUEST, "로그인한 IP 주소와 요청 IP 주소가 일치하지 않습니다.");
         }
 
         Long memberId = refreshTokenSearchService.findByRefreshToken(refreshToken).getMember().getId();

--- a/src/main/java/com/habitpay/habitpay/domain/refreshtoken/application/RefreshTokenCreationService.java
+++ b/src/main/java/com/habitpay/habitpay/domain/refreshtoken/application/RefreshTokenCreationService.java
@@ -26,9 +26,7 @@ import java.util.Objects;
 public class RefreshTokenCreationService {
 
     private final TokenProvider tokenProvider;
-
     private final MemberSearchService memberSearchService;
-    private final MemberRepository memberRepository;
     private final TokenService tokenService;
     private final RefreshTokenUtilService refreshTokenUtilService;
     private final RefreshTokenSearchService refreshTokenSearchService;
@@ -78,8 +76,7 @@ public class RefreshTokenCreationService {
         Long memberId = refreshTokenSearchService.findByRefreshToken(refreshToken).getMember().getId();
         Member member = memberSearchService.getMemberById(memberId);
 
-        // todo : 토큰 유효 기간
-        return tokenProvider.generateToken(member, Duration.ofHours(2));
+        return tokenProvider.generateToken(member, TokenService.ACCESS_TOKEN_EXPIRED_AT);
     }
 
     public String createRefreshToken(Long id) {

--- a/src/main/java/com/habitpay/habitpay/global/config/auth/JwtAuthenticationEntryPoint.java
+++ b/src/main/java/com/habitpay/habitpay/global/config/auth/JwtAuthenticationEntryPoint.java
@@ -8,6 +8,8 @@ import org.springframework.security.web.AuthenticationEntryPoint;
 import org.springframework.stereotype.Component;
 import org.springframework.web.servlet.HandlerExceptionResolver;
 
+import java.io.IOException;
+
 @Component
 public class JwtAuthenticationEntryPoint implements AuthenticationEntryPoint {
 
@@ -21,8 +23,11 @@ public class JwtAuthenticationEntryPoint implements AuthenticationEntryPoint {
     public void commence(
             HttpServletRequest request,
             HttpServletResponse response,
-            AuthenticationException exception) {
+            AuthenticationException exception) throws IOException {
+        response.sendError(HttpServletResponse.SC_UNAUTHORIZED, exception.getLocalizedMessage());
 
-        resolver.resolveException(request, response, null, exception);
+//        resolver.resolveException(request, response, null, (Exception) request.getAttribute("exception"));
+//        resolver.resolveException(request, response, null, exception);
+
     }
 }

--- a/src/main/java/com/habitpay/habitpay/global/config/auth/JwtAuthenticationEntryPoint.java
+++ b/src/main/java/com/habitpay/habitpay/global/config/auth/JwtAuthenticationEntryPoint.java
@@ -1,0 +1,28 @@
+package com.habitpay.habitpay.global.config.auth;
+
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import org.springframework.beans.factory.annotation.Qualifier;
+import org.springframework.security.core.AuthenticationException;
+import org.springframework.security.web.AuthenticationEntryPoint;
+import org.springframework.stereotype.Component;
+import org.springframework.web.servlet.HandlerExceptionResolver;
+
+@Component
+public class JwtAuthenticationEntryPoint implements AuthenticationEntryPoint {
+
+    private final HandlerExceptionResolver resolver;
+
+    public JwtAuthenticationEntryPoint(@Qualifier("handlerExceptionResolver") HandlerExceptionResolver resolver) {
+        this.resolver = resolver;
+    }
+
+    @Override
+    public void commence(
+            HttpServletRequest request,
+            HttpServletResponse response,
+            AuthenticationException exception) {
+
+        resolver.resolveException(request, response, null, exception);
+    }
+}

--- a/src/main/java/com/habitpay/habitpay/global/config/auth/JwtAuthenticationEntryPoint.java
+++ b/src/main/java/com/habitpay/habitpay/global/config/auth/JwtAuthenticationEntryPoint.java
@@ -20,7 +20,7 @@ public class JwtAuthenticationEntryPoint implements AuthenticationEntryPoint {
             HttpServletRequest request,
             HttpServletResponse response,
             AuthenticationException exception) throws IOException {
-        // todo : ErrorCode 메시지를 JWT 커스텀으로 변경하기
+        // todo : ErrorCode 메시지를 JWT 커스텀으로 변경하기 & UNATHORIZED로 변경
         ErrorResponse errorResponse = ErrorResponse.of(ErrorCode.BAD_REQUEST);
         response.setContentType("application/json");
         response.setStatus(HttpServletResponse.SC_BAD_REQUEST);

--- a/src/main/java/com/habitpay/habitpay/global/config/auth/JwtAuthenticationEntryPoint.java
+++ b/src/main/java/com/habitpay/habitpay/global/config/auth/JwtAuthenticationEntryPoint.java
@@ -2,15 +2,15 @@ package com.habitpay.habitpay.global.config.auth;
 
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.security.core.AuthenticationException;
 import org.springframework.security.web.AuthenticationEntryPoint;
 import org.springframework.stereotype.Component;
 import org.springframework.web.servlet.HandlerExceptionResolver;
 
-import java.io.IOException;
-
 @Component
+@Slf4j
 public class JwtAuthenticationEntryPoint implements AuthenticationEntryPoint {
 
     private final HandlerExceptionResolver resolver;
@@ -23,11 +23,9 @@ public class JwtAuthenticationEntryPoint implements AuthenticationEntryPoint {
     public void commence(
             HttpServletRequest request,
             HttpServletResponse response,
-            AuthenticationException exception) throws IOException {
-        response.sendError(HttpServletResponse.SC_UNAUTHORIZED, exception.getLocalizedMessage());
-
-//        resolver.resolveException(request, response, null, (Exception) request.getAttribute("exception"));
-//        resolver.resolveException(request, response, null, exception);
-
+            AuthenticationException exception) {
+        log.error("JwtAuthenticationEntryPoint.commence() {}", exception.getLocalizedMessage());
+        resolver.resolveException(request, response, null, (Exception) request.getAttribute("exception"));
     }
+
 }

--- a/src/main/java/com/habitpay/habitpay/global/config/auth/JwtAuthenticationEntryPoint.java
+++ b/src/main/java/com/habitpay/habitpay/global/config/auth/JwtAuthenticationEntryPoint.java
@@ -1,31 +1,32 @@
 package com.habitpay.habitpay.global.config.auth;
 
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.habitpay.habitpay.global.error.ErrorResponse;
+import com.habitpay.habitpay.global.error.exception.ErrorCode;
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
-import lombok.extern.slf4j.Slf4j;
-import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.security.core.AuthenticationException;
 import org.springframework.security.web.AuthenticationEntryPoint;
 import org.springframework.stereotype.Component;
-import org.springframework.web.servlet.HandlerExceptionResolver;
+
+import java.io.IOException;
 
 @Component
-@Slf4j
 public class JwtAuthenticationEntryPoint implements AuthenticationEntryPoint {
-
-    private final HandlerExceptionResolver resolver;
-
-    public JwtAuthenticationEntryPoint(@Qualifier("handlerExceptionResolver") HandlerExceptionResolver resolver) {
-        this.resolver = resolver;
-    }
 
     @Override
     public void commence(
             HttpServletRequest request,
             HttpServletResponse response,
-            AuthenticationException exception) {
-        log.error("JwtAuthenticationEntryPoint.commence() {}", exception.getLocalizedMessage());
-        resolver.resolveException(request, response, null, (Exception) request.getAttribute("exception"));
+            AuthenticationException exception) throws IOException {
+        // todo : ErrorCode 메시지를 JWT 커스텀으로 변경하기
+        ErrorResponse errorResponse = ErrorResponse.of(ErrorCode.BAD_REQUEST);
+        response.setContentType("application/json");
+        response.setStatus(HttpServletResponse.SC_BAD_REQUEST);
+        ObjectMapper objectMapper  = new ObjectMapper();
+        String jsonResponse = objectMapper.writeValueAsString(errorResponse);
+        response.getWriter().write(jsonResponse);
     }
 
 }

--- a/src/main/java/com/habitpay/habitpay/global/config/auth/SecurityConfig.java
+++ b/src/main/java/com/habitpay/habitpay/global/config/auth/SecurityConfig.java
@@ -53,7 +53,8 @@ public class SecurityConfig {
                         .sessionCreationPolicy(SessionCreationPolicy.STATELESS))
                 .authorizeHttpRequests((authorizeRequests ->
                         authorizeRequests
-                                .requestMatchers("/**").permitAll() // todo: 보안 상 취약할 수 있으니 범위 제한하기
+                                .requestMatchers("/oauth2/**").permitAll()
+                                .requestMatchers("/token").permitAll() // todo: url 수정 후 /api 추가하기
 //                            .requestMatchers("/api/v1/**").hasRole(Role.USER.name()) // todo: 로그인 후 사용하는 api 에서만 적용하기
                                 .anyRequest().authenticated()
                 ))

--- a/src/main/java/com/habitpay/habitpay/global/config/auth/SecurityConfig.java
+++ b/src/main/java/com/habitpay/habitpay/global/config/auth/SecurityConfig.java
@@ -8,6 +8,7 @@ import org.springframework.context.annotation.Configuration;
 import org.springframework.security.config.annotation.web.builders.HttpSecurity;
 import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity;
 import org.springframework.security.config.http.SessionCreationPolicy;
+import org.springframework.security.web.AuthenticationEntryPoint;
 import org.springframework.security.web.SecurityFilterChain;
 import org.springframework.security.web.authentication.UsernamePasswordAuthenticationFilter;
 import org.springframework.web.cors.CorsConfiguration;
@@ -25,6 +26,7 @@ public class SecurityConfig {
     private final CustomOAuth2UserService customOAuth2UserService;
     private final CustomOAuth2LoginSuccessHandler customOAuth2LoginSuccessHandler;
     private final JwtAuthenticationFilter jwtAuthenticationFilter;
+    private final JwtAuthenticationEntryPoint jwtAuthenticationEntryPoint;
 
     // TODO: CorsConfig.java 파일에 옮길 수 있도록 하기 
     @Bean
@@ -65,6 +67,9 @@ public class SecurityConfig {
                                         userInfoEndpoint.userService(customOAuth2UserService)));
 
         http.addFilterBefore(jwtAuthenticationFilter, UsernamePasswordAuthenticationFilter.class);
+
+        http.exceptionHandling((handler) ->
+                handler.authenticationEntryPoint(jwtAuthenticationEntryPoint));
 
         return http.build();
     }

--- a/src/main/java/com/habitpay/habitpay/global/config/jwt/JwtAuthenticationFilter.java
+++ b/src/main/java/com/habitpay/habitpay/global/config/jwt/JwtAuthenticationFilter.java
@@ -32,33 +32,21 @@ public class JwtAuthenticationFilter extends OncePerRequestFilter {
     private final TokenProvider tokenProvider;
     private final TokenService tokenService;
 
-    private final JwtAuthenticationEntryPoint jwtAuthenticationEntryPoint;
-
     @Override
     protected void doFilterInternal(HttpServletRequest request, HttpServletResponse response, FilterChain filterChain) throws ServletException, IOException {
         String accessToken = RequestHeaderUtil.getAccessToken(request);
 
         log.info("request: [{} {}]", request.getMethod(), request.getRequestURI());
 
-        try {
-            // TODO: 예외처리 추가하기
-            if (accessToken == null) {
-                log.error("액세스 토큰이 존재하지 않습니다.");
-                throw new CustomJwtException(HttpStatus.BAD_REQUEST, CustomJwtErrorInfo.BAD_REQUEST, "액세스 토큰이 존재하지 않습니다.");
-            }
+        // TODO: 예외처리 추가하기
 
-            tokenProvider.validateToken(accessToken);
-
+        if (accessToken != null && tokenProvider.validateToken(accessToken)) {
             Authentication authentication = tokenService.getAuthentication(accessToken);
             SecurityContext context = SecurityContextHolder.getContext();
             context.setAuthentication(authentication);
             log.info("authentication.getName(): {}", authentication.getName());
-
-            filterChain.doFilter(request, response);
-        } catch (Exception e) {
-            request.setAttribute("exception", e);
-            jwtAuthenticationEntryPoint.commence(request, response, new AuthenticationException("AuthenticationException" ,e) {});
         }
 
+        filterChain.doFilter(request, response);
     }
 }

--- a/src/main/java/com/habitpay/habitpay/global/config/jwt/JwtAuthenticationFilter.java
+++ b/src/main/java/com/habitpay/habitpay/global/config/jwt/JwtAuthenticationFilter.java
@@ -40,7 +40,9 @@ public class JwtAuthenticationFilter extends OncePerRequestFilter {
 
         // TODO: 예외처리 추가하기
 
-        if (accessToken != null && tokenProvider.validateToken(accessToken)) {
+        if (accessToken == null) {
+            log.error("액세스 토큰이 존재하지 않습니다.");
+        } else if (tokenProvider.validateToken(accessToken)) {
             Authentication authentication = tokenService.getAuthentication(accessToken);
             SecurityContext context = SecurityContextHolder.getContext();
             context.setAuthentication(authentication);

--- a/src/main/java/com/habitpay/habitpay/global/config/jwt/JwtAuthenticationFilter.java
+++ b/src/main/java/com/habitpay/habitpay/global/config/jwt/JwtAuthenticationFilter.java
@@ -1,6 +1,8 @@
 package com.habitpay.habitpay.global.config.jwt;
 
+import com.habitpay.habitpay.global.config.auth.JwtAuthenticationEntryPoint;
 import com.habitpay.habitpay.global.util.RequestHeaderUtil;
+import io.jsonwebtoken.ExpiredJwtException;
 import jakarta.servlet.FilterChain;
 import jakarta.servlet.ServletException;
 import jakarta.servlet.http.HttpServletRequest;
@@ -8,8 +10,10 @@ import jakarta.servlet.http.HttpServletResponse;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.security.core.Authentication;
+import org.springframework.security.core.AuthenticationException;
 import org.springframework.security.core.context.SecurityContext;
 import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.security.oauth2.jwt.JwtException;
 import org.springframework.stereotype.Component;
 import org.springframework.web.filter.OncePerRequestFilter;
 
@@ -22,27 +26,47 @@ public class JwtAuthenticationFilter extends OncePerRequestFilter {
     private final TokenProvider tokenProvider;
     private final TokenService tokenService;
 
+    private final JwtAuthenticationEntryPoint jwtAuthenticationEntryPoint;
+
     @Override
     protected void doFilterInternal(HttpServletRequest request, HttpServletResponse response, FilterChain filterChain) throws ServletException, IOException {
         String accessToken = RequestHeaderUtil.getAccessToken(request);
 
         log.info("request: [{} {}]", request.getMethod(), request.getRequestURI());
 
-        // TODO: 예외처리 추가하기
-        if (accessToken == null) {
-            log.error("No access token");
+        try {
+            // TODO: 예외처리 추가하기
+            if (accessToken == null) {
+                log.error("No access token");
+            }
+
+            // TODO: 예외처리 밖으로 꺼내오기
+            if (tokenProvider.validateToken(accessToken) == false) {
+                log.error("Invalid access token");
+            }
+
+            Authentication authentication = tokenService.getAuthentication(accessToken);
+            SecurityContext context = SecurityContextHolder.getContext();
+            context.setAuthentication(authentication);
+            log.info("authentication.getName(): {}", authentication.getName());
+
+            filterChain.doFilter(request, response);
+        } catch (ExpiredJwtException e) {
+            System.out.println("만료되었다네요");
+            jwtAuthenticationEntryPoint.commence(request, response, new AuthenticationException("만료 토큰!" ,e) {
+            });
+        } catch (JwtException e) {
+            System.out.println("뭔가 JWT 문제");
+            jwtAuthenticationEntryPoint.commence(request, response, new AuthenticationException("만료 토큰!" ,e) {
+            });
+        } catch (Exception e) {
+            System.out.println("여기로는 안 오나요,,,,?");
+            System.out.println(e.getMessage());
+
+            jwtAuthenticationEntryPoint.commence(request, response, new AuthenticationException("만료 토큰!" ,e) {});
+//            request.setAttribute("exception", e);
         }
 
-        // TODO: 예외처리 밖으로 꺼내오기
-        if (tokenProvider.validateToken(accessToken) == false) {
-            log.error("Invalid access token");
-        }
-
-        Authentication authentication = tokenService.getAuthentication(accessToken);
-        SecurityContext context = SecurityContextHolder.getContext();
-        context.setAuthentication(authentication);
-        log.info("authentication.getName(): {}", authentication.getName());
-
-        filterChain.doFilter(request, response);
+//        filterChain.doFilter(request, response);
     }
 }

--- a/src/main/java/com/habitpay/habitpay/global/config/jwt/TokenProvider.java
+++ b/src/main/java/com/habitpay/habitpay/global/config/jwt/TokenProvider.java
@@ -60,27 +60,28 @@ public class TokenProvider {
                 .compact();
     }
 
-    public void validateToken(String token) {
+    public boolean validateToken(String token) {
         try {
             Jwts.parser()
                     .setSigningKey(jwtProperties.getSecret())
                     .parseClaimsJws(token);
+            return true;
         } catch (ExpiredJwtException e) {
             // todo : ErrorResponse 적용하면 바뀔 예정
             log.error("토큰이 만료되었습니다.");
-            throw new CustomJwtException(HttpStatus.UNAUTHORIZED, CustomJwtErrorInfo.UNAUTHORIZED, e.getMessage());
+            return false;
         } catch (MalformedJwtException e) {
             log.error("잘못된 토큰 형식입니다..");
-            throw new CustomJwtException(HttpStatus.UNAUTHORIZED, CustomJwtErrorInfo.UNAUTHORIZED, e.getMessage());
+            return false;
         } catch (SignatureException e) {
             log.error("서명 검증에 실패했습니다.");
-            throw new CustomJwtException(HttpStatus.UNAUTHORIZED, CustomJwtErrorInfo.UNAUTHORIZED, e.getMessage());
+            return false;
         } catch (JwtException e) {
             log.error("JWT 처리 중 예외 발생 : {}", e.getLocalizedMessage());
-            throw new CustomJwtException(HttpStatus.UNAUTHORIZED, CustomJwtErrorInfo.UNAUTHORIZED, e.getMessage());
+            return false;
         } catch (Exception e) {
             log.error("JWT 처리 중 JWT 이외 예외 발생 : {}", e.getLocalizedMessage());
-            throw new CustomJwtException(HttpStatus.UNAUTHORIZED, CustomJwtErrorInfo.UNAUTHORIZED, e.getMessage());
+            return false;
         }
     }
 }

--- a/src/main/java/com/habitpay/habitpay/global/config/jwt/TokenService.java
+++ b/src/main/java/com/habitpay/habitpay/global/config/jwt/TokenService.java
@@ -23,6 +23,7 @@ import java.util.Set;
 public class TokenService {
     public final static Duration ACCESS_TOKEN_EXPIRED_AT = Duration.ofHours(2);
     public final static Duration REFRESH_TOKEN_EXPIRED_AT = Duration.ofDays(14);
+
     // todo : test 용도 (token 테스트 완료되면 삭제하기)
 //    public final static Duration ACCESS_TOKEN_EXPIRED_AT = Duration.ofSeconds(30);
 //    public final static Duration REFRESH_TOKEN_EXPIRED_AT = Duration.ofMinutes(1);

--- a/src/main/java/com/habitpay/habitpay/global/config/jwt/TokenService.java
+++ b/src/main/java/com/habitpay/habitpay/global/config/jwt/TokenService.java
@@ -21,11 +21,12 @@ import java.util.Set;
 @Service
 @Slf4j
 public class TokenService {
-//    public final static Duration ACCESS_TOKEN_EXPIRED_AT = Duration.ofHours(2);
-//    public final static Duration REFRESH_TOKEN_EXPIRED_AT = Duration.ofDays(14);
+    public final static Duration ACCESS_TOKEN_EXPIRED_AT = Duration.ofHours(2);
+    public final static Duration REFRESH_TOKEN_EXPIRED_AT = Duration.ofDays(14);
+    // todo : test 용도 (token 테스트 완료되면 삭제하기)
+//    public final static Duration ACCESS_TOKEN_EXPIRED_AT = Duration.ofSeconds(30);
+//    public final static Duration REFRESH_TOKEN_EXPIRED_AT = Duration.ofMinutes(1);
 
-    public final static Duration ACCESS_TOKEN_EXPIRED_AT = Duration.ofSeconds(30);
-    public final static Duration REFRESH_TOKEN_EXPIRED_AT = Duration.ofMinutes(1);
     private final JwtProperties jwtProperties;
 
     private final TokenProvider tokenProvider;

--- a/src/main/java/com/habitpay/habitpay/global/config/jwt/TokenService.java
+++ b/src/main/java/com/habitpay/habitpay/global/config/jwt/TokenService.java
@@ -21,12 +21,13 @@ import java.util.Set;
 @Service
 @Slf4j
 public class TokenService {
-    private final static Duration ACCESS_TOKEN_EXPIRED_AT = Duration.ofHours(2);
-    public final static Duration REFRESH_TOKEN_EXPIRED_AT = Duration.ofDays(14);
+//    public final static Duration ACCESS_TOKEN_EXPIRED_AT = Duration.ofHours(2);
+//    public final static Duration REFRESH_TOKEN_EXPIRED_AT = Duration.ofDays(14);
+
+    public final static Duration ACCESS_TOKEN_EXPIRED_AT = Duration.ofSeconds(30);
+    public final static Duration REFRESH_TOKEN_EXPIRED_AT = Duration.ofMinutes(1);
     private final JwtProperties jwtProperties;
 
-    // todo : for temp
-//    private final static Duration ACCESS_TOKEN_EXPIRED_AT = Duration.ofHours(1);
     private final TokenProvider tokenProvider;
     private final MemberSearchService memberSearchService;
     private final UserDetailsService userDetailsService;

--- a/src/main/resources/application-local.yaml
+++ b/src/main/resources/application-local.yaml
@@ -7,9 +7,12 @@ spring:
       ddl-auto: update
     show-sql: true
   datasource:
-    url: jdbc:postgresql://${POSTGRES_HOST}:${POSTGRES_PORT}/${POSTGRES_DB}
-    username: ${POSTGRES_USER}
-    password: ${POSTGRES_PASSWORD}
+#    url: jdbc:postgresql://${POSTGRES_HOST}:${POSTGRES_PORT}/${POSTGRES_DB}
+#    username: ${POSTGRES_USER}
+#    password: ${POSTGRES_PASSWORD}
+    url: jdbc:postgresql://localhost:5432/postgres
+    username: postgres
+    password:
   devtools:
     livereload:
       enabled: true

--- a/src/main/resources/application-local.yaml
+++ b/src/main/resources/application-local.yaml
@@ -7,12 +7,9 @@ spring:
       ddl-auto: update
     show-sql: true
   datasource:
-#    url: jdbc:postgresql://${POSTGRES_HOST}:${POSTGRES_PORT}/${POSTGRES_DB}
-#    username: ${POSTGRES_USER}
-#    password: ${POSTGRES_PASSWORD}
-    url: jdbc:postgresql://localhost:5432/postgres
-    username: postgres
-    password:
+    url: jdbc:postgresql://${POSTGRES_HOST}:${POSTGRES_PORT}/${POSTGRES_DB}
+    username: ${POSTGRES_USER}
+    password: ${POSTGRES_PASSWORD}
   devtools:
     livereload:
       enabled: true


### PR DESCRIPTION
### 작업 개요

* 필터에서 토큰 유효성 검사(`validToken`) 시 예외가 발생할 경우를 처리합니다.

---

### 작업 흐름과 주요 코드

* `JWT 토큰 검증` 로직이 `Interceptor`에서 스프링 시큐리티 `Filter`로 이동하면서,
  `CustomJwtException`이 발생할 경우 예외 처리하는 핸들러가 필요해졌습니다.
* `스프링 시큐리티`에서는 `인증 예외`를 관리하는 `AuthenticationEntryPoint`, `인가 예외`를 관리하는 `AccessDeniedHandler`를 제공합니다.
* 그 중에서 `인증 예외`를 관리하는 `AuthenticationEntryPoint`를 활용했습니다.

---

```java
// SecurityConfig.java

SecurityFilterChain filterChain(HttpSecurity http) throws Exception {
    ...
      .authorizeHttpRequests((authorizeRequests ->
              authorizeRequests
                      .requestMatchers("/oauth2/**").permitAll()
                      .requestMatchers("/token").permitAll()
  ...
  http.exceptionHandling((handler) ->
          handler.authenticationEntryPoint(jwtAuthenticationEntryPoint));
...
    }
```

* `http.exceptionHandling` 설정을 통해 직접 만든 `jwtAuthenticationEntryPoint` 객체를 인증 예외 핸들러로 넣었습니다.
* OAuth2 로그인을 하는 `"/oauth2/**"`와 토큰 리프레시를 요청하는 `"/token"` url은 인증 과정이 필요 없기 때문에,
  `.requestMatchers(...).permitAll()` 설정을 통해 인증 없이도 접속할 수 있도록 합니다.

---

* `JwtAuthenticationEntryPoint`는 무엇인가

```java
@Component
public class JwtAuthenticationEntryPoint implements AuthenticationEntryPoint {

    @Override
    public void commence(
            HttpServletRequest request,
            HttpServletResponse response,
            AuthenticationException exception) {
        ...
    }

}
```

* 인증 예외를 관리하는 `AuthenticationEntryPoint`를 구현한 커스텀 클래스입니다.
* `AuthenticationException`이 발생하면 `commence` 메서드에서 처리됩니다.

---

* 그렇다면 `AuthenticationException`는 언제 발생하는가?

```java
// JwtAuthenticationFilter.java

protected void doFilterInternal(...) throws ServletException, IOException {
    String accessToken = RequestHeaderUtil.getAccessToken(request);

    if (accessToken == null) {
        log.error("액세스 토큰이 존재하지 않습니다.");
    } else if (tokenProvider.validateToken(accessToken)) {
        Authentication authentication = tokenService.getAuthentication(accessToken);
        SecurityContext context = SecurityContextHolder.getContext();
        context.setAuthentication(authentication);
        ...
    }

    filterChain.doFilter(request, response);
}
```

* 액세스 토큰 값이 있는지, 그 값은 유효한지 확인하여 통과한다면 정상적으로 `Authentication`이 설정됩니다.
* 그러나 액세스 토큰에 문제가 있다면, `Authentication`에는 아무런 내용이 없을 것입니다.

* 액세스 토큰에 문제가 있어 `Authentication`이 설정되지 않은 상태로 `doFilter`로 들어가게 되면,
  `UsernamePasswordAuthenticationFilter`를 거칠 때 인증 예외, 즉 `AuthenticationException`이 발생하게 됩니다.

---

* `AuthenticationException`이 발생하면 `JwtAuthenticationEntryPoint`이 처리합니다.
* 예외를 받아서 구체적인 로직을 행하는 `Override 메서드` `commence`를 봅시다.

```java
// JwtAuthenticationEntryPoint.java

@Override
public void commence(
        HttpServletRequest request,
        HttpServletResponse response,
        AuthenticationException exception) throws IOException {

    ErrorResponse errorResponse = ErrorResponse.of(ErrorCode.BAD_REQUEST);
    response.setContentType("application/json");
    response.setStatus(HttpServletResponse.SC_BAD_REQUEST);
    ObjectMapper objectMapper  = new ObjectMapper();
    String jsonResponse = objectMapper.writeValueAsString(errorResponse);
    response.getWriter().write(jsonResponse);
}

// errorResponse의 내용과 HttpStatusCode는 ErrorResponse 반영 때 다시 고칠 예정입니다.
// BAD_REQUEST가 아닌 UNAUTHORIZED가 되어야 합니다.
```

* `response.sendError()`로 바로 응답을 보내지 않고,
   일관된 `ErrorResponse` 타입을 지키기 위해 `response.getWriter()` 이용해 작성했습니다.
   텍스트 데이터를 `HttpServletResponse` 응답 스트림에 작성할 수 있는 객체를 반환해준다고 합니다.

---

*  잠깐, `CustomJwtException`은 쓰이지 않나요?
* 네, (JWT 유효성 검사 메서드 안에서는) 그렇습니다.

* 처음에 일괄 관리에 더 편하고 좋을 줄 알고,, vaildToken에서 냅다 `CustomJwtException`를 던졌는데요.
* JWT 유효성 검사 메서드가 `boolean` 값을 반환한 후,
   유효성 검사를 한 클라이언트 메서드가 boolean 값을 판별해 필요한 로직을 구현하는 방향이 더 유연해서 그렇게 바꿨습니다.
   (false를 보고 예외를 던지든, false를 보고 아무 작업도 하지 않고 넘기든 그건 클라이언트 메서드의 몫!)

* 그에 따라 바뀐 토큰 유효성 검사 메서드입니다.

```java
public boolean validateToken(String token) {
  try {
      Jwts.parser()
              .setSigningKey(jwtProperties.getSecret())
              .parseClaimsJws(token);
      return true;
  } catch (ExpiredJwtException e) {
      log.error("토큰이 만료되었습니다.");
      return false;
  } catch (MalformedJwtException e) {
      log.error("잘못된 토큰 형식입니다..");
      return false;
  } catch (SignatureException e) {
      log.error("서명 검증에 실패했습니다.");
      return false;
  } catch (JwtException e) {
      log.error("JWT 처리 중 예외 발생 : {}", e.getLocalizedMessage());
      return false;
  } catch (Exception e) {
      log.error("JWT 처리 중 JWT 이외 예외 발생 : {}", e.getLocalizedMessage());
      return false;
  }
}
```

* 서버에만 구체적인 log를 남기고, 클라이언트 메서드에는 `true`나 `false` 값만 반환합니다.

---

### 기타

* 소소한 리팩토링과 주석 처리된 테스트 코드가 조금 있습니다.
* 이제 `ErrorResponse`를 적용하면 이 코드도 또 달라집니다!

---

### 사족

* 이제 풀리퀘를 오픈하면 리뷰어가 자동으로 설정됩니다.
* 이또한 준한님의 은혜겠지요.