### PR TITLE
Feat/챌린지 전체 목록 조회 기능 구현#252

### DIFF
--- a/src/docs/asciidoc/api/challenge.adoc
+++ b/src/docs/asciidoc/api/challenge.adoc
@@ -7,6 +7,14 @@
 
 챌린지 정보 조회, 챌린지 생성, 챌린지 정보 수정을 수행하는 API 목록입니다.
 
+=== 전체 챌린지 목록 조회
+
+전체 챌린지 목록을 조회합니다.
+
+1페이지에 20개씩 반환합니다.
+
+operation::challenge/get-challenge-page[snippets='http-request,http-response,response-fields']
+
 === 나의 챌린지 참여 목록 조회
 
 현재 접속한 사용자가 참여하고 있는 챌린지 목록을 반환합니다.

--- a/src/main/java/com/habitpay/habitpay/domain/challenge/api/ChallengeApi.java
+++ b/src/main/java/com/habitpay/habitpay/domain/challenge/api/ChallengeApi.java
@@ -3,9 +3,13 @@ package com.habitpay.habitpay.domain.challenge.api;
 import com.habitpay.habitpay.domain.challenge.application.*;
 import com.habitpay.habitpay.domain.challenge.dto.*;
 import com.habitpay.habitpay.global.config.auth.CustomUserDetails;
+import com.habitpay.habitpay.global.response.PageResponse;
 import com.habitpay.habitpay.global.response.SuccessResponse;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.Sort;
+import org.springframework.data.web.PageableDefault;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.*;
 
@@ -22,6 +26,13 @@ public class ChallengeApi {
     private final ChallengeDetailsService challengeDetailsService;
     private final ChallengeSearchService challengeSearchService;
     private final ChallengeDeleteService challengeDeleteService;
+
+    @GetMapping("/challenges")
+    public SuccessResponse<PageResponse<ChallengePageResponse>> getChallengePage(
+            @PageableDefault(size = 20, sort = "id", direction = Sort.Direction.DESC) Pageable pageable
+    ) {
+        return challengeSearchService.getChallengePage(pageable);
+    }
 
     @GetMapping("/challenges/me")
     public SuccessResponse<List<ChallengeEnrolledListItemResponse>> getEnrolledChallengeList(

--- a/src/main/java/com/habitpay/habitpay/domain/challenge/api/ChallengeApi.java
+++ b/src/main/java/com/habitpay/habitpay/domain/challenge/api/ChallengeApi.java
@@ -29,7 +29,7 @@ public class ChallengeApi {
 
     @GetMapping("/challenges")
     public SuccessResponse<PageResponse<ChallengePageResponse>> getChallengePage(
-            @PageableDefault(size = 20, sort = "id", direction = Sort.Direction.DESC) Pageable pageable
+            @PageableDefault(size = 20, sort = "startDate", direction = Sort.Direction.DESC) Pageable pageable
     ) {
         return challengeSearchService.getChallengePage(pageable);
     }

--- a/src/main/java/com/habitpay/habitpay/domain/challenge/application/ChallengeSearchService.java
+++ b/src/main/java/com/habitpay/habitpay/domain/challenge/application/ChallengeSearchService.java
@@ -37,7 +37,9 @@ public class ChallengeSearchService {
     public SuccessResponse<PageResponse<ChallengePageResponse>> getChallengePage(Pageable pageable) {
         Page<ChallengePageResponse> challengePage = challengeRepository.findAll(pageable)
                 .map(challenge -> {
-                    String hostProfileImage = s3FileService.getGetPreSignedUrl("profiles", challenge.getHost().getImageFileName());
+                    String hostProfileImage = Optional.ofNullable(challenge.getHost().getImageFileName())
+                            .map((imageFilename) -> s3FileService.getGetPreSignedUrl("profiles", imageFilename))
+                            .orElse("");
                     return ChallengePageResponse.of(challenge, hostProfileImage);
                 });
 

--- a/src/main/java/com/habitpay/habitpay/domain/challenge/application/ChallengeSearchService.java
+++ b/src/main/java/com/habitpay/habitpay/domain/challenge/application/ChallengeSearchService.java
@@ -3,18 +3,21 @@ package com.habitpay.habitpay.domain.challenge.application;
 import com.habitpay.habitpay.domain.challenge.dao.ChallengeRepository;
 import com.habitpay.habitpay.domain.challenge.domain.Challenge;
 import com.habitpay.habitpay.domain.challenge.dto.ChallengeEnrolledListItemResponse;
+import com.habitpay.habitpay.domain.challenge.dto.ChallengePageResponse;
 import com.habitpay.habitpay.domain.challenge.exception.ChallengeNotFoundException;
 import com.habitpay.habitpay.domain.challengeenrollment.dao.ChallengeEnrollmentRepository;
 import com.habitpay.habitpay.domain.challengeenrollment.domain.ChallengeEnrollment;
 import com.habitpay.habitpay.domain.challengeparticipationrecord.dao.ChallengeParticipationRecordRepository;
 import com.habitpay.habitpay.domain.member.domain.Member;
-import com.habitpay.habitpay.domain.participationstat.dao.ParticipationStatRepository;
 import com.habitpay.habitpay.domain.participationstat.domain.ParticipationStat;
 import com.habitpay.habitpay.global.config.aws.S3FileService;
+import com.habitpay.habitpay.global.response.PageResponse;
 import com.habitpay.habitpay.global.response.SuccessCode;
 import com.habitpay.habitpay.global.response.SuccessResponse;
 import lombok.AllArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -30,6 +33,16 @@ public class ChallengeSearchService {
     private final ChallengeRepository challengeRepository;
     private final ChallengeEnrollmentRepository challengeEnrollmentRepository;
     private final ChallengeParticipationRecordRepository challengeParticipationRecordRepository;
+
+    public SuccessResponse<PageResponse<ChallengePageResponse>> getChallengePage(Pageable pageable) {
+        Page<ChallengePageResponse> challengePage = challengeRepository.findAll(pageable)
+                .map(challenge -> {
+                    String hostProfileImage = s3FileService.getGetPreSignedUrl("profiles", challenge.getHost().getImageFileName());
+                    return ChallengePageResponse.of(challenge, hostProfileImage);
+                });
+
+        return SuccessResponse.of(SuccessCode.NO_MESSAGE, PageResponse.from(challengePage));
+    }
 
     public SuccessResponse<List<ChallengeEnrolledListItemResponse>> getEnrolledChallengeList(Member member) {
         List<ChallengeEnrollment> challengeEnrollmentList = challengeEnrollmentRepository.findAllByMember(member);

--- a/src/main/java/com/habitpay/habitpay/domain/challenge/dao/ChallengeRepository.java
+++ b/src/main/java/com/habitpay/habitpay/domain/challenge/dao/ChallengeRepository.java
@@ -2,6 +2,8 @@ package com.habitpay.habitpay.domain.challenge.dao;
 
 import com.habitpay.habitpay.domain.challenge.domain.Challenge;
 import com.habitpay.habitpay.domain.challenge.domain.ChallengeState;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
@@ -14,4 +16,6 @@ public interface ChallengeRepository extends JpaRepository<Challenge, Long> {
     List<Challenge> findAllByStateAndParticipatingDays(
             @Param("state") ChallengeState state,
             @Param("day") byte participationDays);
+
+    Page<Challenge> findAll(Pageable pageable);
 }

--- a/src/main/java/com/habitpay/habitpay/domain/challenge/dto/ChallengePageResponse.java
+++ b/src/main/java/com/habitpay/habitpay/domain/challenge/dto/ChallengePageResponse.java
@@ -1,0 +1,36 @@
+package com.habitpay.habitpay.domain.challenge.dto;
+
+import com.habitpay.habitpay.domain.challenge.domain.Challenge;
+import lombok.Builder;
+
+import java.time.ZonedDateTime;
+
+@Builder
+public record ChallengePageResponse(
+        Long id,
+        String title,
+        ZonedDateTime startDate,
+        ZonedDateTime endDate,
+        ZonedDateTime stopDate,
+        int numberOfParticipants,
+        int participatingDays,
+        Boolean isEnded,
+        String hostNickname,
+        String hostProfileImage
+) {
+
+    public static ChallengePageResponse of(Challenge challenge, String hostProfileImage) {
+        return ChallengePageResponse.builder()
+                .id(challenge.getId())
+                .title(challenge.getTitle())
+                .startDate(challenge.getStartDate())
+                .endDate(challenge.getEndDate())
+                .stopDate(challenge.getStopDate())
+                .numberOfParticipants(challenge.getNumberOfParticipants())
+                .participatingDays(challenge.getParticipatingDays())
+                .isEnded(challenge.getEndDate().isAfter(ZonedDateTime.now()))
+                .hostNickname(challenge.getHost().getNickname())
+                .hostProfileImage(hostProfileImage)
+                .build();
+    }
+}

--- a/src/main/java/com/habitpay/habitpay/domain/challenge/dto/ChallengePageResponse.java
+++ b/src/main/java/com/habitpay/habitpay/domain/challenge/dto/ChallengePageResponse.java
@@ -14,6 +14,7 @@ public record ChallengePageResponse(
         ZonedDateTime stopDate,
         int numberOfParticipants,
         int participatingDays,
+        Boolean isStarted,
         Boolean isEnded,
         String hostNickname,
         String hostProfileImage
@@ -28,7 +29,8 @@ public record ChallengePageResponse(
                 .stopDate(challenge.getStopDate())
                 .numberOfParticipants(challenge.getNumberOfParticipants())
                 .participatingDays(challenge.getParticipatingDays())
-                .isEnded(challenge.getEndDate().isAfter(ZonedDateTime.now()))
+                .isStarted(ZonedDateTime.now().isAfter(challenge.getStartDate()))
+                .isEnded(ZonedDateTime.now().isAfter(challenge.getEndDate()))
                 .hostNickname(challenge.getHost().getNickname())
                 .hostProfileImage(hostProfileImage)
                 .build();

--- a/src/main/java/com/habitpay/habitpay/global/response/PageResponse.java
+++ b/src/main/java/com/habitpay/habitpay/global/response/PageResponse.java
@@ -1,0 +1,25 @@
+package com.habitpay.habitpay.global.response;
+
+import org.springframework.data.domain.Page;
+
+import java.util.List;
+
+public record PageResponse<T>(
+        List<T> content,
+        int page,
+        int size,
+        long totalElements,
+        int totalPages,
+        boolean hasNextPage
+) {
+    public static <T> PageResponse<T> from(Page<T> page) {
+        return new PageResponse<>(
+                page.getContent(),
+                page.getNumber() + 1,
+                page.getNumberOfElements(),
+                page.getTotalElements(),
+                page.getTotalPages(),
+                page.hasNext()
+        );
+    }
+}

--- a/src/main/resources/application.yaml
+++ b/src/main/resources/application.yaml
@@ -29,6 +29,12 @@ spring:
         access-key: ${AWS_ACCESS_KEY}
         secret-key: ${AWS_SECRET_KEY}
 ---
+spring:
+  data:
+    web:
+      pageable:
+        one-indexed-parameters: true
+---
 jwt:
   issuer: ${JWT_ISSUER}
   secret: ${JWT_SECRET}

--- a/src/test/java/com/habitpay/habitpay/domain/challenge/api/ChallengeApiTest.java
+++ b/src/test/java/com/habitpay/habitpay/domain/challenge/api/ChallengeApiTest.java
@@ -85,6 +85,7 @@ public class ChallengeApiTest extends AbstractRestDocsTests {
                 .stopDate(null)
                 .numberOfParticipants(1)
                 .participatingDays(1 << 2)
+                .isStarted(true)
                 .isEnded(false)
                 .hostNickname("챌린지 주최자 닉네임")
                 .hostProfileImage("챌린지 주최자 프로필 이미지")
@@ -115,6 +116,7 @@ public class ChallengeApiTest extends AbstractRestDocsTests {
                                 fieldWithPath("data.content[].stopDate").description("챌린지 중단 일시"),
                                 fieldWithPath("data.content[].numberOfParticipants").description("챌린지 참여자 수"),
                                 fieldWithPath("data.content[].participatingDays").description("챌린지 총 진행 일"),
+                                fieldWithPath("data.content[].isStarted").description("챌린지 시작 여부"),
                                 fieldWithPath("data.content[].isEnded").description("챌린지 종료 여부"),
                                 fieldWithPath("data.content[].hostNickname").description("챌린지 주최자 닉네임"),
                                 fieldWithPath("data.content[].hostProfileImage").description("챌린지 주최자 프로필 이미지"),

--- a/src/test/java/com/habitpay/habitpay/domain/challenge/api/ChallengeApiTest.java
+++ b/src/test/java/com/habitpay/habitpay/domain/challenge/api/ChallengeApiTest.java
@@ -12,6 +12,7 @@ import com.habitpay.habitpay.global.config.jwt.TokenService;
 import com.habitpay.habitpay.global.error.exception.ErrorCode;
 import com.habitpay.habitpay.global.error.exception.ForbiddenException;
 import com.habitpay.habitpay.global.error.exception.InvalidValueException;
+import com.habitpay.habitpay.global.response.PageResponse;
 import com.habitpay.habitpay.global.response.SuccessCode;
 import com.habitpay.habitpay.global.response.SuccessResponse;
 import com.habitpay.habitpay.global.security.WithMockOAuth2User;
@@ -20,6 +21,9 @@ import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
 import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageImpl;
+import org.springframework.data.domain.Pageable;
 import org.springframework.http.HttpHeaders;
 import org.springframework.http.MediaType;
 import org.springframework.test.web.servlet.ResultActions;
@@ -65,6 +69,63 @@ public class ChallengeApiTest extends AbstractRestDocsTests {
 
     @MockBean
     TokenProvider tokenProvider;
+
+
+    @Test
+    @WithMockOAuth2User
+    @DisplayName("챌린지 전체 목록 조회")
+    void getChallengePage() throws Exception {
+
+        // given
+        ChallengePageResponse response = ChallengePageResponse.builder()
+                .id(1L)
+                .title("챌린지 제목")
+                .startDate(ZonedDateTime.now())
+                .endDate(ZonedDateTime.now().plusDays(5))
+                .stopDate(null)
+                .numberOfParticipants(1)
+                .participatingDays(1 << 2)
+                .isEnded(false)
+                .hostNickname("챌린지 주최자 닉네임")
+                .hostProfileImage("챌린지 주최자 프로필 이미지")
+                .build();
+
+        Page page = new PageImpl<>(List.of(response));
+
+        given(challengeSearchService.getChallengePage(any(Pageable.class)))
+                .willReturn(SuccessResponse.of(SuccessCode.NO_MESSAGE, PageResponse.from(page)));
+
+        // when
+        ResultActions result = mockMvc.perform(get("/api/challenges")
+                .param("page", "page-number")
+                .header(HttpHeaders.AUTHORIZATION, AUTHORIZATION_HEADER_PREFIX + "ACCESS_TOKEN"));
+
+        // then
+        result.andExpect(status().isOk())
+                .andDo(document("challenge/get-challenge-page",
+                        requestHeaders(
+                                headerWithName(HttpHeaders.AUTHORIZATION).description("액세스 토큰")
+                        ),
+                        responseFields(
+                                fieldWithPath("message").description("메세지"),
+                                fieldWithPath("data.content[].id").description("챌린지 ID"),
+                                fieldWithPath("data.content[].title").description("챌린지 제목"),
+                                fieldWithPath("data.content[].startDate").description("챌린지 시작 일시"),
+                                fieldWithPath("data.content[].endDate").description("챌린지 종료 일시"),
+                                fieldWithPath("data.content[].stopDate").description("챌린지 중단 일시"),
+                                fieldWithPath("data.content[].numberOfParticipants").description("챌린지 참여자 수"),
+                                fieldWithPath("data.content[].participatingDays").description("챌린지 총 진행 일"),
+                                fieldWithPath("data.content[].isEnded").description("챌린지 종료 여부"),
+                                fieldWithPath("data.content[].hostNickname").description("챌린지 주최자 닉네임"),
+                                fieldWithPath("data.content[].hostProfileImage").description("챌린지 주최자 프로필 이미지"),
+                                fieldWithPath("data.page").description("현재 페이지 번호"),
+                                fieldWithPath("data.size").description("현재 페이지 조회 결과 건수"),
+                                fieldWithPath("data.totalElements").description("전체 페이지 조회 결과 건수"),
+                                fieldWithPath("data.totalPages").description("전체 페이지 수"),
+                                fieldWithPath("data.hasNextPage").description("다음 페이지 존재 유무")
+                        )));
+    }
+
 
     @Test
     @WithMockOAuth2User
@@ -179,7 +240,6 @@ public class ChallengeApiTest extends AbstractRestDocsTests {
                         )
                 ));
     }
-
 
     @Test
     @WithMockOAuth2User


### PR DESCRIPTION
# 작업 개요

1. 챌린지 전체 목록을 조회하는 API `GET /api/challenges?page={pageNo}` 를 구현했습니다.
2. 1번 API 테스트 코드를 작성했습니다.

# 작업 상세 내용

## 1. Pagination 적용

챌린지 전체 목록 조회 시, 프론트에서 Pagination 을 이용해서 보여줄 수 있도록 했습니다.

```java
// ChallengeSearchService.java

public SuccessResponse<PageResponse<ChallengePageResponse>> getChallengePage(Pageable pageable) {
    Page<ChallengePageResponse> challengePage = challengeRepository.findAll(pageable)
            .map(challenge -> {
                String hostProfileImage = Optional.ofNullable(challenge.getHost().getImageFileName())
                        .map((imageFilename) -> s3FileService.getGetPreSignedUrl("profiles", imageFilename))
                        .orElse("");
                return ChallengePageResponse.of(challenge, hostProfileImage);
            });

    return SuccessResponse.of(SuccessCode.NO_MESSAGE, PageResponse.from(challengePage));
}
```

Slice 와 유사하게 repository 에서 매개변수로 `Pageable` 객체를 전달하면 `Page` 객체가 반환됩니다.

```java
// ChallengeRepository.java

public interface ChallengeRepository extends JpaRepository<Challenge, Long> {
    Page<Challenge> findAll(Pageable pageable);
}
```

Page 객체를 json 으로 변환하면 아래와 같습니다.

```json
{
  "content": [
      {
          "id": 4,
          "title": "4432",
          "startDate": "2024-09-14T05:26:00Z",
          "endDate": "2024-09-16T05:27:00Z",
          "stopDate": null,
          "numberOfParticipants": 1,
          "participatingDays": 2,
          "isStarted": false,
          "isEnded": false,
          "hostNickname": "haewrong",
          "hostProfileImage": ""
      }
  ],
  "pageable": {
      "pageNumber": 0,
      "pageSize": 20,
      "sort": {
          "sorted": true,
          "unsorted": false,
          "empty": false
      },
      "offset": 0,
      "paged": true,
      "unpaged": false
  },
  "totalPages": 1,
  "totalElements": 4,
  "last": true,
  "size": 20,
  "number": 0,
  "sort": {
      "sorted": true,
      "unsorted": false,
      "empty": false
  },
  "first": true,
  "numberOfElements": 4,
  "empty": false
}
```

`content` 속성에는 `Page<T>` 에 `T` 로 전달한 자료형 배열이 담깁니다.
모든 속성을 사용하지는 않기 때문에 필요한 속성만 프론트에 전달하기 위해 `PageResponse` record 를 생성했습니다.

## 2. `PageResponse`

### record?

record 는 class 와 거의 동일하지만, java 14 에서 도입된 자료형입니다.
자세한 내용은 참고자료로 대체합니다.

- 참고자료: [✏️ [Java] record에 대하여](https://velog.io/@pp8817/record) [velog]

record 를 이용했을 때 얻을 수 있는 장점은 크게 3가지입니다.

1. Lombok 어노테이션을 사용하지 않아도 된다.
2. 작성해야 하는 코드가 짧아진다.
3. 멤버 변수들은 모두 final 로 선언되기 때문에 객체의 데이터 무결성을 보장한다.

### 코드

```java
public record PageResponse<T>(
        List<T> content,
        int page,
        int size,
        long totalElements,
        int totalPages,
        boolean hasNextPage
) {
    public static <T> PageResponse<T> from(Page<T> page) {
        return new PageResponse<>(
                page.getContent(),
                page.getNumber() + 1,
                page.getNumberOfElements(),
                page.getTotalElements(),
                page.getTotalPages(),
                page.hasNext()
        );
    }
}
```

`Page` 객체 중에서 필요한 정보만 프론트에 제공하기 위해 from 메서드를 통해 6가지 속성만 추출합니다. 

## 3. Pageable 의 page number index 수정

컨트롤러에서 `Pageable` 로 request 를 받을 때, `page` query parameter 의 기본값은 0 입니다. 

- 참고자료: [[Spring boot] page 1부터 시작하기](https://treasurebear.tistory.com/59) [티스토리]

만약, 프론트에서 1페이지를 요청하면 백엔드에서는 2페이지에 해당하는 내용을 반환하게 됩니다.

따라서 `page` 의 기본값을 1로 설정하기 위해 `application.yaml` 파일에 아래와 같은 속성을 추가했습니다.

```yaml
spring:
  data:
    web:
      pageable:
        one-indexed-parameters: true
```