### PR TITLE
[feat] 컨트롤러 api  정리 #221

### DIFF
--- a/src/main/java/com/habitpay/habitpay/domain/challengepost/api/ChallengePostApi.java
+++ b/src/main/java/com/habitpay/habitpay/domain/challengepost/api/ChallengePostApi.java
@@ -19,6 +19,7 @@ import java.util.List;
 
 @RestController
 @RequiredArgsConstructor
+@RequestMapping("/api")
 @Slf4j
 public class ChallengePostApi {
 
@@ -27,13 +28,13 @@ public class ChallengePostApi {
     private final ChallengePostUpdateService challengePostUpdateService;
     private final ChallengePostDeleteService challengePostDeleteService;
 
-    @GetMapping("/api/posts/{id}")
+    @GetMapping("/posts/{id}")
     public SuccessResponse<PostViewResponse> getPost(@PathVariable Long id) {
 
         return challengePostSearchService.getPostViewByPostId(id);
     }
 
-    @GetMapping("/api/challenges/{id}/posts")
+    @GetMapping("/challenges/{id}/posts")
     public SuccessResponse<Slice<PostViewResponse>> getChallengePosts(
             @PathVariable Long id,
             @PageableDefault(sort = "id", direction = Sort.Direction.DESC) Pageable pageable) {
@@ -41,7 +42,7 @@ public class ChallengePostApi {
         return challengePostSearchService.findPostViewListByChallengeId(id, pageable);
     }
 
-    @GetMapping("/api/challenges/{id}/posts/announcements")
+    @GetMapping("/challenges/{id}/posts/announcements")
     public SuccessResponse<Slice<PostViewResponse>> getAnnouncements(
             @PathVariable Long id,
             @PageableDefault(sort = "id", direction = Sort.Direction.DESC) Pageable pageable) {
@@ -49,7 +50,7 @@ public class ChallengePostApi {
         return challengePostSearchService.findAnnouncementPostViewListByChallengeId(id, pageable);
     }
 
-    @GetMapping("/api/challenges/{id}/posts/me")
+    @GetMapping("/challenges/{id}/posts/me")
     public SuccessResponse<Slice<PostViewResponse>> getChallengePostsByMe(
             @PathVariable Long id,
             @AuthenticationPrincipal CustomUserDetails user,
@@ -60,7 +61,7 @@ public class ChallengePostApi {
 
     // -----------------------------------------------------------------------------
     // todo : 'challengeEnrollmentId' or 'memberId' 등 멤버 식별할 수 있는 데이터를 받아야 함
-//    @GetMapping("/api/challenges/{id}/posts/member")
+//    @GetMapping("/challenges/{id}/posts/member")
 //    public SuccessResponse<Slice<PostViewResponse>> getChallengePostsByMember(
 //            @PathVariable Long id,
 //            @PageableDefault(sort = "id", direction = Sort.Direction.DESC) Pageable pageable) {
@@ -71,7 +72,7 @@ public class ChallengePostApi {
 //    }
     // -------------------------------------------------------------------------------
 
-    @PostMapping("/api/challenges/{id}/post")
+    @PostMapping("/challenges/{id}/post")
     public SuccessResponse<List<String>> createPost(
             @RequestBody AddPostRequest request,
             @PathVariable Long id,
@@ -80,14 +81,14 @@ public class ChallengePostApi {
         return challengePostCreationService.createPost(request, id, user.getMember());
     }
 
-    @PatchMapping("/api/posts/{id}")
+    @PatchMapping("/posts/{id}")
     public SuccessResponse<List<String>> patchPost(
             @RequestBody ModifyPostRequest request, @PathVariable Long id, @AuthenticationPrincipal CustomUserDetails user) {
 
         return challengePostUpdateService.patchPost(request, id, user.getMember());
     }
 
-    @DeleteMapping("/api/posts/{id}")
+    @DeleteMapping("/posts/{id}")
     public SuccessResponse<Void> deletePost(
             @PathVariable Long id, @AuthenticationPrincipal CustomUserDetails user) {
 

--- a/src/main/java/com/habitpay/habitpay/domain/refreshtoken/api/TokenApi.java
+++ b/src/main/java/com/habitpay/habitpay/domain/refreshtoken/api/TokenApi.java
@@ -10,10 +10,12 @@ import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
 @RequiredArgsConstructor
 @RestController
+@RequestMapping("/api")
 @Slf4j
 public class TokenApi {
 

--- a/src/main/java/com/habitpay/habitpay/global/config/auth/SecurityConfig.java
+++ b/src/main/java/com/habitpay/habitpay/global/config/auth/SecurityConfig.java
@@ -54,7 +54,7 @@ public class SecurityConfig {
                 .authorizeHttpRequests((authorizeRequests ->
                         authorizeRequests
                                 .requestMatchers("/oauth2/**").permitAll()
-                                .requestMatchers("/token").permitAll() // todo: url 수정 후 /api 추가하기
+                                .requestMatchers("/api/token").permitAll() // todo: url 수정 후 /api 추가하기
 //                            .requestMatchers("/api/v1/**").hasRole(Role.USER.name()) // todo: 로그인 후 사용하는 api 에서만 적용하기
                                 .anyRequest().authenticated()
                 ))

--- a/src/test/java/com/habitpay/habitpay/domain/refreshtoken/api/RefreshTokenApiTest.java
+++ b/src/test/java/com/habitpay/habitpay/domain/refreshtoken/api/RefreshTokenApiTest.java
@@ -70,7 +70,7 @@ public class RefreshTokenApiTest extends AbstractRestDocsTests {
                 .willReturn(SuccessResponse.of(SuccessCode.REFRESH_TOKEN_SUCCESS, tokenResponse));
 
         //when
-        ResultActions result = mockMvc.perform(post("/token")
+        ResultActions result = mockMvc.perform(post("/api/token")
                 .content(objectMapper.writeValueAsString(tokenRequest))
                 .contentType(MediaType.APPLICATION_JSON));
 
@@ -105,7 +105,7 @@ public class RefreshTokenApiTest extends AbstractRestDocsTests {
                 .willThrow(new BadRequestException(ErrorCode.BAD_REQUEST));
 
         //when
-        ResultActions result = mockMvc.perform(post("/token")
+        ResultActions result = mockMvc.perform(post("/api/token")
                 .content(objectMapper.writeValueAsString(tokenRequest))
                 .contentType(MediaType.APPLICATION_JSON));
 
@@ -134,7 +134,7 @@ public class RefreshTokenApiTest extends AbstractRestDocsTests {
                 .willThrow(new UnauthorizedException(ErrorCode.UNAUTHORIZED));
 
         //when
-        ResultActions result = mockMvc.perform(post("/token")
+        ResultActions result = mockMvc.perform(post("/api/token")
                 .content(objectMapper.writeValueAsString(tokenRequest))
                 .contentType(MediaType.APPLICATION_JSON));
 
@@ -163,7 +163,7 @@ public class RefreshTokenApiTest extends AbstractRestDocsTests {
                 .willThrow(new ForbiddenException(ErrorCode.FORBIDDEN));
 
         //when
-        ResultActions result = mockMvc.perform(post("/token")
+        ResultActions result = mockMvc.perform(post("/api/token")
                 .content(objectMapper.writeValueAsString(tokenRequest))
                 .contentType(MediaType.APPLICATION_JSON));
 


### PR DESCRIPTION
### 작업 내용

* `@RequestMapping` 이용하여 반복되는 api 경로를 정리했습니다.
* 리프레시 토큰 요청 url에 `/api`를 추가하고 관련 코드를 수정했습니다.