### PR TITLE
Feat/챌린지 벌금 조회 시 본인 확인 속성 추가#248

### DIFF
--- a/.github/workflows/deploy.yaml
+++ b/.github/workflows/deploy.yaml
@@ -5,9 +5,6 @@ on:
   push:
     branches:
       - "main"
-  pull_request:
-    branches:
-      - "main"
 
 jobs:
   create-release:

--- a/deploy.sh
+++ b/deploy.sh
@@ -74,6 +74,7 @@ main() {
         log "Application is not running. Starting the application...(with blue container)"
         yq -i ".services.blue.image = \"$DOCKER_IMAGE\"" docker-compose.yaml
         sudo docker compose -p $APPLICATION up blue -d
+        healthcheck blue
     fi
 }
 

--- a/src/main/java/com/habitpay/habitpay/domain/challengeabsencefee/application/ChallengeAbsenceFeeSearchService.java
+++ b/src/main/java/com/habitpay/habitpay/domain/challengeabsencefee/application/ChallengeAbsenceFeeSearchService.java
@@ -1,6 +1,7 @@
 package com.habitpay.habitpay.domain.challengeabsencefee.application;
 
 import com.habitpay.habitpay.domain.challengeabsencefee.dto.FeeStatusResponse;
+import com.habitpay.habitpay.domain.challengeabsencefee.dto.MemberFee;
 import com.habitpay.habitpay.domain.challengeabsencefee.dto.MemberFeeView;
 import com.habitpay.habitpay.domain.challengeabsencefee.exception.DaysCountException;
 import com.habitpay.habitpay.domain.challenge.application.ChallengeSearchService;
@@ -39,7 +40,7 @@ public class ChallengeAbsenceFeeSearchService {
         FeeStatusResponse feeStatusResponse = FeeStatusResponse.builder()
                 .totalFee(findTotalFeeOfChallenge(memberFeeViewList))
                 .myFee(findPersonalTotalFeeOfChallenge(enrollment))
-                .memberFeeList(memberFeeViewList)
+                .memberFee(MemberFee.of(memberFeeViewList, member.getId()))
                 .build();
 
         return SuccessResponse.of(

--- a/src/main/java/com/habitpay/habitpay/domain/challengeabsencefee/dto/FeeStatusResponse.java
+++ b/src/main/java/com/habitpay/habitpay/domain/challengeabsencefee/dto/FeeStatusResponse.java
@@ -12,5 +12,5 @@ import java.util.List;
 public class FeeStatusResponse {
     private int totalFee;
     private int myFee;
-    private List<MemberFeeView> memberFeeList;
+    private List<MemberFee> memberFee;
 }

--- a/src/main/java/com/habitpay/habitpay/domain/challengeabsencefee/dto/MemberFee.java
+++ b/src/main/java/com/habitpay/habitpay/domain/challengeabsencefee/dto/MemberFee.java
@@ -1,0 +1,31 @@
+package com.habitpay.habitpay.domain.challengeabsencefee.dto;
+
+import lombok.*;
+
+import java.util.List;
+
+@Getter
+@Builder
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@AllArgsConstructor
+public class MemberFee {
+    private String nickname;
+    private int totalFee;
+    private int completionRate;
+    private Boolean isMe;
+
+    public static MemberFee of(MemberFeeView memberFeeView, Long memberId) {
+        return MemberFee.builder()
+                .nickname(memberFeeView.getNickname())
+                .totalFee(memberFeeView.getTotalFee())
+                .completionRate(memberFeeView.getCompletionRate())
+                .isMe(memberFeeView.getMemberId().equals(memberId))
+                .build();
+    }
+
+    public static List<MemberFee> of(List<MemberFeeView> memberFeeView, Long memberId) {
+        return memberFeeView.stream()
+                .map(fee -> MemberFee.of(fee, memberId))
+                .toList();
+    }
+}

--- a/src/main/java/com/habitpay/habitpay/domain/challengeabsencefee/dto/MemberFeeView.java
+++ b/src/main/java/com/habitpay/habitpay/domain/challengeabsencefee/dto/MemberFeeView.java
@@ -6,11 +6,13 @@ import lombok.Getter;
 @Getter
 @Builder
 public class MemberFeeView {
+    private Long memberId;
     private String nickname;
     private int totalFee;
     private int completionRate;
 
-    public MemberFeeView(String nickname, int totalFee, int completionRate) {
+    public MemberFeeView(Long memberId, String nickname, int totalFee, int completionRate) {
+        this.memberId = memberId;
         this.nickname = nickname;
         this.totalFee = totalFee;
         this.completionRate = completionRate;

--- a/src/main/java/com/habitpay/habitpay/domain/challengeenrollment/dao/ChallengeEnrollmentRepository.java
+++ b/src/main/java/com/habitpay/habitpay/domain/challengeenrollment/dao/ChallengeEnrollmentRepository.java
@@ -18,7 +18,7 @@ public interface ChallengeEnrollmentRepository extends JpaRepository<ChallengeEn
     List<ChallengeEnrollment> findAllByMember(Member member);
     List<ChallengeEnrollment> findTop3ByChallenge(Challenge challenge);
 
-    @Query("SELECT new com.habitpay.habitpay.domain.challengeabsencefee.dto.MemberFeeView(m.nickname, s.totalFee, (s.successCount / :totalCount) * 100) " +
+    @Query("SELECT new com.habitpay.habitpay.domain.challengeabsencefee.dto.MemberFeeView(m.id, m.nickname, s.totalFee, (s.successCount / :totalCount) * 100) " +
     "FROM ChallengeEnrollment e " +
     "JOIN e.member m " +
     "JOIN e.participationStat s " +

--- a/src/test/java/com/habitpay/habitpay/domain/challengeabsencefee/api/ChallengeAbsenceFeeApiTest.java
+++ b/src/test/java/com/habitpay/habitpay/domain/challengeabsencefee/api/ChallengeAbsenceFeeApiTest.java
@@ -4,6 +4,7 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 import com.habitpay.habitpay.docs.springrestdocs.AbstractRestDocsTests;
 import com.habitpay.habitpay.domain.challengeabsencefee.application.ChallengeAbsenceFeeSearchService;
 import com.habitpay.habitpay.domain.challengeabsencefee.dto.FeeStatusResponse;
+import com.habitpay.habitpay.domain.challengeabsencefee.dto.MemberFee;
 import com.habitpay.habitpay.domain.challengeabsencefee.dto.MemberFeeView;
 import com.habitpay.habitpay.domain.member.domain.Member;
 import com.habitpay.habitpay.global.config.jwt.TokenProvider;
@@ -54,9 +55,9 @@ public class ChallengeAbsenceFeeApiTest extends AbstractRestDocsTests {
         FeeStatusResponse feeStatusResponse = FeeStatusResponse.builder()
                 .totalFee(1500)
                 .myFee(500)
-                .memberFeeList(List.of(
-                        new MemberFeeView("testUser", 1000, 10),
-                        new MemberFeeView("selfUser", 500, 20)))
+                .memberFee(List.of(
+                        new MemberFee("testUser", 1000, 10, true),
+                        new MemberFee("selfUser", 500, 20, false)))
                 .build();
 
         given(challengeAbsenceFeeSearchService.makeMemberFeeDataListOfChallenge(any(Long.class), any(Member.class)))


### PR DESCRIPTION
# 개요

`GET /challenges/[challenge-id]/fee` 기존 응답은 아래와 같았습니다.

```json
{
  "totalFee": 3000,
  "myFee": 1000,
  "memberFeeList": [
    {
      "nickname": "hello",
      "totalFee": 1000,
      "completionRate": 70,
    }
  ]
}
```

벌금 조회를 요청한 유저를 표시하기 위해 아래와 같이 `isMe` 속성을 추가합니다.

```json
{
  "totalFee": 3000,
  "myFee": 1000,
  "memberFeeList": [
    {
      "nickname": "hello",
      "totalFee": 1000,
      "completionRate": 70,
      "isMe": true
    }
  ]
}
```