### PR TITLE
:bug: fix: AWS SSM 실행 jobs 로 분리 #258

### DIFF
--- a/.github/workflows/deploy.yaml
+++ b/.github/workflows/deploy.yaml
@@ -35,7 +35,7 @@ jobs:
           body: ${{ steps.tag_version.outputs.changelog }}
 
   build-spring-and-docker-image:
-    needs: ["create-release"]
+    needs: [ "create-release" ]
     runs-on: ubuntu-latest
     permissions:
       contents: read
@@ -78,7 +78,7 @@ jobs:
 
   deploy-new-container:
     runs-on: ubuntu-latest
-    needs: ["create-release", "build-spring-and-docker-image"]
+    needs: [ "create-release", "build-spring-and-docker-image" ]
     steps:
       - name: Deploy a new version of the container
         uses: peterkimzz/aws-ssm-send-command@master
@@ -93,6 +93,10 @@ jobs:
           command: /bin/bash ./git-pull.sh; /bin/bash ./deploy.sh "${{ secrets.DOCKERHUB_ACCOUNT }}/${{ secrets.DOCKERHUB_REPOSITORY }}:${{ needs.create-release.outputs.new_tag }}"
           comment: Deploy a New Version of the Container
 
+  switching-blue-green-traffic:
+    runs-on: ubuntu-latest
+    needs: [ "deploy-new-container" ]
+    steps:
       - name: Change the backend container server in nginx
         uses: peterkimzz/aws-ssm-send-command@master
         id: ssm-change-nginx-server
@@ -106,6 +110,10 @@ jobs:
           command: /bin/bash ./deploy.sh
           comment: Change the backend container server in nginx
 
+  turn-off-previous-container:
+    runs-on: ubuntu-latest
+    needs: [ "switching-blue-green-traffic" ]
+    steps:
       - name: Turn off the previous container
         uses: peterkimzz/aws-ssm-send-command@master
         id: ssm-turn-off-previous-container


### PR DESCRIPTION
# 작업 내용

GitHub Actions 에서 AWS SSM 실행하는 부분을 개별 jobs 로 분리하고, 순서를 보장하도록 설정했습니다.