### PR TITLE
[Feat] API 요청 정상 응답 시 SuccessResponse에 SuccessCode 반영하기 #216

### DIFF
--- a/src/main/java/com/habitpay/habitpay/domain/challenge/application/ChallengeCreationService.java
+++ b/src/main/java/com/habitpay/habitpay/domain/challenge/application/ChallengeCreationService.java
@@ -9,6 +9,7 @@ import com.habitpay.habitpay.domain.challengeenrollment.dao.ChallengeEnrollmentR
 import com.habitpay.habitpay.domain.challengeenrollment.domain.ChallengeEnrollment;
 import com.habitpay.habitpay.domain.member.application.MemberSearchService;
 import com.habitpay.habitpay.domain.member.domain.Member;
+import com.habitpay.habitpay.global.response.SuccessCode;
 import com.habitpay.habitpay.global.response.SuccessResponse;
 import lombok.AllArgsConstructor;
 import org.springframework.stereotype.Service;
@@ -37,7 +38,7 @@ public class ChallengeCreationService {
         challengeEnrollmentRepository.save(challengeEnrollment);
 
         return SuccessResponse.of(
-                "챌린지가 생성되었습니다.",
+                SuccessCode.CREATE_CHALLENGE_SUCCESS,
                 ChallengeCreationResponse.of(member, challenge)
         );
     }

--- a/src/main/java/com/habitpay/habitpay/domain/challenge/application/ChallengeDetailsService.java
+++ b/src/main/java/com/habitpay/habitpay/domain/challenge/application/ChallengeDetailsService.java
@@ -7,6 +7,7 @@ import com.habitpay.habitpay.domain.challengeenrollment.domain.ChallengeEnrollme
 import com.habitpay.habitpay.domain.member.application.MemberSearchService;
 import com.habitpay.habitpay.domain.member.domain.Member;
 import com.habitpay.habitpay.global.config.aws.S3FileService;
+import com.habitpay.habitpay.global.response.SuccessCode;
 import com.habitpay.habitpay.global.response.SuccessResponse;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
@@ -38,7 +39,7 @@ public class ChallengeDetailsService {
 
 
         return SuccessResponse.of(
-                "",
+                SuccessCode.NO_MESSAGE,
                 ChallengeDetailsResponse.of(
                         member,
                         challenge,

--- a/src/main/java/com/habitpay/habitpay/domain/challenge/application/ChallengePatchService.java
+++ b/src/main/java/com/habitpay/habitpay/domain/challenge/application/ChallengePatchService.java
@@ -9,6 +9,7 @@ import com.habitpay.habitpay.domain.member.domain.Member;
 import com.habitpay.habitpay.global.error.exception.ErrorCode;
 import com.habitpay.habitpay.global.error.exception.ForbiddenException;
 import com.habitpay.habitpay.global.error.exception.InvalidValueException;
+import com.habitpay.habitpay.global.response.SuccessCode;
 import com.habitpay.habitpay.global.response.SuccessResponse;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
@@ -36,7 +37,7 @@ public class ChallengePatchService {
         challenge.setDescription(challengePatchRequest.getDescription());
 
         return SuccessResponse.of(
-                "챌린지 정보 수정이 반영되었습니다.",
+                SuccessCode.PATCH_CHALLENGE_SUCCESS,
                 ChallengePatchResponse.of(challenge)
         );
     }

--- a/src/main/java/com/habitpay/habitpay/domain/challenge/application/ChallengeSearchService.java
+++ b/src/main/java/com/habitpay/habitpay/domain/challenge/application/ChallengeSearchService.java
@@ -9,6 +9,7 @@ import com.habitpay.habitpay.domain.challengeenrollment.domain.ChallengeEnrollme
 import com.habitpay.habitpay.domain.challengeparticipationrecord.dao.ChallengeParticipationRecordRepository;
 import com.habitpay.habitpay.domain.member.domain.Member;
 import com.habitpay.habitpay.global.config.aws.S3FileService;
+import com.habitpay.habitpay.global.response.SuccessCode;
 import com.habitpay.habitpay.global.response.SuccessResponse;
 import lombok.AllArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
@@ -34,7 +35,7 @@ public class ChallengeSearchService {
                 .map(this::mapToResponse)
                 .toList();
 
-        return SuccessResponse.of("", response);
+        return SuccessResponse.of(SuccessCode.NO_MESSAGE, response);
     }
 
     @Transactional(readOnly = true)

--- a/src/main/java/com/habitpay/habitpay/domain/challengepost/api/ChallengePostApi.java
+++ b/src/main/java/com/habitpay/habitpay/domain/challengepost/api/ChallengePostApi.java
@@ -88,7 +88,7 @@ public class ChallengePostApi {
     }
 
     @DeleteMapping("/api/posts/{id}")
-    public SuccessResponse<Long> deletePost(
+    public SuccessResponse<Void> deletePost(
             @PathVariable Long id, @AuthenticationPrincipal CustomUserDetails user) {
 
         return challengePostDeleteService.deletePost(id, user.getMember());

--- a/src/main/java/com/habitpay/habitpay/domain/challengepost/application/ChallengePostCreationService.java
+++ b/src/main/java/com/habitpay/habitpay/domain/challengepost/application/ChallengePostCreationService.java
@@ -12,6 +12,7 @@ import com.habitpay.habitpay.domain.member.domain.Member;
 import com.habitpay.habitpay.domain.postphoto.application.PostPhotoCreationService;
 import com.habitpay.habitpay.global.error.exception.ErrorCode;
 import com.habitpay.habitpay.global.error.exception.ForbiddenException;
+import com.habitpay.habitpay.global.response.SuccessCode;
 import com.habitpay.habitpay.global.response.SuccessResponse;
 import jakarta.transaction.Transactional;
 import lombok.RequiredArgsConstructor;
@@ -40,7 +41,7 @@ public class ChallengePostCreationService {
         List<String> presignedUrlList = postPhotoCreationService.createPhotoUrlList(challengePost, request.getPhotos());
 
         return SuccessResponse.of(
-                "포스트가 생성되었습니다.",
+                SuccessCode.CREATE_POST_SUCCESS,
                 presignedUrlList
         );
     }

--- a/src/main/java/com/habitpay/habitpay/domain/challengepost/application/ChallengePostDeleteService.java
+++ b/src/main/java/com/habitpay/habitpay/domain/challengepost/application/ChallengePostDeleteService.java
@@ -7,6 +7,7 @@ import com.habitpay.habitpay.domain.member.domain.Member;
 import com.habitpay.habitpay.domain.postphoto.application.PostPhotoDeleteService;
 import com.habitpay.habitpay.global.error.exception.ErrorCode;
 import com.habitpay.habitpay.global.error.exception.ForbiddenException;
+import com.habitpay.habitpay.global.response.SuccessCode;
 import com.habitpay.habitpay.global.response.SuccessResponse;
 import jakarta.transaction.Transactional;
 import lombok.RequiredArgsConstructor;
@@ -24,7 +25,7 @@ public class ChallengePostDeleteService {
     private final ChallengePostUtilService challengePostUtilService;
 
     @Transactional
-    public SuccessResponse<Long> deletePost(Long postId, Member member) {
+    public SuccessResponse<Void> deletePost(Long postId, Member member) {
         ChallengePost post = challengePostSearchService.getChallengePostById(postId);
         Challenge challenge = post.getChallenge();
 
@@ -42,10 +43,7 @@ public class ChallengePostDeleteService {
         postPhotoDeleteService.deleteByPost(post);
         challengePostRepository.delete(post);
 
-        return SuccessResponse.of(
-                "포스트가 정상적으로 삭제되었습니다.",
-                postId
-        );
+        return SuccessResponse.of(SuccessCode.DELETE_POST_SUCCESS);
     }
 
 }

--- a/src/main/java/com/habitpay/habitpay/domain/challengepost/application/ChallengePostSearchService.java
+++ b/src/main/java/com/habitpay/habitpay/domain/challengepost/application/ChallengePostSearchService.java
@@ -14,6 +14,7 @@ import com.habitpay.habitpay.domain.postphoto.application.PostPhotoSearchService
 import com.habitpay.habitpay.domain.postphoto.application.PostPhotoUtilService;
 import com.habitpay.habitpay.domain.postphoto.domain.PostPhoto;
 import com.habitpay.habitpay.domain.postphoto.dto.PostPhotoView;
+import com.habitpay.habitpay.global.response.SuccessCode;
 import com.habitpay.habitpay.global.response.SuccessResponse;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
@@ -41,7 +42,7 @@ public class ChallengePostSearchService {
         List<PostPhotoView> photoViewList = postPhotoUtilService.makePhotoViewList(photoList);
 
         return SuccessResponse.of(
-                "",
+                SuccessCode.NO_MESSAGE,
                 new PostViewResponse(challengePost, photoViewList)
         );
     }
@@ -57,7 +58,7 @@ public class ChallengePostSearchService {
                 .toList();
 
         return SuccessResponse.of(
-                "",
+                SuccessCode.NO_MESSAGE,
                 postViewResponseList
         );
     }
@@ -73,7 +74,7 @@ public class ChallengePostSearchService {
                 .toList();
 
         return SuccessResponse.of(
-                "",
+                SuccessCode.NO_MESSAGE,
                 postViewResponseList
         );
     }
@@ -94,7 +95,7 @@ public class ChallengePostSearchService {
                 .toList();
 
         return SuccessResponse.of(
-                "",
+                SuccessCode.NO_MESSAGE,
                 postViewResponseList
         );
     }

--- a/src/main/java/com/habitpay/habitpay/domain/challengepost/application/ChallengePostUpdateService.java
+++ b/src/main/java/com/habitpay/habitpay/domain/challengepost/application/ChallengePostUpdateService.java
@@ -10,6 +10,7 @@ import com.habitpay.habitpay.domain.postphoto.application.PostPhotoDeleteService
 import com.habitpay.habitpay.domain.postphoto.application.PostPhotoUtilService;
 import com.habitpay.habitpay.global.error.exception.ErrorCode;
 import com.habitpay.habitpay.global.error.exception.ForbiddenException;
+import com.habitpay.habitpay.global.response.SuccessCode;
 import com.habitpay.habitpay.global.response.SuccessResponse;
 import jakarta.transaction.Transactional;
 import lombok.RequiredArgsConstructor;
@@ -47,7 +48,7 @@ public class ChallengePostUpdateService {
         );
 
         return SuccessResponse.of(
-                "포스트가 수정되었습니다.",
+                SuccessCode.PATCH_POST_SUCCESS,
                 presignedUrlList
         );
     }

--- a/src/main/java/com/habitpay/habitpay/domain/member/application/MemberDeleteService.java
+++ b/src/main/java/com/habitpay/habitpay/domain/member/application/MemberDeleteService.java
@@ -3,6 +3,7 @@ package com.habitpay.habitpay.domain.member.application;
 import com.habitpay.habitpay.domain.member.dao.MemberRepository;
 import com.habitpay.habitpay.domain.member.domain.Member;
 import com.habitpay.habitpay.global.config.aws.S3FileService;
+import com.habitpay.habitpay.global.response.SuccessCode;
 import com.habitpay.habitpay.global.response.SuccessResponse;
 import lombok.AllArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
@@ -26,7 +27,7 @@ public class MemberDeleteService {
         member.clear();
         memberRepository.save(member);
 
-        return SuccessResponse.of("정상적으로 탈퇴되었습니다.", member.getId());
+        return SuccessResponse.of(SuccessCode.DELETE_MEMBER_ACCOUNT_SUCCESS, member.getId());
     }
 
 }

--- a/src/main/java/com/habitpay/habitpay/domain/member/application/MemberSearchService.java
+++ b/src/main/java/com/habitpay/habitpay/domain/member/application/MemberSearchService.java
@@ -3,7 +3,9 @@ package com.habitpay.habitpay.domain.member.application;
 import com.habitpay.habitpay.domain.member.dao.MemberRepository;
 import com.habitpay.habitpay.domain.member.domain.Member;
 import com.habitpay.habitpay.domain.member.dto.MemberProfileResponse;
+import com.habitpay.habitpay.domain.member.exception.MemberNotFoundException;
 import com.habitpay.habitpay.global.config.aws.S3FileService;
+import com.habitpay.habitpay.global.response.SuccessCode;
 import com.habitpay.habitpay.global.response.SuccessResponse;
 import lombok.AllArgsConstructor;
 import org.springframework.stereotype.Service;
@@ -21,12 +23,12 @@ public class MemberSearchService {
         String imageFileName = Optional.ofNullable(member.getImageFileName()).orElse("");
         String imageUrl = imageFileName.isEmpty() ? "" : s3FileService.getGetPreSignedUrl("profiles", imageFileName);
         
-        return SuccessResponse.of("", MemberProfileResponse.of(member, imageUrl));
+        return SuccessResponse.of(SuccessCode.NO_MESSAGE, MemberProfileResponse.of(member, imageUrl));
     }
 
     @Transactional(readOnly = true)
     public Member getMemberById(Long id) {
         return memberRepository.findById(id)
-                .orElseThrow(() -> new IllegalArgumentException("사용자를 찾을 수 없습니다."));
+                .orElseThrow(() -> new MemberNotFoundException(id));
     }
 }

--- a/src/main/java/com/habitpay/habitpay/domain/refreshtoken/application/RefreshTokenCreationService.java
+++ b/src/main/java/com/habitpay/habitpay/domain/refreshtoken/application/RefreshTokenCreationService.java
@@ -11,6 +11,7 @@ import com.habitpay.habitpay.global.config.jwt.TokenService;
 import com.habitpay.habitpay.global.error.exception.BadRequestException;
 import com.habitpay.habitpay.global.error.exception.ErrorCode;
 import com.habitpay.habitpay.global.error.exception.UnauthorizedException;
+import com.habitpay.habitpay.global.response.SuccessCode;
 import com.habitpay.habitpay.global.response.SuccessResponse;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
@@ -56,7 +57,7 @@ public class RefreshTokenCreationService {
                 refreshToken);
 
         return SuccessResponse.of(
-                "새로운 액세스 토큰 및 리프레시 토큰이 성공적으로 발급되었습니다.",
+                SuccessCode.REFRESH_TOKEN_SUCCESS,
                 tokenResponse
         );
     }

--- a/src/main/java/com/habitpay/habitpay/global/response/SuccessCode.java
+++ b/src/main/java/com/habitpay/habitpay/global/response/SuccessCode.java
@@ -23,7 +23,10 @@ public enum SuccessCode {
     // Post
     CREATE_POST_SUCCESS("정상적으로 포스트를 생성했습니다."),
     PATCH_POST_SUCCESS("정상적으로 포스트를 수정했습니다."),
-    DELETE_POST_SUCCESS("정상적으로 포스트를 삭제했습니다.");
+    DELETE_POST_SUCCESS("정상적으로 포스트를 삭제했습니다."),
+
+    // Token
+    REFRESH_TOKEN_SUCCESS("새로운 액세스 토큰 및 리프레시 토큰이 성공적으로 발급되었습니다.");
 
     private final String message;
 

--- a/src/main/java/com/habitpay/habitpay/global/response/SuccessCode.java
+++ b/src/main/java/com/habitpay/habitpay/global/response/SuccessCode.java
@@ -7,6 +7,9 @@ import lombok.Getter;
 @AllArgsConstructor
 public enum SuccessCode {
 
+    // common
+    NO_MESSAGE(""),
+
     // Member
     NICKNAME_UPDATE_SUCCESS("닉네임 변경에 성공했습니다."),
     PROFILE_IMAGE_UPDATE_SUCCESS("프로필 이미지 변경에 성공했습니다."),

--- a/src/main/java/com/habitpay/habitpay/global/response/SuccessCode.java
+++ b/src/main/java/com/habitpay/habitpay/global/response/SuccessCode.java
@@ -14,7 +14,11 @@ public enum SuccessCode {
     // Challenge
     ENROLL_CHALLENGE_SUCCESS("정상적으로 챌린지에 등록했습니다."),
     CANCEL_CHALLENGE_ENROLLMENT_SUCCESS("정상적으로 챌린지 등록을 취소했습니다."),
-    DELETE_CHALLENGE_SUCCESS("정상적으로 챌린지를 삭제했습니다.");
+    DELETE_CHALLENGE_SUCCESS("정상적으로 챌린지를 삭제했습니다."),
+
+    // Post
+    DELETE_POST_SUCCESS("정상적으로 포스트를 삭제했습니다.");
+
     private final String message;
 
 }

--- a/src/main/java/com/habitpay/habitpay/global/response/SuccessCode.java
+++ b/src/main/java/com/habitpay/habitpay/global/response/SuccessCode.java
@@ -16,6 +16,8 @@ public enum SuccessCode {
     DELETE_MEMBER_ACCOUNT_SUCCESS("정상적으로 탈퇴되었습니다."),
 
     // Challenge
+    CREATE_CHALLENGE_SUCCESS("정상적으로 챌린지가 생성되었습니다."),
+    PATCH_CHALLENGE_SUCCESS("정상적으로 챌린지 정보 수정이 반영되었습니다."),
     ENROLL_CHALLENGE_SUCCESS("정상적으로 챌린지에 등록했습니다."),
     CANCEL_CHALLENGE_ENROLLMENT_SUCCESS("정상적으로 챌린지 등록을 취소했습니다."),
     DELETE_CHALLENGE_SUCCESS("정상적으로 챌린지를 삭제했습니다."),

--- a/src/main/java/com/habitpay/habitpay/global/response/SuccessCode.java
+++ b/src/main/java/com/habitpay/habitpay/global/response/SuccessCode.java
@@ -13,6 +13,7 @@ public enum SuccessCode {
     // Member
     NICKNAME_UPDATE_SUCCESS("닉네임 변경에 성공했습니다."),
     PROFILE_IMAGE_UPDATE_SUCCESS("프로필 이미지 변경에 성공했습니다."),
+    DELETE_MEMBER_ACCOUNT_SUCCESS("정상적으로 탈퇴되었습니다."),
 
     // Challenge
     ENROLL_CHALLENGE_SUCCESS("정상적으로 챌린지에 등록했습니다."),

--- a/src/main/java/com/habitpay/habitpay/global/response/SuccessCode.java
+++ b/src/main/java/com/habitpay/habitpay/global/response/SuccessCode.java
@@ -20,6 +20,8 @@ public enum SuccessCode {
     DELETE_CHALLENGE_SUCCESS("정상적으로 챌린지를 삭제했습니다."),
 
     // Post
+    CREATE_POST_SUCCESS("정상적으로 포스트를 생성했습니다."),
+    PATCH_POST_SUCCESS("정상적으로 포스트를 수정했습니다."),
     DELETE_POST_SUCCESS("정상적으로 포스트를 삭제했습니다.");
 
     private final String message;

--- a/src/test/java/com/habitpay/habitpay/domain/challegepost/api/ChallengePostApiTest.java
+++ b/src/test/java/com/habitpay/habitpay/domain/challegepost/api/ChallengePostApiTest.java
@@ -88,7 +88,7 @@ public class ChallengePostApiTest extends AbstractRestDocsTests {
                 .build();
 
         given(challengePostSearchService.getPostViewByPostId(anyLong()))
-                .willReturn(SuccessResponse.of("", mockPostViewResponse));
+                .willReturn(SuccessResponse.of(SuccessCode.NO_MESSAGE, mockPostViewResponse));
 
         // when
         ResultActions result = mockMvc.perform(get("/api/posts/{id}", 1L)
@@ -142,7 +142,7 @@ public class ChallengePostApiTest extends AbstractRestDocsTests {
                         .build());
 
         given(challengePostSearchService.findPostViewListByChallengeId(anyLong(), any(Pageable.class)))
-                .willReturn(SuccessResponse.of("", mockPostViewResponseList));
+                .willReturn(SuccessResponse.of(SuccessCode.NO_MESSAGE, mockPostViewResponseList));
 
         // when
         ResultActions result = mockMvc.perform(get("/api/challenges/{id}/posts", 1L)
@@ -196,7 +196,7 @@ public class ChallengePostApiTest extends AbstractRestDocsTests {
                         .build());
 
         given(challengePostSearchService.findAnnouncementPostViewListByChallengeId(anyLong(), any(Pageable.class)))
-                .willReturn(SuccessResponse.of("", mockPostViewResponseList));
+                .willReturn(SuccessResponse.of(SuccessCode.NO_MESSAGE, mockPostViewResponseList));
 
         // when
         ResultActions result = mockMvc.perform(get("/api/challenges/{id}/posts/announcements", 1L)
@@ -251,7 +251,7 @@ public class ChallengePostApiTest extends AbstractRestDocsTests {
                         .build());
 
         given(challengePostSearchService.findPostViewListByMember(anyLong(), any(Member.class), any(Pageable.class)))
-                .willReturn(SuccessResponse.of("", mockPostViewResponseList));
+                .willReturn(SuccessResponse.of(SuccessCode.NO_MESSAGE, mockPostViewResponseList));
 
         // when
         ResultActions result = mockMvc.perform(get("/api/challenges/{id}/posts/me", 1L)
@@ -294,7 +294,7 @@ public class ChallengePostApiTest extends AbstractRestDocsTests {
         List<String> presignedUrlList = List.of("https://please.upload/your-photo/here");
 
         given(challengePostCreationService.createPost(any(AddPostRequest.class), anyLong(), any(Member.class)))
-                .willReturn(SuccessResponse.of("포스트가 생성되었습니다.", presignedUrlList));
+                .willReturn(SuccessResponse.of(SuccessCode.CREATE_POST_SUCCESS, presignedUrlList));
 
         //when
         ResultActions result = mockMvc.perform(post("/api/challenges/{id}/post", 1L)
@@ -340,7 +340,7 @@ public class ChallengePostApiTest extends AbstractRestDocsTests {
         List<String> presignedUrlList = List.of("https://please.upload/your-photo/here");
 
         given(challengePostUpdateService.patchPost(any(ModifyPostRequest.class), anyLong(), any(Member.class)))
-                .willReturn(SuccessResponse.of("포스트가 수정되었습니다.", presignedUrlList));
+                .willReturn(SuccessResponse.of(SuccessCode.PATCH_POST_SUCCESS, presignedUrlList));
 
         //when
         ResultActions result = mockMvc.perform(patch("/api/posts/{id}", 1L)

--- a/src/test/java/com/habitpay/habitpay/domain/challegepost/api/ChallengePostApiTest.java
+++ b/src/test/java/com/habitpay/habitpay/domain/challegepost/api/ChallengePostApiTest.java
@@ -13,6 +13,7 @@ import com.habitpay.habitpay.domain.postphoto.dto.ModifyPostPhotoData;
 import com.habitpay.habitpay.domain.postphoto.dto.PostPhotoView;
 import com.habitpay.habitpay.global.config.jwt.TokenProvider;
 import com.habitpay.habitpay.global.config.jwt.TokenService;
+import com.habitpay.habitpay.global.response.SuccessCode;
 import com.habitpay.habitpay.global.response.SuccessResponse;
 import com.habitpay.habitpay.global.security.WithMockOAuth2User;
 import org.junit.jupiter.api.DisplayName;
@@ -379,7 +380,7 @@ public class ChallengePostApiTest extends AbstractRestDocsTests {
 
         //given
         given(challengePostDeleteService.deletePost(anyLong(), any(Member.class)))
-                .willReturn(SuccessResponse.of("포스트가 정상적으로 삭제되었습니다.", 1L));
+                .willReturn(SuccessResponse.of(SuccessCode.DELETE_POST_SUCCESS));
 
         //when
         ResultActions result = mockMvc.perform(delete("/api/posts/{id}", 1L)

--- a/src/test/java/com/habitpay/habitpay/domain/challenge/api/ChallengeApiTest.java
+++ b/src/test/java/com/habitpay/habitpay/domain/challenge/api/ChallengeApiTest.java
@@ -92,7 +92,7 @@ public class ChallengeApiTest extends AbstractRestDocsTests {
                 .build();
 
         given(challengeSearchService.getEnrolledChallengeList(any(Member.class)))
-                .willReturn(SuccessResponse.of("", List.of(response)));
+                .willReturn(SuccessResponse.of(SuccessCode.NO_MESSAGE, List.of(response)));
 
         // when
         ResultActions result = mockMvc.perform(get("/api/challenges/me")
@@ -149,7 +149,7 @@ public class ChallengeApiTest extends AbstractRestDocsTests {
                 .build();
 
         given(challengeDetailsService.getChallengeDetails(anyLong(), any(Member.class)))
-                .willReturn(SuccessResponse.of("", challengeDetailsResponse));
+                .willReturn(SuccessResponse.of(SuccessCode.NO_MESSAGE, challengeDetailsResponse));
 
         // when
         ResultActions result = mockMvc.perform(get("/api/challenges/{id}", 1L)
@@ -233,7 +233,7 @@ public class ChallengeApiTest extends AbstractRestDocsTests {
                 .build();
 
         given(challengeCreationService.createChallenge(any(ChallengeCreationRequest.class), any(Member.class)))
-                .willReturn(SuccessResponse.of("챌린지가 생성되었습니다.", challengeCreationResponse));
+                .willReturn(SuccessResponse.of(SuccessCode.CREATE_CHALLENGE_SUCCESS, challengeCreationResponse));
 
         // when
         ResultActions result = mockMvc.perform(post("/api/challenges")
@@ -335,7 +335,7 @@ public class ChallengeApiTest extends AbstractRestDocsTests {
                 .build();
 
         given(challengePatchService.patch(anyLong(), any(ChallengePatchRequest.class), any(Member.class)))
-                .willReturn(SuccessResponse.of("챌린지 정보 수정이 반영되었습니다.", challengePatchResponse));
+                .willReturn(SuccessResponse.of(SuccessCode.PATCH_CHALLENGE_SUCCESS, challengePatchResponse));
 
         // when
         ResultActions result = mockMvc.perform(patch("/api/challenges/{id}", 1L)

--- a/src/test/java/com/habitpay/habitpay/domain/member/api/MemberApiTest.java
+++ b/src/test/java/com/habitpay/habitpay/domain/member/api/MemberApiTest.java
@@ -79,7 +79,7 @@ public class MemberApiTest extends AbstractRestDocsTests {
                 .build();
 
         given(memberSearchService.getMemberProfile(any(Member.class)))
-                .willReturn(SuccessResponse.of("", memberProfileResponse));
+                .willReturn(SuccessResponse.of(SuccessCode.NO_MESSAGE, memberProfileResponse));
 
         // when
         ResultActions result = mockMvc.perform(get("/api/member")
@@ -217,8 +217,7 @@ public class MemberApiTest extends AbstractRestDocsTests {
         ImageUpdateResponse imageUpdateResponse = ImageUpdateResponse.builder()
                 .preSignedUrl("https://{AWS S3 preSignedUrl to upload image file}")
                 .build();
-        // TODO: 응답 메세지 enum 으로 관리하기
-        SuccessResponse<ImageUpdateResponse> successResponse = SuccessResponse.of("프로필 업데이트에 성공했습니다.", imageUpdateResponse);
+        SuccessResponse<ImageUpdateResponse> successResponse = SuccessResponse.of(SuccessCode.PROFILE_IMAGE_UPDATE_SUCCESS, imageUpdateResponse);
         given(memberUpdateService.updateImage(any(ImageUpdateRequest.class), any(Member.class)))
                 .willReturn(successResponse);
 
@@ -329,8 +328,7 @@ public class MemberApiTest extends AbstractRestDocsTests {
     void deleteMember() throws Exception {
 
         // given
-        // TODO: 응답 메세지 enum 으로 관리하기
-        SuccessResponse<Long> successResponse = SuccessResponse.of("정상적으로 탈퇴되었습니다.", 1L);
+        SuccessResponse<Long> successResponse = SuccessResponse.of(SuccessCode.DELETE_MEMBER_ACCOUNT_SUCCESS, 1L);
         given(memberDeleteService.delete(any(Member.class)))
                 .willReturn(successResponse);
 

--- a/src/test/java/com/habitpay/habitpay/domain/refreshtoken/api/RefreshTokenApiTest.java
+++ b/src/test/java/com/habitpay/habitpay/domain/refreshtoken/api/RefreshTokenApiTest.java
@@ -12,6 +12,7 @@ import com.habitpay.habitpay.global.error.exception.BadRequestException;
 import com.habitpay.habitpay.global.error.exception.ErrorCode;
 import com.habitpay.habitpay.global.error.exception.ForbiddenException;
 import com.habitpay.habitpay.global.error.exception.UnauthorizedException;
+import com.habitpay.habitpay.global.response.SuccessCode;
 import com.habitpay.habitpay.global.response.SuccessResponse;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
@@ -66,7 +67,7 @@ public class RefreshTokenApiTest extends AbstractRestDocsTests {
                 .build();
 
         given(refreshTokenCreationService.createNewAccessTokenAndNewRefreshToken(any(CreateAccessTokenRequest.class)))
-                .willReturn(SuccessResponse.of("새로운 액세스 토큰 및 리프레시 토큰이 성공적으로 발급되었습니다.", tokenResponse));
+                .willReturn(SuccessResponse.of(SuccessCode.REFRESH_TOKEN_SUCCESS, tokenResponse));
 
         //when
         ResultActions result = mockMvc.perform(post("/token")


### PR DESCRIPTION
### 작업 내용

* `DELETE` 요청이 정상적으로 수행되면, `SuccessResponse`의 `data`에 `null`을 담아 보냅니다.
    : 이번 브랜치에서는 `ChallengePost`의 `DELETE` 메서드에 적용되었습니다.
* `SuccessResponse`의 message가 빈 문자열 `""`일 경우, `NO_MESSAGE` `enum`을 사용하도록 했습니다.
    : 전 서비스 메서드에 적용했습니다.
* 서비스 메서드에서 `SuccessResponse`을 반환할 경우, `message`는 `SuccessCode`의 `enum`을 사용하도록 했습니다.
* 해당 내용을 테스트 코드에 반영했습니다.
    : 테스트 코드에 `Enum 관련 주석`도 처리되었기에 삭제했습니다.

---

```java
public enum SuccessCode {

    // common
    NO_MESSAGE(""),

    // Member
    NICKNAME_UPDATE_SUCCESS("닉네임 변경에 성공했습니다."),
    PROFILE_IMAGE_UPDATE_SUCCESS("프로필 이미지 변경에 성공했습니다."),
    DELETE_MEMBER_ACCOUNT_SUCCESS("정상적으로 탈퇴되었습니다."),

    // Challenge
    CREATE_CHALLENGE_SUCCESS("정상적으로 챌린지가 생성되었습니다."),
    PATCH_CHALLENGE_SUCCESS("정상적으로 챌린지 정보 수정이 반영되었습니다."),
    ENROLL_CHALLENGE_SUCCESS("정상적으로 챌린지에 등록했습니다."),
    CANCEL_CHALLENGE_ENROLLMENT_SUCCESS("정상적으로 챌린지 등록을 취소했습니다."),
    DELETE_CHALLENGE_SUCCESS("정상적으로 챌린지를 삭제했습니다."),

    // Post
    CREATE_POST_SUCCESS("정상적으로 포스트를 생성했습니다."),
    PATCH_POST_SUCCESS("정상적으로 포스트를 수정했습니다."),
    DELETE_POST_SUCCESS("정상적으로 포스트를 삭제했습니다."),

    // Token
    REFRESH_TOKEN_SUCCESS("새로운 액세스 토큰 및 리프레시 토큰이 성공적으로 발급되었습니다.");

    private final String message;

}
```

* 현재 `SuceessCode`입니다.
* 수정 사항이 필요하면 바로 고치겠습니다요!