### PR TITLE
[Feat] 챌린지 참여 기록이 생성되면, enrollment 엔티티의 successCount의 횟수를 증가시킵니다.#211

### DIFF
--- a/src/main/java/com/habitpay/habitpay/domain/challengeenrollment/domain/ChallengeEnrollment.java
+++ b/src/main/java/com/habitpay/habitpay/domain/challengeenrollment/domain/ChallengeEnrollment.java
@@ -1,6 +1,7 @@
 package com.habitpay.habitpay.domain.challengeenrollment.domain;
 
 import com.habitpay.habitpay.domain.challenge.domain.Challenge;
+import com.habitpay.habitpay.domain.challengeparticipationrecord.domain.ChallengeParticipationRecord;
 import com.habitpay.habitpay.domain.member.domain.Member;
 import jakarta.persistence.*;
 import lombok.Builder;
@@ -60,5 +61,11 @@ public class ChallengeEnrollment {
                 .challenge(challenge)
                 .member(member)
                 .build();
+    }
+
+    public void plusSuccessCountWithParticipationRecord(ChallengeParticipationRecord record) {
+        if (this.equals(record.getChallengeEnrollment())) {
+            ++this.successCount;
+        }
     }
 }

--- a/src/main/java/com/habitpay/habitpay/domain/challengeparticipationrecord/application/ChallengeParticipationRecordCreationService.java
+++ b/src/main/java/com/habitpay/habitpay/domain/challengeparticipationrecord/application/ChallengeParticipationRecordCreationService.java
@@ -16,12 +16,15 @@ public class ChallengeParticipationRecordCreationService {
     private final ChallengeParticipationRecordRepository challengeParticipationRecordRepository;
 
     public ChallengeParticipationRecord save(ChallengeEnrollment enrollment, ChallengePost post) {
-        // todo : 챌린지 조건 따져서 인정될 때만 저장해야 함
-        // todo : enrollment service에서 enrollment의 성공 횟수를 +1하는 메서드 만들고, 여기에 넣어야 할 듯
-        return challengeParticipationRecordRepository.save(
-                ChallengeParticipationRecord.builder()
-                        .enrollment(enrollment)
-                        .post(post)
-                        .build());
+
+        ChallengeParticipationRecord record =
+                challengeParticipationRecordRepository.save(
+                        ChallengeParticipationRecord.builder()
+                                .enrollment(enrollment)
+                                .post(post)
+                                .build());
+
+        enrollment.plusSuccessCountWithParticipationRecord(record);
+        return record;
     }
 }

--- a/src/main/java/com/habitpay/habitpay/domain/challengepost/application/ChallengePostCreationService.java
+++ b/src/main/java/com/habitpay/habitpay/domain/challengepost/application/ChallengePostCreationService.java
@@ -37,7 +37,9 @@ public class ChallengePostCreationService {
     public SuccessResponse<List<String>> createPost(AddPostRequest request, Long challengeId, Member member) {
 
         ChallengePost challengePost = this.savePost(request, challengeId, member);
-        challengePostUtilService.verifyChallengePostForRecord(challengePost);
+        if (!challengePost.getIsAnnouncement()) {
+            challengePostUtilService.verifyChallengePostForRecord(challengePost);
+        }
         List<String> presignedUrlList = postPhotoCreationService.createPhotoUrlList(challengePost, request.getPhotos());
 
         return SuccessResponse.of(

--- a/src/main/java/com/habitpay/habitpay/domain/challengepost/application/ChallengePostUtilService.java
+++ b/src/main/java/com/habitpay/habitpay/domain/challengepost/application/ChallengePostUtilService.java
@@ -47,10 +47,8 @@ public class ChallengePostUtilService {
         }
 
         // todo : ParticipationDay 비트 방식 확인하기
-        //  (우선 8비트 기준 앞자리부터 월요일이라고 상정함 ex.0b10101000(월수금))
         DayOfWeek nowDayOfWeek = now.getDayOfWeek();
         int nowDayOfWeekValue = nowDayOfWeek.getValue();
-//        int nowDayOfWeekValue = now.getDayOfWeek().getValue();
         boolean todayIsParticipationDay = (challenge.getParticipatingDays() & (1 << (nowDayOfWeekValue - 1))) != 0;
 
         // todo : 디버깅 용도
@@ -67,7 +65,6 @@ public class ChallengePostUtilService {
             return;
         }
 
-        //todo: challengeEnrollment.successCount +1 하는 메서드 만들기 (challenge 도메인이나 서비스 내 위치?)
         challengeParticipationRecordCreationService.save(enrollment, post);
     }
 

--- a/src/main/java/com/habitpay/habitpay/domain/challengepost/application/ChallengePostUtilService.java
+++ b/src/main/java/com/habitpay/habitpay/domain/challengepost/application/ChallengePostUtilService.java
@@ -46,16 +46,9 @@ public class ChallengePostUtilService {
             return;
         }
 
-        // todo : ParticipationDay 비트 방식 확인하기
         DayOfWeek nowDayOfWeek = now.getDayOfWeek();
         int nowDayOfWeekValue = nowDayOfWeek.getValue();
-        boolean todayIsParticipationDay = (challenge.getParticipatingDays() & (1 << (nowDayOfWeekValue - 1))) != 0;
-
-        // todo : 디버깅 용도
-        log.info("오늘은 " + nowDayOfWeek);
-        log.info("비트로 표현하자면 " + nowDayOfWeekValue);
-        log.info("챌린지 인증해야 하는 날은? " + challenge.getParticipatingDays());
-        log.info("오늘은 챌린지 참여날: " + todayIsParticipationDay);
+        boolean todayIsParticipationDay = (challenge.getParticipatingDays() & (1 << (7 - nowDayOfWeekValue))) != 0;
 
         if (!todayIsParticipationDay) {
             return;


### PR DESCRIPTION
### 작업 개요

* `ChallengeEnrollment` 엔티티에는 챌린지 내 참여 성공 횟수를 기록하는 `successCount` 속성이 있습니다.
```java
@Table(name = "challenge_enrollment")
public class ChallengeEnrollment {
    ...
    @Column(nullable = false)
    private int successCount;
    ...
}
```
* 챌린지 내 참여 성공 시 기록을 위한 `ChallengeParticipationRecord`가 생성되는데
  이는 `enrollment` 내 `successCount`의 수와 동일해야 하므로,
  `record` 엔티티 객체가 생성 및 저장될 때 `successCount`의 횟수를 `1`씩 증가시켜 정합성을 맞추는 로직을 추가했습니다.

---

### 주요 내용

* `enrollment` 엔티티 내에 `record 객체`를 받으면 `successCount`를 증가시키는 메서드를 추가했습니다.
```java
// ChallengeEnrollment.java

public void plusSuccessCountWithParticipationRecord(ChallengeParticipationRecord record) {
    if (this.equals(record.getChallengeEnrollment())) {
        ++this.successCount;
    }
}
```
* `record`의 `소속 enrollment`와 동일하면 `successCount`가 `1` 증가합니다.

---

* `plusSuccessCountWithParticipationRecord` 메서드는 `record 생성 서비스` 메서드에서 사용됩니다.

```java
// ChallengeParticipationRecordCreationService.java

public ChallengeParticipationRecord save(ChallengeEnrollment enrollment, ChallengePost post) {

    ChallengeParticipationRecord record =
            challengeParticipationRecordRepository.save(
                    ChallengeParticipationRecord.builder()
                            .enrollment(enrollment)
                            .post(post)
                            .build());

    enrollment.plusSuccessCountWithParticipationRecord(record);
    return record;
}
```

* `record`가 정상적으로 생성 및 저장된 후에 `successCount`도 증가합니다.

---

* 마음에 걸리는 점 :
* `plusSuccessCountWithParticipationRecord` 메서드를 (`record` 객체만 넣어주면) 어디에서나 쓸 수 있다는 점.

---

* 생각해본 대안 :
* `plusSuccessCountWithParticipationRecord` 메서드 내에
   오늘 날짜 `enrollment`에 해당하는 `record`가 있는지 확인하는 로직 추가하기
   -> `isAlreadyParticipateToday` 메서드가 이미 존재하며, `record` 생성 전에 이미 확인함
   => 동일한 검증 로직을 반복하는 게 낭비라는 생각 vs 그래도 안전성을 위해 추가해야 하나라는 생각

---

### 기타

* record 객체 생성 전 검증 로직에 공지글 여부 확인하는 분기 추가

```java
@Transactional
public SuccessResponse<List<String>> createPost(...) {

    ...
    if (!challengePost.getIsAnnouncement()) {
        challengePostUtilService.verifyChallengePostForRecord(challengePost);
    }
    ...
}
```

* 공지 포스트가 아닐 때만 `record`가 될 수 있는지 검증 후 저장하는 메서드에 들어갑니다.

---

* 요일 표현 비트 방식에 맞추어 참여 요일 확인하는 비트 마스킹 코드 수정