### PR TITLE
[feat] 챌린지 유효 기간이 아닐 시 포스트 생성 및 수정 불가 #224

### DIFF
--- a/src/main/java/com/habitpay/habitpay/domain/challengepost/application/ChallengePostCreationService.java
+++ b/src/main/java/com/habitpay/habitpay/domain/challengepost/application/ChallengePostCreationService.java
@@ -38,7 +38,7 @@ public class ChallengePostCreationService {
 
         Challenge challenge = challengeSearchService.getChallengeById(challengeId);
         if (!challengePostUtilService.isChallengePeriodForPost(challenge)) {
-            throw new ForbiddenException(ErrorCode.POST_ACCESSIBLE_ONLY_WITHIN_CHALLENGE_PERIOD);
+            throw new ForbiddenException(ErrorCode.POST_EDITABLE_ONLY_WITHIN_CHALLENGE_PERIOD);
         }
 
         ChallengePost challengePost = this.savePost(request, challenge, member);

--- a/src/main/java/com/habitpay/habitpay/domain/challengepost/application/ChallengePostUpdateService.java
+++ b/src/main/java/com/habitpay/habitpay/domain/challengepost/application/ChallengePostUpdateService.java
@@ -1,5 +1,6 @@
 package com.habitpay.habitpay.domain.challengepost.application;
 
+import com.habitpay.habitpay.domain.challenge.application.ChallengeSearchService;
 import com.habitpay.habitpay.domain.challenge.domain.Challenge;
 import com.habitpay.habitpay.domain.challengepost.dao.ChallengePostRepository;
 import com.habitpay.habitpay.domain.challengepost.domain.ChallengePost;
@@ -35,6 +36,11 @@ public class ChallengePostUpdateService {
     @Transactional
     public SuccessResponse<List<String>> patchPost(ModifyPostRequest request, Long postId, Member member) {
         ChallengePost post = challengePostSearchService.getChallengePostById(postId);
+
+        if (!challengePostUtilService.isChallengePeriodForPost(post.getChallenge())) {
+            throw new ForbiddenException(ErrorCode.POST_ACCESSIBLE_ONLY_WITHIN_CHALLENGE_PERIOD);
+        }
+
         challengePostUtilService.authorizePostWriter(post, member);
 
         patchContent(post, request.getContent());

--- a/src/main/java/com/habitpay/habitpay/domain/challengepost/application/ChallengePostUpdateService.java
+++ b/src/main/java/com/habitpay/habitpay/domain/challengepost/application/ChallengePostUpdateService.java
@@ -38,7 +38,7 @@ public class ChallengePostUpdateService {
         ChallengePost post = challengePostSearchService.getChallengePostById(postId);
 
         if (!challengePostUtilService.isChallengePeriodForPost(post.getChallenge())) {
-            throw new ForbiddenException(ErrorCode.POST_ACCESSIBLE_ONLY_WITHIN_CHALLENGE_PERIOD);
+            throw new ForbiddenException(ErrorCode.POST_EDITABLE_ONLY_WITHIN_CHALLENGE_PERIOD);
         }
 
         challengePostUtilService.authorizePostWriter(post, member);

--- a/src/main/java/com/habitpay/habitpay/domain/challengepost/application/ChallengePostUtilService.java
+++ b/src/main/java/com/habitpay/habitpay/domain/challengepost/application/ChallengePostUtilService.java
@@ -37,6 +37,12 @@ public class ChallengePostUtilService {
         return challenge.getHost().equals(member);
     }
 
+    public boolean isChallengePeriodForPost(Challenge challenge) {
+        ZonedDateTime now = ZonedDateTime.now();
+
+        return now.isAfter(challenge.getStartDate()) && !challenge.isPaidAll();
+    }
+
     public void verifyChallengePostForRecord(ChallengePost post) {
         ChallengeEnrollment enrollment = post.getChallengeEnrollment();
         Challenge challenge = enrollment.getChallenge();

--- a/src/main/java/com/habitpay/habitpay/global/error/exception/ErrorCode.java
+++ b/src/main/java/com/habitpay/habitpay/global/error/exception/ErrorCode.java
@@ -50,7 +50,7 @@ public enum ErrorCode {
     POST_CANNOT_BE_DELETED(HttpStatus.FORBIDDEN, "일반 포스트 삭제는 제공되지 않는 기능입니다."),
     POST_PHOTO_IMAGE_SIZE_TOO_LARGE(HttpStatus.BAD_REQUEST, "이미지 파일의 크기가 제한을 초과했습니다. (최대 1MB)"),
     PHOTO_NOT_FOUND(HttpStatus.NOT_FOUND, "포스트 포토가 존재하지 않습니다."),
-    POST_ACCESSIBLE_ONLY_WITHIN_CHALLENGE_PERIOD(HttpStatus.FORBIDDEN, "챌린지 유효 기간에만 포스트를 작성 및 수정할 수 있습니다."),
+    POST_EDITABLE_ONLY_WITHIN_CHALLENGE_PERIOD(HttpStatus.FORBIDDEN, "챌린지 유효 기간에만 포스트를 작성 및 수정할 수 있습니다."),
 
     // todo : 마지막 error code 뒤에 붙이기
     ;

--- a/src/main/java/com/habitpay/habitpay/global/error/exception/ErrorCode.java
+++ b/src/main/java/com/habitpay/habitpay/global/error/exception/ErrorCode.java
@@ -50,6 +50,7 @@ public enum ErrorCode {
     POST_CANNOT_BE_DELETED(HttpStatus.FORBIDDEN, "일반 포스트 삭제는 제공되지 않는 기능입니다."),
     POST_PHOTO_IMAGE_SIZE_TOO_LARGE(HttpStatus.BAD_REQUEST, "이미지 파일의 크기가 제한을 초과했습니다. (최대 1MB)"),
     PHOTO_NOT_FOUND(HttpStatus.NOT_FOUND, "포스트 포토가 존재하지 않습니다."),
+    POST_ACCESSIBLE_ONLY_WITHIN_CHALLENGE_PERIOD(HttpStatus.FORBIDDEN, "챌린지 유효 기간에만 포스트를 작성 및 수정할 수 있습니다."),
 
     // todo : 마지막 error code 뒤에 붙이기
     ;


### PR DESCRIPTION
### 작업 개요

* `챌린지 시작 ~ 챌린지 종료 후 정산 타임` 기한을 챌린지 유효 기간으로 보고,
   챌린지 유효 기간 이내에만 포스트 생성 및 수정이 가능하도록 수정했습니다.

---

### 주요 코드

* 챌린지 유효 기간 여부를 확인하는 메서드를 만들었습니다.
```java
// ChallengePostUtilService.java

public boolean isChallengePeriodForPost(Challenge challenge) {
    ZonedDateTime now = ZonedDateTime.now();

    return now.isAfter(challenge.getStartDate()) && !challenge.isPaidAll();
}
```

---

* 챌린지 포스트를 생성 혹은 수정하기 전에 위의 메서드로 검사하고,
   검사  결과가 `false`라면 예외를 던집니다.

```java
throw new ForbiddenException(ErrorCode.POST_EDITABLE_ONLY_WITHIN_CHALLENGE_PERIOD);
```
```java
// ErrorCode
POST_EDITABLE_ONLY_WITHIN_CHALLENGE_PERIOD(HttpStatus.FORBIDDEN, "챌린지 유효 기간에만 포스트를 작성 및 수정할 수 있습니다."),
```