### PR TITLE
test/ 배열 속성의 데이터 타입을 추가 작성, fix/ ErrorCode 파일의 코드 종료문 위치 수정 #214

### DIFF
--- a/src/main/java/com/habitpay/habitpay/global/error/exception/ErrorCode.java
+++ b/src/main/java/com/habitpay/habitpay/global/error/exception/ErrorCode.java
@@ -38,7 +38,7 @@ public enum ErrorCode {
     ALREADY_ENROLLED_IN_CHALLENGE(HttpStatus.CONFLICT, "이미 참여한 챌린지 입니다."),
     NOT_ENROLLED_IN_CHALLENGE(HttpStatus.BAD_REQUEST, "참여하지 않은 챌린지 입니다."),
     NOT_ALLOWED_TO_CANCEL_ENROLLMENT_OF_HOST(HttpStatus.BAD_REQUEST, "챌린지 주최자는 참여 취소가 불가능 합니다."),
-    NOT_ALLOWED_TO_DELETE_CHALLENGE(HttpStatus.FORBIDDEN, "챌린지 삭제는 챌린지 주최자만 가능합니다.");
+    NOT_ALLOWED_TO_DELETE_CHALLENGE(HttpStatus.FORBIDDEN, "챌린지 삭제는 챌린지 주최자만 가능합니다."),
   
       // Challenge Participation Record
     RECORD_NOT_FOUND(HttpStatus.NOT_FOUND, "챌린지 참여 기록이 존재하지 않습니다."),

--- a/src/test/java/com/habitpay/habitpay/domain/challegepost/api/ChallengePostApiTest.java
+++ b/src/test/java/com/habitpay/habitpay/domain/challegepost/api/ChallengePostApiTest.java
@@ -317,8 +317,7 @@ public class ChallengePostApiTest extends AbstractRestDocsTests {
                         ),
                         responseFields(
                                 fieldWithPath("message").description("메시지"),
-                                fieldWithPath("data").description("AWS S3 업로드를 위한 url List<String>"),
-                                fieldWithPath("data[]").description("AWS S3 업로드를 위한 preSignedUrl")
+                                fieldWithPath("data").description("AWS S3 업로드를 위한 preSignedUrl List<String>")
                         )
                 ));
     }
@@ -364,13 +363,11 @@ public class ChallengePostApiTest extends AbstractRestDocsTests {
                                 fieldWithPath("modifiedPhotos").description("포스트 내 정렬 순서가 변경된 이미지 파일 목록"),
                                 fieldWithPath("modifiedPhotos[].photoId").description("정렬 순서를 변경하려는 이미지 파일의 PostPhotoId"),
                                 fieldWithPath("modifiedPhotos[].viewOrder").description("변경하려는 정렬 순서"),
-                                fieldWithPath("deletedPhotoIds").description("삭제한 이미지 파일 목록"),
-                                fieldWithPath("deletedPhotoIds[]").description("삭제할 이미지 파일의 PostPhotoId")
+                                fieldWithPath("deletedPhotoIds").description("삭제할 이미지 파일 PostPhotoId List<Long>")
                                 ),
                         responseFields(
                                 fieldWithPath("message").description("메시지"),
-                                fieldWithPath("data").description("AWS S3 업로드를 위한 url List<String>"),
-                                fieldWithPath("data[]").description("AWS S3 업로드를 위한 preSignedUrl")
+                                fieldWithPath("data").description("AWS S3 업로드를 위한 preSignedUrl List<String>")
                         )
                 ));
     }


### PR DESCRIPTION
### 작업 개요

* 이전 브랜치 풀리퀘에서 conflict를 처리하던 중 `ErrorCode` 객체 내의 `;` 위치를 잘못 수정했어서,
 다시 바로잡았습니다.
* `RestDocs` 문서에 반영되는 문구를 수정했습니다.

---

### 자세한 내용

```java
// before
    NOT_ALLOWED_TO_DELETE_CHALLENGE(HttpStatus..., "...");

// after
    NOT_ALLOWED_TO_DELETE_CHALLENGE(HttpStatus..., "...."),
```

* 다음에도 Enum이 이어지는데 `;`를 그대로 써서 `ErrorCode`가 제대로 작동하지 않았습니다.
* 작동하도록 `,`를 다시 넣어 수정했습니다.

---

* `RestDocs`는 `request-fields`, `response-fields`의 요소 데이터 타입을 파악해 자동으로 문서를 만들어줍니다.
* 일반적인 객체의 경우 간단합니다.

```java
// ex (예시를 위해 대충 만들었읍니다,,)

ResponseDTO {
    Long id,
    String content,
    List<ResponseDTO> dtoList;
}

// test code ex

...
    fieldWithPath(data.id).description("..."),
    fieldWithPath(data.content).description("..."),
    fieldWithPath(data.dtoList).description("..."),
    fieldWithPath(data.dtoList[].id).description("..."),
    fieldWithPath(data.dtoList[].contest).description("..."),
...

// restDocs

data.id : Number
data.content : String
data.dtoList : Array
data.dtoList[].id : Number
data.dtoList[].content : String
```

---

* 그러나 객체 List 대신 일반 List가 들어가면,,

```java
// ex

ResponseDTO {
    Long id,
    String content,
    List<Long> numberList;
}

// test code ex

...
    fieldWithPath(data.id).description("..."),
    fieldWithPath(data.content).description("..."),
    fieldWithPath(data.numberList).description("..."),
    fieldWithPath(data.numberList[]).description("..."),
...

// restDocs

data.id : Number
data.content : String
data.numberList : Array
data.dtoList[] : Array

// dta.dtoList[0] 이런 식으로 특정 요소를 지칭해도 Array가 됨.
```

* 객체의 배열이어서 `[ ].요소` 이렇게 명시할 수 있는 경우는 데이터 타입을 바로 잘 인식하는데,
일반 배열(`List<String>`, `List<Long>` ..)은 내부 요소의 데이터를 지칭하는 방법을 못 찾았습니다😢
* `.type(JsonFieldType.STRING)`을 사용하면 Array와 데이터 타입이 다르기 떄문에 충돌이 납니다.

---

* 인터넷 정보성 글은 보통 객체 배열을 대상으로만 설명하고,
  ChatGPT도 명확한 답을 주지 아니하여,, 그러나 RestDocs는 정확하게 작성하고 싶고,,
* 그래서 List에 들어갈 요소를 감싸는 래핑 객체를 만들고자 했습니다.
```java
// ex

public class DeletedPhoto {
    Long id;
}

// List<Long> 대신 다음처럼 쓸 수 있게 됨
ResponseDto {
    ...
    List<DeletedPhoto> ids;
    ...
}
```

* 그런데 한 개 만들고 적용하려고 보니,
간단한 List로 처리할 수 있는 것을 불필요하게 래핑하여 복잡도를 올리는 게 합당한가에 대한 고민이 들었습니다.
* 프론트엔드에서도 `쓰려는배열[0]`으로 쓸 수 있는 걸 `쓰려는배열[0].id` 이렇게 depth가 더 생기니까요.

---

* 약간의 고민 끝에, RestDocs에 description으로 직접 데이터 타입을 밝히는 방식을 썼습니다.
* 문서화는 중요하지만, 문서화만을 위해 코드 복잡성을 증가시키는 느낌이어서 우선 이렇게 적용했습니다.