### PR TITLE
[Feat] 토큰 재발급 시 리프레시 토큰을 쿠키로 주고 받기 #231

### DIFF
--- a/src/docs/asciidoc/api/refreshToken.adoc
+++ b/src/docs/asciidoc/api/refreshToken.adoc
@@ -16,16 +16,18 @@
 액세스 토큰이 만료되는 등 더 이상 사용할 수 없다는 의미입니다.
 
 그 경우 "/api/token" 경로를 통해 토큰 재발급을 요청해야 합니다.
+(401 이외의 상태 코드로는 토큰 재발급을 요청할 수 없습니다.)
+
 리프레시 토큰은 이미 쿠키에 세팅되어 요청에 담기기 때문에, 추가로 보내야 할 값은 없습니다.
 
 다만 표준 CORS 요청은 기본적으로 쿠키를 포함한 인증 정보를 설정할 수 없습니다.
-그렇기 때문에 인증 정보(쿠키 등)를 요청에 추가하도록 수동으로 "withCredentials: true" 설정을 해줘야 합니다.
+그렇기 때문에 인증 정보(쿠키 등)를 요청에 추가하도록 수동으로 "withCredentials: true" 설정을 추가해야 합니다.
 
-(이는 백엔드에서 쿠키를 포함한 응답을 보낼 때 "Access-Control-Allow-Credentials" 설정을 "true"로 맞춰야 하는 이유와 동일합니다.)
+(이는 백엔드에서 쿠키를 포함한 응답을 보낼 때 "Access-Control-Allow-Credentials" 설정을 "true"로 하는 이유와 동일합니다.)
 
 리프레시 토큰이 유효하고 적절하다면 새로운 액세스 토큰은 응답 본문에, 새로운 리프레시 토큰은 쿠키에 담아 재발급합니다.
 
-operation::refreshToken/create-new-access-token-and-new-refresh-token[snippets='http-request,http-response,request-fields,response-fields']
+operation::refreshToken/create-new-access-token-and-new-refresh-token[snippets='http-request,http-response,response-fields']
 
 === 토큰 리프레시 실패 : 400 Bad Request
 
@@ -39,10 +41,6 @@ operation::refreshToken/return-400-when-invalid-request[snippets='http-request,h
 
 토큰 리프레시 요청 시 이 응답을 받았다면 리프레시 토큰이 만료되었을 가능성이 큽니다. 이 경우 재로그인이 필요합니다.
 
-그러나 일반 "/api" 요청 중 위와 같은 401 상태 코드를 받았다면, 액세스 토큰이 만료된 것으로 보고 클라이언트는 토큰 재발급, 즉 토큰 리프레시("/token")를 요청해야 합니다.
-
-(중요한 점은, 401 이외의 상태 코드로는 클라이언트가 토큰 재발급을 요청할 수 없다는 것입니다.)
-
 operation::refreshToken/return-401-when-invalid-token[snippets='http-request,http-response,response-fields']
 
 === 토큰 리프레시 실패 : 403 Forbidden
@@ -50,6 +48,6 @@ operation::refreshToken/return-401-when-invalid-token[snippets='http-request,htt
 토큰이 제공하는 권한보다 더 높은 권한을 요구할 때 발생합니다.
 예를 들면 일반 사용자가 관리자 페이지에 접근하는 경우를 들 수 있습니다.
 
-해빗페이에서 권한 문제가 발생하는 대상은 액세스 토큰이기 때문에, (토큰 리프레시 API 문서이지만) 액세스 토큰의 권한이 부족할 때 발생하는 상태 코드로 이해하면 되겠습니다.
+해빗페이에서 권한 문제가 발생하는 대상은 액세스 토큰이기 때문에, 액세스 토큰의 권한이 부족할 때 발생하는 상태 코드로 이해하면 되겠습니다.
 
 operation::refreshToken/return-403-when-insufficient-scope[snippets='http-request,http-response,response-fields']

--- a/src/docs/asciidoc/api/refreshToken.adoc
+++ b/src/docs/asciidoc/api/refreshToken.adoc
@@ -12,10 +12,18 @@
 
 === 토큰 리프레시 요청
 
-Request Body에 클라이언트가 가지고 있던 리프레시 토큰을 담아 형식에 맞게 요청합니다.
-리프레시 토큰이 유효하고 적절하다면, 새로운 액세스 토큰과 함께 새로운 리프레시 토큰을 세트로 발급합니다.
+백엔드 URL에 요청을 보냈으나 401 Unauthorized 상태 코드를 받았다면,
+액세스 토큰이 만료되는 등 더 이상 사용할 수 없다는 의미입니다.
 
-이때 "grantType" 속성의 값은 "refreshToken"으로 정확히 보내야 합니다.
+그 경우 "/api/token" 경로를 통해 토큰 재발급을 요청해야 합니다.
+리프레시 토큰은 이미 쿠키에 세팅되어 요청에 담기기 때문에, 추가로 보내야 할 값은 없습니다.
+
+다만 표준 CORS 요청은 기본적으로 쿠키를 포함한 인증 정보를 설정할 수 없습니다.
+그렇기 때문에 인증 정보(쿠키 등)를 요청에 추가하도록 수동으로 "withCredentials: true" 설정을 해줘야 합니다.
+
+(이는 백엔드에서 쿠키를 포함한 응답을 보낼 때 "Access-Control-Allow-Credentials" 설정을 "true"로 맞춰야 하는 이유와 동일합니다.)
+
+리프레시 토큰이 유효하고 적절하다면 새로운 액세스 토큰은 응답 본문에, 새로운 리프레시 토큰은 쿠키에 담아 재발급합니다.
 
 operation::refreshToken/create-new-access-token-and-new-refresh-token[snippets='http-request,http-response,request-fields,response-fields']
 

--- a/src/main/java/com/habitpay/habitpay/domain/member/domain/Member.java
+++ b/src/main/java/com/habitpay/habitpay/domain/member/domain/Member.java
@@ -1,6 +1,7 @@
 package com.habitpay.habitpay.domain.member.domain;
 
 import com.habitpay.habitpay.domain.model.BaseTime;
+import com.habitpay.habitpay.domain.refreshtoken.domain.RefreshToken;
 import jakarta.persistence.*;
 import lombok.Builder;
 import lombok.Getter;

--- a/src/main/java/com/habitpay/habitpay/domain/refreshtoken/api/TokenApi.java
+++ b/src/main/java/com/habitpay/habitpay/domain/refreshtoken/api/TokenApi.java
@@ -4,6 +4,8 @@ import com.habitpay.habitpay.domain.refreshtoken.application.RefreshTokenCreatio
 import com.habitpay.habitpay.domain.refreshtoken.dto.CreateAccessTokenRequest;
 import com.habitpay.habitpay.domain.refreshtoken.dto.CreateAccessTokenResponse;
 import com.habitpay.habitpay.global.response.SuccessResponse;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.http.HttpStatus;
@@ -23,8 +25,9 @@ public class TokenApi {
 
     @PostMapping("/token")
     public SuccessResponse<CreateAccessTokenResponse> createNewAccessTokenAndNewRefreshToken(
-            @RequestBody CreateAccessTokenRequest requestBody) {
+            HttpServletRequest request,
+            HttpServletResponse response) {
 
-        return refreshTokenCreationService.createNewAccessTokenAndNewRefreshToken(requestBody);
+        return refreshTokenCreationService.createNewAccessTokenAndNewRefreshToken(request, response);
     }
 }

--- a/src/main/java/com/habitpay/habitpay/domain/refreshtoken/application/RefreshTokenCreationService.java
+++ b/src/main/java/com/habitpay/habitpay/domain/refreshtoken/application/RefreshTokenCreationService.java
@@ -31,15 +31,14 @@ import static com.habitpay.habitpay.global.config.jwt.TokenService.REFRESH_TOKEN
 @Slf4j
 public class RefreshTokenCreationService {
 
-    private final TokenProvider tokenProvider;
     private final MemberSearchService memberSearchService;
-    private final TokenService tokenService;
     private final RefreshTokenUtilService refreshTokenUtilService;
     private final RefreshTokenSearchService refreshTokenSearchService;
 
     private final RefreshTokenRepository refreshTokenRepository;
 
-    // todo
+    private final TokenProvider tokenProvider;
+    private final TokenService tokenService;
     private final CookieUtil cookieUtil;
 
 
@@ -56,6 +55,8 @@ public class RefreshTokenCreationService {
                 newAccessToken,
                 "Bearer",
                 tokenService.getAccessTokenExpiresInToMillis());
+
+        log.info(String.valueOf(SuccessCode.REFRESH_TOKEN_SUCCESS));
 
         return SuccessResponse.of(
                 SuccessCode.REFRESH_TOKEN_SUCCESS,

--- a/src/main/java/com/habitpay/habitpay/domain/refreshtoken/application/RefreshTokenUtilService.java
+++ b/src/main/java/com/habitpay/habitpay/domain/refreshtoken/application/RefreshTokenUtilService.java
@@ -17,7 +17,6 @@ public class RefreshTokenUtilService {
     public String getClientIpAddress() {
 
         if (Objects.isNull(RequestContextHolder.getRequestAttributes())) {
-            log.info("[IP address] 0.0.0.0");
             return "0.0.0.0";
         }
 

--- a/src/main/java/com/habitpay/habitpay/domain/refreshtoken/dto/CreateAccessTokenResponse.java
+++ b/src/main/java/com/habitpay/habitpay/domain/refreshtoken/dto/CreateAccessTokenResponse.java
@@ -12,5 +12,4 @@ public class CreateAccessTokenResponse {
     private String accessToken;
     private String tokenType;
     private Long expiresIn;
-    private String refreshToken;
 }

--- a/src/main/java/com/habitpay/habitpay/global/config/auth/CustomOAuth2LoginSuccessHandler.java
+++ b/src/main/java/com/habitpay/habitpay/global/config/auth/CustomOAuth2LoginSuccessHandler.java
@@ -2,6 +2,7 @@ package com.habitpay.habitpay.global.config.auth;
 
 import com.habitpay.habitpay.domain.refreshtoken.application.RefreshTokenCreationService;
 import com.habitpay.habitpay.global.config.jwt.TokenService;
+import com.habitpay.habitpay.global.util.CookieUtil;
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
 import lombok.RequiredArgsConstructor;
@@ -26,6 +27,7 @@ public class CustomOAuth2LoginSuccessHandler extends SimpleUrlAuthenticationSucc
 
     private final TokenService tokenService;
     private final RefreshTokenCreationService refreshTokenCreationService;
+    private final CookieUtil cookieUtil;
 
     @Override
     public void onAuthenticationSuccess(
@@ -43,14 +45,7 @@ public class CustomOAuth2LoginSuccessHandler extends SimpleUrlAuthenticationSucc
 
             super.clearAuthenticationAttributes(request);
 
-            ResponseCookie responseCookie = ResponseCookie.from("refresh", refreshToken)
-                    .httpOnly(true)
-                    .maxAge(REFRESH_TOKEN_EXPIRED_AT)
-                    .domain("localhost")
-                    .path("/")
-                    .build();
-
-            response.addHeader("Set-Cookie", responseCookie.toString());
+            cookieUtil.setRefreshToken(response, refreshToken);
             response.sendRedirect(UriComponentsBuilder.fromUriString(redirectUrl)
                     .queryParam("accessToken", accessToken)
                     .build().toUriString());

--- a/src/main/java/com/habitpay/habitpay/global/config/jwt/TokenProvider.java
+++ b/src/main/java/com/habitpay/habitpay/global/config/jwt/TokenProvider.java
@@ -67,7 +67,7 @@ public class TokenProvider {
             log.error("토큰이 만료되었습니다.");
             return false;
         } catch (MalformedJwtException e) {
-            log.error("잘못된 토큰 형식입니다..");
+            log.error("잘못된 토큰 형식입니다.");
             return false;
         } catch (SignatureException e) {
             log.error("서명 검증에 실패했습니다.");

--- a/src/main/java/com/habitpay/habitpay/global/config/jwt/TokenService.java
+++ b/src/main/java/com/habitpay/habitpay/global/config/jwt/TokenService.java
@@ -21,12 +21,12 @@ import java.util.Set;
 @Service
 @Slf4j
 public class TokenService {
-    public final static Duration ACCESS_TOKEN_EXPIRED_AT = Duration.ofHours(2);
-    public final static Duration REFRESH_TOKEN_EXPIRED_AT = Duration.ofDays(14);
+//    public final static Duration ACCESS_TOKEN_EXPIRED_AT = Duration.ofHours(2);
+//    public final static Duration REFRESH_TOKEN_EXPIRED_AT = Duration.ofDays(14);
 
     // todo : test 용도 (token 테스트 완료되면 삭제하기)
-//    public final static Duration ACCESS_TOKEN_EXPIRED_AT = Duration.ofSeconds(30);
-//    public final static Duration REFRESH_TOKEN_EXPIRED_AT = Duration.ofMinutes(1);
+    public final static Duration ACCESS_TOKEN_EXPIRED_AT = Duration.ofSeconds(30);
+    public final static Duration REFRESH_TOKEN_EXPIRED_AT = Duration.ofMinutes(1);
 
     private final JwtProperties jwtProperties;
 

--- a/src/main/java/com/habitpay/habitpay/global/config/jwt/TokenService.java
+++ b/src/main/java/com/habitpay/habitpay/global/config/jwt/TokenService.java
@@ -21,12 +21,12 @@ import java.util.Set;
 @Service
 @Slf4j
 public class TokenService {
-//    public final static Duration ACCESS_TOKEN_EXPIRED_AT = Duration.ofHours(2);
-//    public final static Duration REFRESH_TOKEN_EXPIRED_AT = Duration.ofDays(14);
+    public final static Duration ACCESS_TOKEN_EXPIRED_AT = Duration.ofHours(2);
+    public final static Duration REFRESH_TOKEN_EXPIRED_AT = Duration.ofDays(14);
 
     // todo : test 용도 (token 테스트 완료되면 삭제하기)
-    public final static Duration ACCESS_TOKEN_EXPIRED_AT = Duration.ofSeconds(30);
-    public final static Duration REFRESH_TOKEN_EXPIRED_AT = Duration.ofMinutes(1);
+//    public final static Duration ACCESS_TOKEN_EXPIRED_AT = Duration.ofSeconds(10);
+//    public final static Duration REFRESH_TOKEN_EXPIRED_AT = Duration.ofMinutes(1);
 
     private final JwtProperties jwtProperties;
 

--- a/src/main/java/com/habitpay/habitpay/global/error/exception/ErrorCode.java
+++ b/src/main/java/com/habitpay/habitpay/global/error/exception/ErrorCode.java
@@ -17,6 +17,7 @@ public enum ErrorCode {
     CONFLICT(HttpStatus.CONFLICT, "Conflict"),
 
     // JWT
+    JWT_CLIENT_HAS_NO_IDEA_ABOUT_GRANT_TYPE(HttpStatus.BAD_REQUEST, "인증 방법을 알 수 없습니다."),
     JWT_REQUEST_IP_AND_LOGIN_IP_NOT_SAME_FOR_REFRESH(HttpStatus.BAD_REQUEST, "로그인한 IP 주소와 요청 IP 주소가 일치하지 않습니다."),
     JWT_REFRESH_TOKEN_NOT_FOUND(HttpStatus.NOT_FOUND, "리프레시 토큰이 존재하지 않습니다."),
     JWT_FORBIDDEN_TO_MODIFY_OTHERS_POST(HttpStatus.FORBIDDEN, "본인의 포스트만 수정할 수 있습니다."),

--- a/src/main/java/com/habitpay/habitpay/global/handler/GlobalExceptionHandler.java
+++ b/src/main/java/com/habitpay/habitpay/global/handler/GlobalExceptionHandler.java
@@ -15,7 +15,7 @@ public class GlobalExceptionHandler {
 
     @ExceptionHandler(BusinessException.class)
     protected ResponseEntity<ErrorResponse> handleBusinessException(final BusinessException ex) {
-        log.error("handleBusinessException: ", ex);
+        log.error("handleBusinessException: {}", ex.getClass().getName());
         final ErrorCode errorCode = ex.getErrorCode();
         final ErrorResponse response = ErrorResponse.of(errorCode);
         return ResponseEntity.status(errorCode.getStatus()).body(response);

--- a/src/main/java/com/habitpay/habitpay/global/util/CookieUtil.java
+++ b/src/main/java/com/habitpay/habitpay/global/util/CookieUtil.java
@@ -1,5 +1,6 @@
 package com.habitpay.habitpay.global.util;
 
+import com.habitpay.habitpay.global.error.exception.BadRequestException;
 import com.habitpay.habitpay.global.error.exception.ErrorCode;
 import com.habitpay.habitpay.global.error.exception.UnauthorizedException;
 import jakarta.servlet.http.Cookie;
@@ -48,7 +49,7 @@ public class CookieUtil {
 
         if (cookies == null) {
             log.info("cookies is null");
-            throw new UnauthorizedException(ErrorCode.JWT_REFRESH_TOKEN_NOT_FOUND);
+            throw new BadRequestException(ErrorCode.JWT_CLIENT_HAS_NO_IDEA_ABOUT_GRANT_TYPE);
         }
 
         for (Cookie cookie : cookies) {
@@ -58,7 +59,7 @@ public class CookieUtil {
             }
         }
 
-        throw new UnauthorizedException(ErrorCode.JWT_REFRESH_TOKEN_NOT_FOUND);
+        throw new BadRequestException(ErrorCode.JWT_CLIENT_HAS_NO_IDEA_ABOUT_GRANT_TYPE);
     }
 
     public void setRefreshToken(HttpServletResponse response, String refreshToken) {

--- a/src/main/java/com/habitpay/habitpay/global/util/CookieUtil.java
+++ b/src/main/java/com/habitpay/habitpay/global/util/CookieUtil.java
@@ -68,6 +68,7 @@ public class CookieUtil {
             .maxAge(REFRESH_TOKEN_EXPIRED_AT)
             .domain("localhost")
             .path("/")
+//            .secure() // todo
             .build();
 
         response.addHeader("Set-Cookie", responseCookie.toString());

--- a/src/main/java/com/habitpay/habitpay/global/util/CookieUtil.java
+++ b/src/main/java/com/habitpay/habitpay/global/util/CookieUtil.java
@@ -4,11 +4,13 @@ import jakarta.servlet.http.Cookie;
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
 import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Service;
 import org.springframework.util.SerializationUtils;
 
 import java.util.Base64;
 
 // todo : refresh token 목적으로 만든 util. 추후 필요 없으면 삭제하기
+@Service
 @Slf4j
 public class CookieUtil {
 
@@ -62,6 +64,24 @@ public class CookieUtil {
         for (Cookie cookie : cookies) {
             if (cookie.getName().equals("accessToken")) {
                 log.info("accessToken: {}", cookie.getValue());
+                return cookie.getValue();
+            }
+        }
+
+        return null;
+    }
+
+    public String getRefreshToken(HttpServletRequest request) {
+        Cookie[] cookies = request.getCookies();
+
+        if (cookies == null) {
+            log.info("cookies is null");
+            return null;
+        }
+
+        for (Cookie cookie : cookies) {
+            if (cookie.getName().equals("refresh")) {
+                log.info("refreshToken: {}", cookie.getValue());
                 return cookie.getValue();
             }
         }

--- a/src/main/java/com/habitpay/habitpay/global/util/CookieUtil.java
+++ b/src/main/java/com/habitpay/habitpay/global/util/CookieUtil.java
@@ -1,15 +1,19 @@
 package com.habitpay.habitpay.global.util;
 
+import com.habitpay.habitpay.global.error.exception.ErrorCode;
+import com.habitpay.habitpay.global.error.exception.UnauthorizedException;
 import jakarta.servlet.http.Cookie;
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
 import lombok.extern.slf4j.Slf4j;
+import org.springframework.http.ResponseCookie;
 import org.springframework.stereotype.Service;
 import org.springframework.util.SerializationUtils;
 
 import java.util.Base64;
 
-// todo : refresh token 목적으로 만든 util. 추후 필요 없으면 삭제하기
+import static com.habitpay.habitpay.global.config.jwt.TokenService.REFRESH_TOKEN_EXPIRED_AT;
+
 @Service
 @Slf4j
 public class CookieUtil {
@@ -39,44 +43,12 @@ public class CookieUtil {
         }
     }
 
-    // todo : 보안에 취약. 직렬화 및 역직렬화 방식 바꿔야 함.
-//    public static String serialize(Object object) {
-//        return Base64.getUrlEncoder()
-//                .encodeToString(SerializationUtils.serialize(object));
-//    }
-//
-//    public static <T> T deserialize(Cookie cookie, Class<T> cls) {
-//        return cls.cast(
-//                SerializationUtils.deserialize(
-//                        Base64.getUrlDecoder().decode(cookie.getValue())
-//                )
-//        );
-//    }
-
-    public static String getAccessToken(HttpServletRequest request) {
-        Cookie[] cookies = request.getCookies();
-
-        if (cookies == null) {
-            log.info("cookies is null");
-            return null;
-        }
-
-        for (Cookie cookie : cookies) {
-            if (cookie.getName().equals("accessToken")) {
-                log.info("accessToken: {}", cookie.getValue());
-                return cookie.getValue();
-            }
-        }
-
-        return null;
-    }
-
     public String getRefreshToken(HttpServletRequest request) {
         Cookie[] cookies = request.getCookies();
 
         if (cookies == null) {
             log.info("cookies is null");
-            return null;
+            throw new UnauthorizedException(ErrorCode.JWT_REFRESH_TOKEN_NOT_FOUND);
         }
 
         for (Cookie cookie : cookies) {
@@ -86,6 +58,18 @@ public class CookieUtil {
             }
         }
 
-        return null;
+        throw new UnauthorizedException(ErrorCode.JWT_REFRESH_TOKEN_NOT_FOUND);
+    }
+
+    public void setRefreshToken(HttpServletResponse response, String refreshToken) {
+
+    ResponseCookie responseCookie = ResponseCookie.from("refresh", refreshToken)
+            .httpOnly(true)
+            .maxAge(REFRESH_TOKEN_EXPIRED_AT)
+            .domain("localhost")
+            .path("/")
+            .build();
+
+        response.addHeader("Set-Cookie", responseCookie.toString());
     }
 }

--- a/src/test/java/com/habitpay/habitpay/domain/refreshtoken/api/RefreshTokenApiTest.java
+++ b/src/test/java/com/habitpay/habitpay/domain/refreshtoken/api/RefreshTokenApiTest.java
@@ -13,6 +13,8 @@ import com.habitpay.habitpay.global.error.exception.ForbiddenException;
 import com.habitpay.habitpay.global.error.exception.UnauthorizedException;
 import com.habitpay.habitpay.global.response.SuccessCode;
 import com.habitpay.habitpay.global.response.SuccessResponse;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -61,10 +63,9 @@ public class RefreshTokenApiTest extends AbstractRestDocsTests {
                 .accessToken("eyJhbGciOiJIUzI1NiJ9.eyJzdWIiOiIxMjM0In0.DUMMY_SIGNATURE1")
                 .tokenType("Bearer")
                 .expiresIn(Duration.ofMinutes(30).toMillis())
-                .refreshToken("eyJhbGciOiJIUzI1NiJ9.eyJ1c2VyIjoiYWxpY2UifQ.DUMMY_SIGNATURE3")
                 .build();
 
-        given(refreshTokenCreationService.createNewAccessTokenAndNewRefreshToken(any(CreateAccessTokenRequest.class)))
+        given(refreshTokenCreationService.createNewAccessTokenAndNewRefreshToken(any(HttpServletRequest.class), any(HttpServletResponse.class)))
                 .willReturn(SuccessResponse.of(SuccessCode.REFRESH_TOKEN_SUCCESS, tokenResponse));
 
         //when
@@ -75,16 +76,11 @@ public class RefreshTokenApiTest extends AbstractRestDocsTests {
         //then
         result.andExpect(status().isOk())
                 .andDo(document("refreshToken/create-new-access-token-and-new-refresh-token",
-                        requestFields(
-                                fieldWithPath("grantType").description("클라이언트가 액세스 토큰을 요청할 때 사용하는 인증 방법. \"refreshToken\""),
-                                fieldWithPath("refreshToken").description("클라이언트가 보관하던 리프레시 토큰")
-                        ),
                         responseFields(
                                 fieldWithPath("message").description("메시지"),
                                 fieldWithPath("data.accessToken").description("새로 발급한 액세스 토큰"),
                                 fieldWithPath("data.tokenType").description("발급한 토큰의 유형. \"Bearer\""),
-                                fieldWithPath("data.expiresIn").description("액세스 토큰의 유효 기간"),
-                                fieldWithPath("data.refreshToken").description("새로 발급한 리프레시 토큰. 추후 새 액세스 토큰 발급 시 이용된다.")
+                                fieldWithPath("data.expiresIn").description("액세스 토큰의 유효 기간")
                         )
                 ));
 
@@ -99,7 +95,7 @@ public class RefreshTokenApiTest extends AbstractRestDocsTests {
                 .refreshToken("eyJhbGciOiJIUzI1NiJ9.eyJzdWIiOiIxMjM0In0.DUMMY_SIGNATURE1")
                 .build();
 
-        given(refreshTokenCreationService.createNewAccessTokenAndNewRefreshToken(any(CreateAccessTokenRequest.class)))
+        given(refreshTokenCreationService.createNewAccessTokenAndNewRefreshToken(any(HttpServletRequest.class), any(HttpServletResponse.class)))
                 .willThrow(new BadRequestException(ErrorCode.BAD_REQUEST));
 
         //when
@@ -128,7 +124,7 @@ public class RefreshTokenApiTest extends AbstractRestDocsTests {
                 .refreshToken("eyJhbGciOiJIUzI1NiJ9.eyJzdWIiOiIxMjM0In0.EXPIRED_DUMMY_SIGNATURE1")
                 .build();
 
-        given(refreshTokenCreationService.createNewAccessTokenAndNewRefreshToken(any(CreateAccessTokenRequest.class)))
+        given(refreshTokenCreationService.createNewAccessTokenAndNewRefreshToken(any(HttpServletRequest.class), any(HttpServletResponse.class)))
                 .willThrow(new UnauthorizedException(ErrorCode.UNAUTHORIZED));
 
         //when
@@ -157,7 +153,7 @@ public class RefreshTokenApiTest extends AbstractRestDocsTests {
                 .refreshToken("eyJhbGciOiJIUzI1NiJ9.eyJzdWIiOiIxMjM0In0.GUEST_DUMMY_SIGNATURE1")
                 .build();
 
-        given(refreshTokenCreationService.createNewAccessTokenAndNewRefreshToken(any(CreateAccessTokenRequest.class)))
+        given(refreshTokenCreationService.createNewAccessTokenAndNewRefreshToken(any(HttpServletRequest.class), any(HttpServletResponse.class)))
                 .willThrow(new ForbiddenException(ErrorCode.FORBIDDEN));
 
         //when


### PR DESCRIPTION
### 작업 개요

* 최초 로그인 시 `리프레시 토큰`은 `쿠키`를 통해 전달됩니다.
* 그러나 `토큰 재발급 요청` 로직에는 `쿠키`가 아닌,
  (예전에 만든 방식인) `요청 및 응답 본문`을 통해 `리프레시 토큰`을 주고 받는 방식이 사용되고 있었습니다.
* 이를 `쿠키`를 통해 `리프레시 토큰`을 주고 받는 로직으로 변경했습니다.

---

### 코드 주요 내용

* `리프레시 토큰 컨트롤러` 메서드에서 `요청 본문`을 받는 대신,
   `HttpServletRequest`와 `HttpServletResponse`만 인자로 받습니다.

```java
// TokenApi.java

@PostMapping("/token")
public SuccessResponse<CreateAccessTokenResponse> createNewAccessTokenAndNewRefreshToken(
        HttpServletRequest request,
        HttpServletResponse response) {

    return refreshTokenCreationService.createNewAccessTokenAndNewRefreshToken(request, response);
}
```

* `쿠키`를 주고 받는 게 필요하기 때문에 `HttpServlet 요청 및 응답`만 있으면 됩니다.

---

* 로직을 담당하는 서비스 메서드는 다음과 같습니다.

```java
// RefreshTokenCreationService.java

public SuccessResponse<CreateAccessTokenResponse> createNewAccessTokenAndNewRefreshToken(
        HttpServletRequest request,
        HttpServletResponse response) {

    String oldRefreshToken = cookieUtil.getRefreshToken(request);
    String newAccessToken = this.createNewAccessToken(oldRefreshToken);
    String newRefreshToken = this.createRefreshToken(tokenService.getUserId(newAccessToken));
    cookieUtil.setRefreshToken(response, newRefreshToken);
    ...
}
```

* `HttpServletRequest`의 쿠키를 통해 `리프레시 토큰` 값을 얻습니다.
* `리프레시 토큰`을 검증하여, `새로운 액세스 토큰`을 발급합니다.
* `새로운 액세스 토큰`의 사용자 정보에 기반해 역시 `새로운 리프레시 토큰`을 추가로 발급합니다.
* 마지막으로 `새로운 리프레시 토큰`을 `HttpServletResponse`의 쿠키에 설정합니다.

---

* 이후의 코드 내용입니다.

```java
// RefreshTokenCreationService.java

public SuccessResponse<CreateAccessTokenResponse> createNewAccessTokenAndNewRefreshToken(...) {
    ...
    CreateAccessTokenResponse tokenResponse = new CreateAccessTokenResponse(
            newAccessToken,
            "Bearer",
            tokenService.getAccessTokenExpiresInToMillis());

    return SuccessResponse.of(
            SuccessCode.REFRESH_TOKEN_SUCCESS,
            tokenResponse
    );
}
```

* `새로운 리프레시 토큰`이 `쿠키`에 담겨있기 때문에,
   이제 `응답 본문`에는 `액세스 토큰`의 데이터만 담기게 됩니다.

---

### 기타 주요 변화

* 쿠키에서 리프레시 토큰의 값을 얻는 유틸 메서드를 추가했습니다.
```java
// RefreshTokenCreationService.java
...
String oldRefreshToken = cookieUtil.getRefreshToken(request);
...
```

```java
// CookieUtil.java

public String getRefreshToken(HttpServletRequest request) {
    Cookie[] cookies = request.getCookies();

    if (cookies == null) {
        log.info("cookies is null");
        throw new BadRequestException(ErrorCode.JWT_CLIENT_HAS_NO_IDEA_ABOUT_GRANT_TYPE);
    }

    for (Cookie cookie : cookies) {
        if (cookie.getName().equals("refresh")) {
            log.info("refreshToken: {}", cookie.getValue());
            return cookie.getValue();
        }
    }

    throw new BadRequestException(ErrorCode.JWT_CLIENT_HAS_NO_IDEA_ABOUT_GRANT_TYPE);
}
```

* `cookie` 배열에서 `"refresh" 키`에 해당하는 값을 찾습니다.
* 쿠키에 `"refresh" 키`가 없다면, 그 요청은 `/api/token`에 필요한 인증 정보가 무엇인지도 모른다는 뜻입니다.
  -> 이는 악의적인 사용자일 가능성이 높습니다.
       그렇기 때문에 상태 코드를 `UNAUTHORIZED`가 아닌 `BAD_REQUEST`로 설정했고,
       에러 메시지에서도 `리프레시 토큰`에 대한 언급을 없앴습니다.

```java
JWT_CLIENT_HAS_NO_IDEA_ABOUT_GRANT_TYPE(HttpStatus.BAD_REQUEST, "인증 방법을 알 수 없습니다."),
```

---

* 쿠키에 리프레시 토큰의 값을 설정하는 메서드를 추가했습니다.

```java
// RefreshTokenCreationService.java

cookieUtil.setRefreshToken(response, newRefreshToken);
```

* 해당 코드의 내용은 `CustomOAuth2LoginSuccessHandler.java`에서 준한님이 작성하신
  쿠키에 리프레시 토큰 값 넣는 코드와 중복되기에 그대로 사용했습니다.

```java
// CookieUtil.java

public void setRefreshToken(HttpServletResponse response, String refreshToken) {

ResponseCookie responseCookie = ResponseCookie.from("refresh", refreshToken)
        .httpOnly(true)
        .maxAge(REFRESH_TOKEN_EXPIRED_AT)
        .domain("localhost")
        .path("/")
//      .secure()
        .build();

    response.addHeader("Set-Cookie", responseCookie.toString());
}
```

* 메서드가 생겼으므로, `CustomOAuth2LoginSuccessHandler.java`의 해당 코드에도
  이 메서드를 사용하는 것으로 변경했습니다.

```java
@Override
public void onAuthenticationSuccess(...) throws IOException {

    if (authentication.getPrincipal() instanceof OAuth2User oAuth2User) {
        ...
       // 이 코드를 그대로 담은 함수인
        // ResponseCookie responseCookie = ResponseCookie.from("refresh", refreshToken)
        //        .httpOnly(true)
        //        .maxAge(REFRESH_TOKEN_EXPIRED_AT)
        //        .domain("habitpay.link")
        //        .path("/")
        //        .build();

        // response.addHeader("Set-Cookie", responseCookie.toString());

        // 이 메서드로 대체했습니다.
        cookieUtil.setRefreshToken(response, refreshToken);

        response.sendRedirect(UriComponentsBuilder.fromUriString(redirectUrl)
                .queryParam("accessToken", accessToken)
                .build().toUriString());
    }
}
```

---

### 기타

* 쿠키에서 리프레시 토큰의 키값을 `"refresh"`로 설정하신 특별한 이유가 있을까요?
`refreshToken`이나 `refresh_token`으로 하면 의미가 더 명확해지지 않을까 싶어 여쭙니다.