### PR TITLE
Feat/챌린지 시작 전 챌린지 삭제 기능 추가#208

### DIFF
--- a/src/docs/asciidoc/api/challenge.adoc
+++ b/src/docs/asciidoc/api/challenge.adoc
@@ -116,3 +116,25 @@ operation::challenge/cancel-challenge-enrollment-not-enrolled-exception[snippets
 챌린지가 시작하고 나서 등록 취소를 하는 경우입니다.
 
 operation::challenge/cancel-challenge-enrollment-invalid-cancellation-time-exception[snippets='http-request,http-response,response-fields']
+
+=== 챌린지 삭제
+
+챌린지를 삭제합니다.
+
+삭제는 챌린지 시작 시간 전까지만 가능하며, 챌린지 주최자만 삭제할 수 있습니다.
+
+operation::challenge/delete[snippets='http-request,http-response,response-fields']
+
+==== 에러 응답
+
+===== 챌린지가 존재하지 않는 경우 (403 Forbidden)
+
+챌린지 주최자가 아닌 경우 챌린지를 삭제하려는 경우입니다.
+
+operation::challenge/delete-forbidden-exception[snippets='http-request,http-response,response-fields']
+
+===== 챌린지가 존재하지 않는 경우 (404 Not Found)
+
+존재하지 않는 챌린지를 삭제하려는 경우입니다.
+
+operation::challenge/delete-not-found-exception[snippets='http-request,http-response,response-fields']

--- a/src/main/java/com/habitpay/habitpay/domain/challenge/api/ChallengeApi.java
+++ b/src/main/java/com/habitpay/habitpay/domain/challenge/api/ChallengeApi.java
@@ -50,7 +50,7 @@ public class ChallengeApi {
     @DeleteMapping("/challenges/{id}")
     public SuccessResponse<Void> deleteChallenge(@PathVariable("id") Long id,
                                                  @AuthenticationPrincipal CustomUserDetails user) {
-        return challengeDeleteService.delete(id);
+        return challengeDeleteService.delete(id, user.getId());
     }
 
 }

--- a/src/main/java/com/habitpay/habitpay/domain/challenge/api/ChallengeApi.java
+++ b/src/main/java/com/habitpay/habitpay/domain/challenge/api/ChallengeApi.java
@@ -1,9 +1,6 @@
 package com.habitpay.habitpay.domain.challenge.api;
 
-import com.habitpay.habitpay.domain.challenge.application.ChallengeCreationService;
-import com.habitpay.habitpay.domain.challenge.application.ChallengeDetailsService;
-import com.habitpay.habitpay.domain.challenge.application.ChallengePatchService;
-import com.habitpay.habitpay.domain.challenge.application.ChallengeSearchService;
+import com.habitpay.habitpay.domain.challenge.application.*;
 import com.habitpay.habitpay.domain.challenge.dto.*;
 import com.habitpay.habitpay.global.config.auth.CustomUserDetails;
 import com.habitpay.habitpay.global.response.SuccessResponse;
@@ -24,6 +21,7 @@ public class ChallengeApi {
     private final ChallengePatchService challengePatchService;
     private final ChallengeDetailsService challengeDetailsService;
     private final ChallengeSearchService challengeSearchService;
+    private final ChallengeDeleteService challengeDeleteService;
 
     @GetMapping("/challenges/me")
     public SuccessResponse<List<ChallengeEnrolledListItemResponse>> getEnrolledChallengeList(
@@ -48,4 +46,11 @@ public class ChallengeApi {
                                                                          @AuthenticationPrincipal CustomUserDetails user) {
         return challengePatchService.patch(id, challengePatchRequest, user.getMember());
     }
+
+    @DeleteMapping("/challenges/{id}")
+    public SuccessResponse<Void> deleteChallenge(@PathVariable("id") Long id,
+                                                 @AuthenticationPrincipal CustomUserDetails user) {
+        return challengeDeleteService.delete(id);
+    }
+
 }

--- a/src/main/java/com/habitpay/habitpay/domain/challenge/application/ChallengeDeleteService.java
+++ b/src/main/java/com/habitpay/habitpay/domain/challenge/application/ChallengeDeleteService.java
@@ -1,0 +1,24 @@
+package com.habitpay.habitpay.domain.challenge.application;
+
+import com.habitpay.habitpay.domain.challenge.dao.ChallengeRepository;
+import com.habitpay.habitpay.domain.challenge.domain.Challenge;
+import com.habitpay.habitpay.global.response.SuccessCode;
+import com.habitpay.habitpay.global.response.SuccessResponse;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Service;
+
+@Slf4j
+@Service
+@RequiredArgsConstructor
+public class ChallengeDeleteService {
+    private final ChallengeSearchService challengeSearchService;
+    private final ChallengeRepository challengeRepository;
+
+    public SuccessResponse<Void> delete(Long id) {
+        Challenge challenge = challengeSearchService.getChallengeById(id);
+        challengeRepository.delete(challenge);
+
+        return SuccessResponse.of(SuccessCode.DELETE_CHALLENGE_SUCCESS);
+    }
+}

--- a/src/main/java/com/habitpay/habitpay/domain/challenge/application/ChallengeDeleteService.java
+++ b/src/main/java/com/habitpay/habitpay/domain/challenge/application/ChallengeDeleteService.java
@@ -2,6 +2,8 @@ package com.habitpay.habitpay.domain.challenge.application;
 
 import com.habitpay.habitpay.domain.challenge.dao.ChallengeRepository;
 import com.habitpay.habitpay.domain.challenge.domain.Challenge;
+import com.habitpay.habitpay.global.error.exception.ErrorCode;
+import com.habitpay.habitpay.global.error.exception.ForbiddenException;
 import com.habitpay.habitpay.global.response.SuccessCode;
 import com.habitpay.habitpay.global.response.SuccessResponse;
 import lombok.RequiredArgsConstructor;
@@ -15,8 +17,13 @@ public class ChallengeDeleteService {
     private final ChallengeSearchService challengeSearchService;
     private final ChallengeRepository challengeRepository;
 
-    public SuccessResponse<Void> delete(Long id) {
-        Challenge challenge = challengeSearchService.getChallengeById(id);
+    public SuccessResponse<Void> delete(Long challengeId, Long memberId) {
+        Challenge challenge = challengeSearchService.getChallengeById(challengeId);
+
+        if (challenge.getHost().getId().equals(memberId) == false) {
+            throw new ForbiddenException(ErrorCode.NOT_ALLOWED_TO_DELETE_CHALLENGE);
+        }
+
         challengeRepository.delete(challenge);
 
         return SuccessResponse.of(SuccessCode.DELETE_CHALLENGE_SUCCESS);

--- a/src/main/java/com/habitpay/habitpay/domain/challenge/domain/Challenge.java
+++ b/src/main/java/com/habitpay/habitpay/domain/challenge/domain/Challenge.java
@@ -22,8 +22,6 @@ import java.util.List;
 @Slf4j
 @Table(name = "challenge")
 public class Challenge extends BaseTime {
-    @OneToMany(mappedBy = "challenge", cascade = CascadeType.REMOVE)
-    List<ChallengeEnrollment> challengeEnrollmentList = new ArrayList<>();
 
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
@@ -33,6 +31,9 @@ public class Challenge extends BaseTime {
     @JoinColumn(name = "member_id")
     private Member host;
 
+    @OneToMany(mappedBy = "challenge", cascade = CascadeType.REMOVE)
+    List<ChallengeEnrollment> challengeEnrollmentList = new ArrayList<>();
+    
     @Column(nullable = false)
     private String title;
 

--- a/src/main/java/com/habitpay/habitpay/domain/challenge/domain/Challenge.java
+++ b/src/main/java/com/habitpay/habitpay/domain/challenge/domain/Challenge.java
@@ -1,6 +1,7 @@
 package com.habitpay.habitpay.domain.challenge.domain;
 
 import com.habitpay.habitpay.domain.challenge.dto.ChallengeCreationRequest;
+import com.habitpay.habitpay.domain.challengeenrollment.domain.ChallengeEnrollment;
 import com.habitpay.habitpay.domain.member.domain.Member;
 import com.habitpay.habitpay.domain.model.BaseTime;
 import jakarta.persistence.*;
@@ -11,7 +12,9 @@ import lombok.extern.slf4j.Slf4j;
 
 import java.time.DayOfWeek;
 import java.time.ZonedDateTime;
+import java.util.ArrayList;
 import java.util.EnumSet;
+import java.util.List;
 
 @Getter
 @NoArgsConstructor
@@ -19,6 +22,9 @@ import java.util.EnumSet;
 @Slf4j
 @Table(name = "challenge")
 public class Challenge extends BaseTime {
+    @OneToMany(mappedBy = "challenge", cascade = CascadeType.REMOVE)
+    List<ChallengeEnrollment> challengeEnrollmentList = new ArrayList<>();
+
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;
@@ -86,20 +92,6 @@ public class Challenge extends BaseTime {
                 .build();
     }
 
-    public void setDescription(String description) {
-        this.description = description;
-    }
-
-    public void setNumberOfParticipants(int numberOfParticipants) {
-        this.numberOfParticipants = numberOfParticipants;
-    }
-
-    public boolean isTodayParticipatingDay() {
-        DayOfWeek today = ZonedDateTime.now().getDayOfWeek();
-        int todayBitPosition = 6 - (today.getValue() - 1);
-        return (this.participatingDays & (1 << todayBitPosition)) != 0;
-    }
-
     private static int calculateTotalParticipatingDays(ChallengeCreationRequest challengeCreationRequest) {
         int count = 0;
         EnumSet<DayOfWeek> daysOfParticipatingDays = EnumSet.noneOf(DayOfWeek.class);
@@ -123,5 +115,19 @@ public class Challenge extends BaseTime {
         }
 
         return count;
+    }
+
+    public void setDescription(String description) {
+        this.description = description;
+    }
+
+    public void setNumberOfParticipants(int numberOfParticipants) {
+        this.numberOfParticipants = numberOfParticipants;
+    }
+
+    public boolean isTodayParticipatingDay() {
+        DayOfWeek today = ZonedDateTime.now().getDayOfWeek();
+        int todayBitPosition = 6 - (today.getValue() - 1);
+        return (this.participatingDays & (1 << todayBitPosition)) != 0;
     }
 }

--- a/src/main/java/com/habitpay/habitpay/global/error/exception/ErrorCode.java
+++ b/src/main/java/com/habitpay/habitpay/global/error/exception/ErrorCode.java
@@ -31,7 +31,9 @@ public enum ErrorCode {
     INVALID_CHALLENGE_CANCELLATION_TIME(HttpStatus.BAD_REQUEST, "챌린지 취소 가능한 시간이 지났습니다."),
     ALREADY_ENROLLED_IN_CHALLENGE(HttpStatus.CONFLICT, "이미 참여한 챌린지 입니다."),
     NOT_ENROLLED_IN_CHALLENGE(HttpStatus.BAD_REQUEST, "참여하지 않은 챌린지 입니다."),
-    NOT_ALLOWED_TO_CANCEL_ENROLLMENT_OF_HOST(HttpStatus.BAD_REQUEST, "챌린지 주최자는 참여 취소가 불가능 합니다.");
+    NOT_ALLOWED_TO_CANCEL_ENROLLMENT_OF_HOST(HttpStatus.BAD_REQUEST, "챌린지 주최자는 참여 취소가 불가능 합니다."),
+    NOT_ALLOWED_TO_DELETE_CHALLENGE(HttpStatus.FORBIDDEN, "챌린지 삭제는 챌린지 주최자만 가능합니다.");
+
     private HttpStatus status;
     private final String message;
 

--- a/src/main/java/com/habitpay/habitpay/global/response/SuccessCode.java
+++ b/src/main/java/com/habitpay/habitpay/global/response/SuccessCode.java
@@ -13,8 +13,8 @@ public enum SuccessCode {
 
     // Challenge
     ENROLL_CHALLENGE_SUCCESS("정상적으로 챌린지에 등록했습니다."),
-    CANCEL_CHALLENGE_ENROLLMENT_SUCCESS("정상적으로 챌린지 등록을 취소했습니다.");
-
+    CANCEL_CHALLENGE_ENROLLMENT_SUCCESS("정상적으로 챌린지 등록을 취소했습니다."),
+    DELETE_CHALLENGE_SUCCESS("정상적으로 챌린지를 삭제했습니다.");
     private final String message;
 
 }


### PR DESCRIPTION
# 작업 개요

1. 챌린지 시작 전 챌린지를 삭제할 수 있는 `DELETE /challenges/{id}` 컨트롤러를 추가했습니다.
2. 1번에서 추가한 컨트롤러의 테스트 코드를 작성했습니다. 

# 참고사항

`Challenge` 삭제 시 해당하는 `Challenge` 의 `ChallengeEnrollment` 를 모두 삭제하기 위해 양방향 연결을 해주었습니다.

`@OneToMany` 의 매개변수로 `mappedBy = "challenge", cascade = CascadeType.REMOVE` 를 넘겨줍니다. 

그리고 자료형은 `List` 로 선언하고, 빈 ArrayList 를 선언해서 NPE(Null Pointer Exception) 을 방지합니다. 


```diff
@Table(name = "challenge")
public class Challenge extends BaseTime {

    @Id
    @GeneratedValue(strategy = GenerationType.IDENTITY)
    private Long id;

    @JoinColumn(name = "member_id")
    private Member host;

+   @OneToMany(mappedBy = "challenge", cascade = CascadeType.REMOVE)
+   List<ChallengeEnrollment> challengeEnrollmentList = new ArrayList<>();
```