### PR TITLE
[Feat] 회원 탈퇴 시 리프레시 토큰도 레포지토리에서 삭제 #226

### DIFF
--- a/src/main/java/com/habitpay/habitpay/domain/member/application/MemberDeleteService.java
+++ b/src/main/java/com/habitpay/habitpay/domain/member/application/MemberDeleteService.java
@@ -2,12 +2,14 @@ package com.habitpay.habitpay.domain.member.application;
 
 import com.habitpay.habitpay.domain.member.dao.MemberRepository;
 import com.habitpay.habitpay.domain.member.domain.Member;
+import com.habitpay.habitpay.domain.refreshtoken.application.RefreshTokenDeleteService;
 import com.habitpay.habitpay.global.config.aws.S3FileService;
 import com.habitpay.habitpay.global.response.SuccessCode;
 import com.habitpay.habitpay.global.response.SuccessResponse;
 import lombok.AllArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
 
 import java.util.Optional;
 
@@ -18,11 +20,15 @@ public class MemberDeleteService {
 
     private final MemberRepository memberRepository;
     private final S3FileService s3FileService;
+    private final RefreshTokenDeleteService refreshTokenDeleteService;
 
+    @Transactional
     public SuccessResponse<Long> delete(Member member) {
         log.info("[DELETE /member] imageFileName: {}", member.getImageFileName());
         Optional.ofNullable(member.getImageFileName())
                 .ifPresent((imageFileName) -> s3FileService.deleteImage("profiles", imageFileName));
+
+        refreshTokenDeleteService.delete(member);
 
         member.clear();
         memberRepository.save(member);

--- a/src/main/java/com/habitpay/habitpay/domain/refreshtoken/application/RefreshTokenCreationService.java
+++ b/src/main/java/com/habitpay/habitpay/domain/refreshtoken/application/RefreshTokenCreationService.java
@@ -92,7 +92,7 @@ public class RefreshTokenCreationService {
 
     private void saveRefreshToken(Member member, String newRefreshToken) {
         String loginId = refreshTokenUtilService.getClientIpAddress();
-        RefreshToken refreshToken = refreshTokenRepository.findByMemberId(member.getId())
+        RefreshToken refreshToken = refreshTokenRepository.findByMember(member)
                 .map(entity -> entity.update(newRefreshToken, loginId))
                 .orElse(new RefreshToken(member, newRefreshToken, loginId));
 

--- a/src/main/java/com/habitpay/habitpay/domain/refreshtoken/application/RefreshTokenDeleteService.java
+++ b/src/main/java/com/habitpay/habitpay/domain/refreshtoken/application/RefreshTokenDeleteService.java
@@ -16,6 +16,6 @@ public class RefreshTokenDeleteService {
 
     public void delete(Member member) {
         Optional<RefreshToken> optionalRefreshToken = refreshTokenRepository.findByMember(member);
-//        refreshTokenRepository.delete();
+        optionalRefreshToken.ifPresent(refreshTokenRepository::delete);
     }
 }

--- a/src/main/java/com/habitpay/habitpay/domain/refreshtoken/application/RefreshTokenDeleteService.java
+++ b/src/main/java/com/habitpay/habitpay/domain/refreshtoken/application/RefreshTokenDeleteService.java
@@ -1,0 +1,21 @@
+package com.habitpay.habitpay.domain.refreshtoken.application;
+
+import com.habitpay.habitpay.domain.member.domain.Member;
+import com.habitpay.habitpay.domain.refreshtoken.dao.RefreshTokenRepository;
+import com.habitpay.habitpay.domain.refreshtoken.domain.RefreshToken;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+import java.util.Optional;
+
+@RequiredArgsConstructor
+@Service
+public class RefreshTokenDeleteService {
+
+    private final RefreshTokenRepository refreshTokenRepository;
+
+    public void delete(Member member) {
+        Optional<RefreshToken> optionalRefreshToken = refreshTokenRepository.findByMember(member);
+//        refreshTokenRepository.delete();
+    }
+}

--- a/src/main/java/com/habitpay/habitpay/domain/refreshtoken/application/RefreshTokenDeleteService.java
+++ b/src/main/java/com/habitpay/habitpay/domain/refreshtoken/application/RefreshTokenDeleteService.java
@@ -15,7 +15,6 @@ public class RefreshTokenDeleteService {
     private final RefreshTokenRepository refreshTokenRepository;
 
     public void delete(Member member) {
-        Optional<RefreshToken> optionalRefreshToken = refreshTokenRepository.findByMember(member);
-        optionalRefreshToken.ifPresent(refreshTokenRepository::delete);
+       refreshTokenRepository.findByMember(member).ifPresent(refreshTokenRepository::delete);
     }
 }

--- a/src/main/java/com/habitpay/habitpay/domain/refreshtoken/dao/RefreshTokenRepository.java
+++ b/src/main/java/com/habitpay/habitpay/domain/refreshtoken/dao/RefreshTokenRepository.java
@@ -1,11 +1,12 @@
 package com.habitpay.habitpay.domain.refreshtoken.dao;
 
+import com.habitpay.habitpay.domain.member.domain.Member;
 import com.habitpay.habitpay.domain.refreshtoken.domain.RefreshToken;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 import java.util.Optional;
 
 public interface RefreshTokenRepository extends JpaRepository<RefreshToken, Long> {
-    Optional<RefreshToken> findByMemberId(Long memberId);
+    Optional<RefreshToken> findByMember(Member member);
     Optional<RefreshToken> findByRefreshToken(String refreshToken);
 }

--- a/src/main/java/com/habitpay/habitpay/domain/refreshtoken/domain/RefreshToken.java
+++ b/src/main/java/com/habitpay/habitpay/domain/refreshtoken/domain/RefreshToken.java
@@ -24,7 +24,6 @@ public class RefreshToken {
     @Column(nullable = false)
     private String refreshToken;
 
-    // todo: 과정 좀 복잡하면 즉시 삭제
     @Column(nullable = false)
     private String loginIp;
 


### PR DESCRIPTION
### 작업 개요

* 회원 탈퇴 시, 회원의 리프레시 토큰 정보를 담고 있는 RefreshTokenRepository의 컬럼도 삭제합니다.

---

### 코드 내용

*`Member` 객체를 받으면 그에 대응하는 `RefreshToken`을 삭제하는 메서드를 만들었습니다.
```java
// RefreshTokenDeleteService.java

public void delete(Member member) {
    Optional<RefreshToken> optionalRefreshToken = refreshTokenRepository.findByMember(member);
    optionalRefreshToken.ifPresent(refreshTokenRepository::delete);
}
```

---

* 멤버를 탈퇴할 경우 처리하는 메서드에 위의 메서드를 추가했습니다.

```java
// MemberDeleteService.java

@Transactional
public SuccessResponse<Long> delete(Member member) {
    ...

    refreshTokenDeleteService.delete(member);

    member.clear();
    memberRepository.save(member);

    return ..;
}
```
* 삭제는 한 단위로 진행되어야 해서 @Transactional 어노테이션을 추가했습니다.
---

### 기타

* 메서드 호출을 줄이는 방향으로 작은 리팩토링을 진행했습니다.

---

### 그러나

* 확실한 양방향 삭제를 위해 `cascade = CascadeType.REMOVE`를 염두에 두고 계셨을 수도 있겠다는 생각이 들었습니다.
* 작업 목록 리스트를 임의로 행한 작업이라 준한님이 의도하신 방향과 다를 수 있습니다.
   피드백 받고 진행 or 의도대로 다시 코드 변경하고자 풀리퀘 남깁니다.