### PR TITLE
Feat/챌린지 개별 정보 api 개발#256

### DIFF
--- a/src/docs/asciidoc/api/challenge.adoc
+++ b/src/docs/asciidoc/api/challenge.adoc
@@ -71,6 +71,20 @@ operation::challenge/get-challenge-dates[snippets='http-request,http-response,re
 
 operation::challenge/get-challenge-dates-not-found-exception[snippets='http-request,http-response,response-fields']
 
+=== 챌린지 참여 요일 조회
+
+첼린지 참여 요일을 조회합니다.
+
+operation::challenge/get-challenge-participating-days[snippets='http-request,http-response,response-fields']
+
+==== 에러 응답
+
+===== 챌린지가 존재하지 않는 경우 (404 Not Found)
+
+존재하지 않는 챌린지를 조회한 경우입니다.
+
+operation::challenge/get-challenge-participating-days-not-found-exception[snippets='http-request,http-response,response-fields']
+
 === 챌린지 생성
 
 새로운 첼린지를 생성합니다.

--- a/src/docs/asciidoc/api/challenge.adoc
+++ b/src/docs/asciidoc/api/challenge.adoc
@@ -43,6 +43,20 @@ operation::challenge/get-challenge-details[snippets='http-request,http-response,
 
 operation::challenge/get-challenge-details-not-found-exception[snippets='http-request,http-response,response-fields']
 
+=== 챌린지 1회 실패당 벌금 조회
+
+첼린지 1회 실패당 벌금을 조회합니다.
+
+operation::challenge/get-challenge-fee-per-absence[snippets='http-request,http-response,response-fields']
+
+==== 에러 응답
+
+===== 챌린지가 존재하지 않는 경우 (404 Not Found)
+
+존재하지 않는 챌린지를 조회한 경우입니다.
+
+operation::challenge/get-challenge-fee-per-absence-not-found-exception[snippets='http-request,http-response,response-fields']
+
 === 챌린지 생성
 
 새로운 첼린지를 생성합니다.

--- a/src/docs/asciidoc/api/challenge.adoc
+++ b/src/docs/asciidoc/api/challenge.adoc
@@ -57,6 +57,20 @@ operation::challenge/get-challenge-fee-per-absence[snippets='http-request,http-r
 
 operation::challenge/get-challenge-fee-per-absence-not-found-exception[snippets='http-request,http-response,response-fields']
 
+=== 챌린지 진행 기간 조회
+
+첼린지 1회 실패당 벌금을 조회합니다.
+
+operation::challenge/get-challenge-dates[snippets='http-request,http-response,response-fields']
+
+==== 에러 응답
+
+===== 챌린지가 존재하지 않는 경우 (404 Not Found)
+
+존재하지 않는 챌린지를 조회한 경우입니다.
+
+operation::challenge/get-challenge-dates-not-found-exception[snippets='http-request,http-response,response-fields']
+
 === 챌린지 생성
 
 새로운 첼린지를 생성합니다.

--- a/src/main/java/com/habitpay/habitpay/domain/challenge/api/ChallengeApi.java
+++ b/src/main/java/com/habitpay/habitpay/domain/challenge/api/ChallengeApi.java
@@ -51,6 +51,11 @@ public class ChallengeApi {
         return challengeDetailsService.getChallengeFeePerAbsence(id);
     }
 
+    @GetMapping("/challenges/{id}/dates")
+    public SuccessResponse<ChallengeDatesResponse> getChallengeDates(@PathVariable("id") Long id) {
+        return challengeDetailsService.getChallengeDates(id);
+    }
+
     @PostMapping("/challenges")
     public SuccessResponse<ChallengeCreationResponse> createChallenge(@RequestBody ChallengeCreationRequest challengeCreationRequest,
                                                                       @AuthenticationPrincipal CustomUserDetails user) {

--- a/src/main/java/com/habitpay/habitpay/domain/challenge/api/ChallengeApi.java
+++ b/src/main/java/com/habitpay/habitpay/domain/challenge/api/ChallengeApi.java
@@ -46,6 +46,11 @@ public class ChallengeApi {
         return challengeDetailsService.getChallengeDetails(id, user.getMember());
     }
 
+    @GetMapping("/challenges/{id}/fees/absence")
+    public SuccessResponse<ChallengeFeePerAbsenceResponse> getChallengeFeePerAbsence(@PathVariable("id") Long id) {
+        return challengeDetailsService.getChallengeFeePerAbsence(id);
+    }
+
     @PostMapping("/challenges")
     public SuccessResponse<ChallengeCreationResponse> createChallenge(@RequestBody ChallengeCreationRequest challengeCreationRequest,
                                                                       @AuthenticationPrincipal CustomUserDetails user) {

--- a/src/main/java/com/habitpay/habitpay/domain/challenge/api/ChallengeApi.java
+++ b/src/main/java/com/habitpay/habitpay/domain/challenge/api/ChallengeApi.java
@@ -56,6 +56,11 @@ public class ChallengeApi {
         return challengeDetailsService.getChallengeDates(id);
     }
 
+    @GetMapping("/challenges/{id}/participating-days")
+    public SuccessResponse<ChallengeParticipatingDaysResponse> getChallengeParticipatingDays(@PathVariable("id") Long id) {
+        return challengeDetailsService.getChallengeParticipatingDays(id);
+    }
+
     @PostMapping("/challenges")
     public SuccessResponse<ChallengeCreationResponse> createChallenge(@RequestBody ChallengeCreationRequest challengeCreationRequest,
                                                                       @AuthenticationPrincipal CustomUserDetails user) {

--- a/src/main/java/com/habitpay/habitpay/domain/challenge/application/ChallengeDetailsService.java
+++ b/src/main/java/com/habitpay/habitpay/domain/challenge/application/ChallengeDetailsService.java
@@ -2,9 +2,9 @@ package com.habitpay.habitpay.domain.challenge.application;
 
 import com.habitpay.habitpay.domain.challenge.domain.Challenge;
 import com.habitpay.habitpay.domain.challenge.dto.ChallengeDetailsResponse;
+import com.habitpay.habitpay.domain.challenge.dto.ChallengeFeePerAbsenceResponse;
 import com.habitpay.habitpay.domain.challengeenrollment.dao.ChallengeEnrollmentRepository;
 import com.habitpay.habitpay.domain.challengeenrollment.domain.ChallengeEnrollment;
-import com.habitpay.habitpay.domain.member.application.MemberSearchService;
 import com.habitpay.habitpay.domain.member.domain.Member;
 import com.habitpay.habitpay.global.config.aws.S3FileService;
 import com.habitpay.habitpay.global.response.SuccessCode;
@@ -45,6 +45,15 @@ public class ChallengeDetailsService {
                         challenge,
                         enrolledMembersProfileImageList,
                         isMemberEnrolledInChallenge)
+        );
+    }
+
+    public SuccessResponse<ChallengeFeePerAbsenceResponse> getChallengeFeePerAbsence(Long challengeId) {
+        Challenge challenge = challengeSearchService.getChallengeById(challengeId);
+
+        return SuccessResponse.of(
+                SuccessCode.NO_MESSAGE,
+                ChallengeFeePerAbsenceResponse.from(challenge)
         );
     }
 }

--- a/src/main/java/com/habitpay/habitpay/domain/challenge/application/ChallengeDetailsService.java
+++ b/src/main/java/com/habitpay/habitpay/domain/challenge/application/ChallengeDetailsService.java
@@ -4,6 +4,7 @@ import com.habitpay.habitpay.domain.challenge.domain.Challenge;
 import com.habitpay.habitpay.domain.challenge.dto.ChallengeDatesResponse;
 import com.habitpay.habitpay.domain.challenge.dto.ChallengeDetailsResponse;
 import com.habitpay.habitpay.domain.challenge.dto.ChallengeFeePerAbsenceResponse;
+import com.habitpay.habitpay.domain.challenge.dto.ChallengeParticipatingDaysResponse;
 import com.habitpay.habitpay.domain.challengeenrollment.dao.ChallengeEnrollmentRepository;
 import com.habitpay.habitpay.domain.challengeenrollment.domain.ChallengeEnrollment;
 import com.habitpay.habitpay.domain.member.domain.Member;
@@ -64,6 +65,15 @@ public class ChallengeDetailsService {
         return SuccessResponse.of(
                 SuccessCode.NO_MESSAGE,
                 ChallengeDatesResponse.from(challenge)
+        );
+    }
+
+    public SuccessResponse<ChallengeParticipatingDaysResponse> getChallengeParticipatingDays(Long challengeId) {
+        Challenge challenge = challengeSearchService.getChallengeById(challengeId);
+
+        return SuccessResponse.of(
+                SuccessCode.NO_MESSAGE,
+                ChallengeParticipatingDaysResponse.from(challenge)
         );
     }
 }

--- a/src/main/java/com/habitpay/habitpay/domain/challenge/application/ChallengeDetailsService.java
+++ b/src/main/java/com/habitpay/habitpay/domain/challenge/application/ChallengeDetailsService.java
@@ -1,6 +1,7 @@
 package com.habitpay.habitpay.domain.challenge.application;
 
 import com.habitpay.habitpay.domain.challenge.domain.Challenge;
+import com.habitpay.habitpay.domain.challenge.dto.ChallengeDatesResponse;
 import com.habitpay.habitpay.domain.challenge.dto.ChallengeDetailsResponse;
 import com.habitpay.habitpay.domain.challenge.dto.ChallengeFeePerAbsenceResponse;
 import com.habitpay.habitpay.domain.challengeenrollment.dao.ChallengeEnrollmentRepository;
@@ -54,6 +55,15 @@ public class ChallengeDetailsService {
         return SuccessResponse.of(
                 SuccessCode.NO_MESSAGE,
                 ChallengeFeePerAbsenceResponse.from(challenge)
+        );
+    }
+
+    public SuccessResponse<ChallengeDatesResponse> getChallengeDates(Long challengeId) {
+        Challenge challenge = challengeSearchService.getChallengeById(challengeId);
+
+        return SuccessResponse.of(
+                SuccessCode.NO_MESSAGE,
+                ChallengeDatesResponse.from(challenge)
         );
     }
 }

--- a/src/main/java/com/habitpay/habitpay/domain/challenge/dto/ChallengeDatesResponse.java
+++ b/src/main/java/com/habitpay/habitpay/domain/challenge/dto/ChallengeDatesResponse.java
@@ -1,0 +1,22 @@
+package com.habitpay.habitpay.domain.challenge.dto;
+
+import com.habitpay.habitpay.domain.challenge.domain.Challenge;
+import lombok.Builder;
+import lombok.Getter;
+
+import java.time.ZonedDateTime;
+
+@Getter
+@Builder
+public class ChallengeDatesResponse {
+
+    private ZonedDateTime startDate;
+    private ZonedDateTime endDate;
+
+    public static ChallengeDatesResponse from(Challenge challenge) {
+        return ChallengeDatesResponse.builder()
+                .startDate(challenge.getStartDate())
+                .endDate(challenge.getEndDate())
+                .build();
+    }
+}

--- a/src/main/java/com/habitpay/habitpay/domain/challenge/dto/ChallengeFeePerAbsenceResponse.java
+++ b/src/main/java/com/habitpay/habitpay/domain/challenge/dto/ChallengeFeePerAbsenceResponse.java
@@ -1,0 +1,18 @@
+package com.habitpay.habitpay.domain.challenge.dto;
+
+import com.habitpay.habitpay.domain.challenge.domain.Challenge;
+import lombok.Builder;
+import lombok.Getter;
+
+@Getter
+@Builder
+public class ChallengeFeePerAbsenceResponse {
+
+    private int feePerAbsence;
+
+    public static ChallengeFeePerAbsenceResponse from(Challenge challenge) {
+        return ChallengeFeePerAbsenceResponse.builder()
+                .feePerAbsence(challenge.getFeePerAbsence())
+                .build();
+    }
+}

--- a/src/main/java/com/habitpay/habitpay/domain/challenge/dto/ChallengeParticipatingDaysResponse.java
+++ b/src/main/java/com/habitpay/habitpay/domain/challenge/dto/ChallengeParticipatingDaysResponse.java
@@ -1,0 +1,38 @@
+package com.habitpay.habitpay.domain.challenge.dto;
+
+import com.habitpay.habitpay.domain.challenge.domain.Challenge;
+import lombok.Builder;
+import lombok.Getter;
+
+import java.time.DayOfWeek;
+import java.time.format.TextStyle;
+import java.util.EnumSet;
+import java.util.Locale;
+
+@Getter
+@Builder
+public class ChallengeParticipatingDaysResponse {
+
+    private String[] participatingDays;
+
+    public static ChallengeParticipatingDaysResponse from(Challenge challenge) {
+        return ChallengeParticipatingDaysResponse.builder()
+                .participatingDays(extractDaysFromBits(challenge.getParticipatingDays()))
+                .build();
+    }
+
+    public static String[] extractDaysFromBits(int participatingDays) {
+        EnumSet<DayOfWeek> daysOfParticipatingDays = EnumSet.noneOf(DayOfWeek.class);
+
+        for (int bit = 0; bit <= 6; bit += 1) {
+            int todayBitPosition = 6 - bit;
+            if ((participatingDays & (1 << todayBitPosition)) != 0) {
+                daysOfParticipatingDays.add(DayOfWeek.of(bit + 1));
+            }
+        }
+
+        return daysOfParticipatingDays.stream()
+                .map(day -> day.getDisplayName(TextStyle.SHORT, Locale.KOREAN))
+                .toArray(String[]::new);
+    }
+}

--- a/src/test/java/com/habitpay/habitpay/domain/challenge/api/ChallengeApiTest.java
+++ b/src/test/java/com/habitpay/habitpay/domain/challenge/api/ChallengeApiTest.java
@@ -325,7 +325,6 @@ public class ChallengeApiTest extends AbstractRestDocsTests {
                 ));
     }
 
-
     @Test
     @WithMockOAuth2User
     @DisplayName("챌린지 진행 기간 조회")
@@ -374,6 +373,63 @@ public class ChallengeApiTest extends AbstractRestDocsTests {
         // then
         result.andExpect(status().isNotFound())
                 .andDo(document("challenge/get-challenge-dates-not-found-exception",
+                        requestHeaders(
+                                headerWithName(HttpHeaders.AUTHORIZATION).description("액세스 토큰")
+                        ),
+                        responseFields(
+                                fieldWithPath("code").description("오류 응답 코드"),
+                                fieldWithPath("message").description("오류 메세지")
+                        )
+                ));
+    }
+
+    @Test
+    @WithMockOAuth2User
+    @DisplayName("챌린지 참여 요일 조회")
+    void getChallengeParticipatingDays() throws Exception {
+
+        // given
+        String[] participatingDays = {"월", "화"};
+        ChallengeParticipatingDaysResponse challengeParticipatingDaysResponse = ChallengeParticipatingDaysResponse.builder()
+                .participatingDays(participatingDays)
+                .build();
+
+        given(challengeDetailsService.getChallengeParticipatingDays(anyLong()))
+                .willReturn(SuccessResponse.of(SuccessCode.NO_MESSAGE, challengeParticipatingDaysResponse));
+
+        // when
+        ResultActions result = mockMvc.perform(get("/api/challenges/{id}/participating-days", 1L)
+                .header(HttpHeaders.AUTHORIZATION, AUTHORIZATION_HEADER_PREFIX + "ACCESS_TOKEN"));
+
+        // then
+        result.andExpect(status().isOk())
+                .andDo(document("challenge/get-challenge-participating-days",
+                        requestHeaders(
+                                headerWithName(HttpHeaders.AUTHORIZATION).description("액세스 토큰")
+                        ),
+                        responseFields(
+                                fieldWithPath("message").description("메세지"),
+                                fieldWithPath("data.participatingDays").description("챌린지 참여 요일")
+                        )
+                ));
+    }
+
+    @Test
+    @WithMockOAuth2User
+    @DisplayName("챌린지 참여 요일 조회 예외처리 - 존재하지 않는 챌린지 (404 Not Found)")
+    void getChallengeParticipatingDaysNotFoundException() throws Exception {
+
+        // given
+        given(challengeDetailsService.getChallengeParticipatingDays(anyLong()))
+                .willThrow(new ChallengeNotFoundException(0L));
+
+        // when
+        ResultActions result = mockMvc.perform(get("/api/challenges/{id}/participating-days", 0L)
+                .header(HttpHeaders.AUTHORIZATION, AUTHORIZATION_HEADER_PREFIX + "ACCESS_TOKEN"));
+
+        // then
+        result.andExpect(status().isNotFound())
+                .andDo(document("challenge/get-challenge-participating-days-not-found-exception",
                         requestHeaders(
                                 headerWithName(HttpHeaders.AUTHORIZATION).description("액세스 토큰")
                         ),


### PR DESCRIPTION
# 작업 개요

챌린지 개별 정보를 조회할 수 있는 API 와 테스트 코드를 구현했습니다.

1. 챌린지 1회 실패당 벌금(`feePerAbsence`) 조회 API
2. 챌린지 진행 기간(`startDate`, `endDate`) 조회 API
3. 챌린지 참여 요일(`participatingDays`) 조회 API
    - 참여 요일은 `["월", "화"]` 와 같이 `String[]` 자료형으로 반환합니다. 