### PR TITLE
[feat] 토큰 리프레시를 위한 쿠키의 키값 이름을 refresh_token으로 변경 #236

### DIFF
--- a/src/main/java/com/habitpay/habitpay/global/util/CookieUtil.java
+++ b/src/main/java/com/habitpay/habitpay/global/util/CookieUtil.java
@@ -53,7 +53,7 @@ public class CookieUtil {
         }
 
         for (Cookie cookie : cookies) {
-            if (cookie.getName().equals("refresh")) {
+            if (cookie.getName().equals("refresh_token")) {
                 log.info("refreshToken: {}", cookie.getValue());
                 return cookie.getValue();
             }
@@ -64,7 +64,7 @@ public class CookieUtil {
 
     public void setRefreshToken(HttpServletResponse response, String refreshToken) {
 
-    ResponseCookie responseCookie = ResponseCookie.from("refresh", refreshToken)
+    ResponseCookie responseCookie = ResponseCookie.from("refresh_token", refreshToken)
             .httpOnly(true)
             .maxAge(REFRESH_TOKEN_EXPIRED_AT)
             .domain("localhost")


### PR DESCRIPTION
### 작업 내용

* 리프레시 토큰 값을 관리하는 쿠키의 이름을 `refresh`에서 `refresh_token`으로 변경했습니다.
* 응답으로 보낼 쿠키를 설정할 때도, 요청으로 온 쿠키를 확인할 때도 적용됩니다.

---

* HTTP 쿠키 이름에서는 스네이크 케이싱이 관습인 것 같아 `refresh_token`으로 우선 설정했습니다.
* 변경 가능성 및 프론트엔드에는 아직 변경사항이 전달되지 않아서, 확인 및 변경 후 머지하면 될 듯 합니다.