### PR TITLE
Feat/챌린지 생성 시 참여 요일 검증 추가#261

### DIFF
--- a/src/docs/asciidoc/api/challenge.adoc
+++ b/src/docs/asciidoc/api/challenge.adoc
@@ -99,6 +99,17 @@ operation::challenge/create-challenge[snippets='http-request,http-response,respo
 
 operation::challenge/create-challenge-invalid-start-time[snippets='http-request,http-response,response-fields']
 
+===== 챌린지 진행 기간에 참여 요일이 포함되지 않은 경우 (400 Bad Request)
+
+챌린지 진행 기간에 선택한 참여 요일이 전혀 포함되지 않은 경우입니다.
+
+예시
+
+- 진행 기간: 2024.10.07(월) ~ 2024.10.08(화)
+- 참여 요일: 수요일
+
+operation::challenge/create-challenge-invalid-participating-days[snippets='http-request,http-response,response-fields']
+
 === 챌린지 정보 수정
 
 챌린지 정보를 수정합니다.

--- a/src/docs/asciidoc/api/challenge.adoc
+++ b/src/docs/asciidoc/api/challenge.adoc
@@ -59,7 +59,7 @@ operation::challenge/get-challenge-fee-per-absence-not-found-exception[snippets=
 
 === 챌린지 진행 기간 조회
 
-첼린지 1회 실패당 벌금을 조회합니다.
+첼린지 진행 기간을 조회합니다.
 
 operation::challenge/get-challenge-dates[snippets='http-request,http-response,response-fields']
 

--- a/src/main/java/com/habitpay/habitpay/domain/challenge/application/ChallengeCreationService.java
+++ b/src/main/java/com/habitpay/habitpay/domain/challenge/application/ChallengeCreationService.java
@@ -5,10 +5,10 @@ import com.habitpay.habitpay.domain.challenge.domain.Challenge;
 import com.habitpay.habitpay.domain.challenge.dto.ChallengeCreationRequest;
 import com.habitpay.habitpay.domain.challenge.dto.ChallengeCreationResponse;
 import com.habitpay.habitpay.domain.challenge.exception.ChallengeStartTimeInvalidException;
+import com.habitpay.habitpay.domain.challenge.exception.InvalidChallengeParticipatingDaysException;
 import com.habitpay.habitpay.domain.challengeenrollment.dao.ChallengeEnrollmentRepository;
 import com.habitpay.habitpay.domain.challengeenrollment.domain.ChallengeEnrollment;
 import com.habitpay.habitpay.domain.challengescheduler.application.SchedulerTaskHelperService;
-import com.habitpay.habitpay.domain.member.application.MemberSearchService;
 import com.habitpay.habitpay.domain.member.domain.Member;
 import com.habitpay.habitpay.domain.participationstat.dao.ParticipationStatRepository;
 import com.habitpay.habitpay.domain.participationstat.domain.ParticipationStat;
@@ -18,9 +18,11 @@ import lombok.AllArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
+import java.time.DayOfWeek;
 import java.time.ZoneId;
 import java.time.ZonedDateTime;
 import java.util.Collections;
+import java.util.EnumSet;
 import java.util.List;
 
 @Service
@@ -33,9 +35,8 @@ public class ChallengeCreationService {
 
     @Transactional
     public SuccessResponse<ChallengeCreationResponse> createChallenge(ChallengeCreationRequest challengeCreationRequest, Member member) {
-        if (isStartDateBeforeNow(challengeCreationRequest.getStartDate())) {
-            throw new ChallengeStartTimeInvalidException(challengeCreationRequest.getStartDate());
-        }
+        validateChallengeStartDate(challengeCreationRequest.getStartDate());
+        validateChallengeParticipatingDays(challengeCreationRequest);
 
         Challenge challenge = Challenge.of(member, challengeCreationRequest);
         challenge.setNumberOfParticipants(challenge.getNumberOfParticipants() + 1);
@@ -61,13 +62,45 @@ public class ChallengeCreationService {
         );
     }
 
-    private boolean isStartDateBeforeNow(ZonedDateTime startDate) {
-        return startDate.isBefore(ZonedDateTime.now());
+    private void validateChallengeParticipatingDays(ChallengeCreationRequest challengeCreationRequest) {
+        ZonedDateTime startDate = challengeCreationRequest.getStartDate();
+        ZonedDateTime endDate = challengeCreationRequest.getEndDate();
+        int participatingDays = challengeCreationRequest.getParticipatingDays();
+
+        EnumSet<DayOfWeek> challengeDays = EnumSet.noneOf(DayOfWeek.class);
+        ZonedDateTime currentDate = startDate;
+        while (!currentDate.isAfter(endDate) && challengeDays.size() < 7) {
+            challengeDays.add(currentDate.getDayOfWeek());
+            currentDate = currentDate.plusDays(1);
+        }
+
+        challengeDays.forEach(day -> System.out.printf("day: %s\n", day));
+
+        int count = 0;
+        for (int bit = 0; bit <= 6; bit += 1) {
+            int dayBitPosition = 6 - bit; // [0000000] 7자리 비트 사용. 가장 왼쪽 비트가 월요일.
+
+            if ((participatingDays & (1 << dayBitPosition)) != 0) {
+                DayOfWeek dayOfWeek = DayOfWeek.of(bit + 1); // (1=Monday, 7=Sunday)
+                count = challengeDays.contains(dayOfWeek) ? count + 1 : count;
+                System.out.printf("dayOfWeek: %s, count: %d\n", dayOfWeek, count);
+            }
+        }
+
+        if (count == 0) {
+            throw new InvalidChallengeParticipatingDaysException();
+        }
+    }
+
+    private void validateChallengeStartDate(ZonedDateTime startDate) {
+        if (startDate.isBefore(ZonedDateTime.now())) {
+            throw new ChallengeStartTimeInvalidException(startDate);
+        }
     }
 
     private boolean isStartDateIsToday(ZonedDateTime startDate) {
         ZonedDateTime startDateInLocalZone = startDate.withZoneSameInstant(ZoneId.of("Asia/Seoul"));
         ZonedDateTime now = ZonedDateTime.now();
-        return  startDateInLocalZone.toLocalDate().equals(now.toLocalDate());
+        return startDateInLocalZone.toLocalDate().equals(now.toLocalDate());
     }
 }

--- a/src/main/java/com/habitpay/habitpay/domain/challenge/application/ChallengeCreationService.java
+++ b/src/main/java/com/habitpay/habitpay/domain/challenge/application/ChallengeCreationService.java
@@ -74,8 +74,6 @@ public class ChallengeCreationService {
             currentDate = currentDate.plusDays(1);
         }
 
-        challengeDays.forEach(day -> System.out.printf("day: %s\n", day));
-
         int count = 0;
         for (int bit = 0; bit <= 6; bit += 1) {
             int dayBitPosition = 6 - bit; // [0000000] 7자리 비트 사용. 가장 왼쪽 비트가 월요일.
@@ -83,7 +81,6 @@ public class ChallengeCreationService {
             if ((participatingDays & (1 << dayBitPosition)) != 0) {
                 DayOfWeek dayOfWeek = DayOfWeek.of(bit + 1); // (1=Monday, 7=Sunday)
                 count = challengeDays.contains(dayOfWeek) ? count + 1 : count;
-                System.out.printf("dayOfWeek: %s, count: %d\n", dayOfWeek, count);
             }
         }
 

--- a/src/main/java/com/habitpay/habitpay/domain/challenge/exception/InvalidChallengeParticipatingDaysException.java
+++ b/src/main/java/com/habitpay/habitpay/domain/challenge/exception/InvalidChallengeParticipatingDaysException.java
@@ -1,0 +1,12 @@
+package com.habitpay.habitpay.domain.challenge.exception;
+
+import com.habitpay.habitpay.global.error.exception.ErrorCode;
+import com.habitpay.habitpay.global.error.exception.InvalidValueException;
+
+public class InvalidChallengeParticipatingDaysException extends InvalidValueException {
+
+    public InvalidChallengeParticipatingDaysException() {
+        super(ErrorCode.INVALID_CHALLENGE_PARTICIPATING_DAYS);
+    }
+
+}

--- a/src/main/java/com/habitpay/habitpay/global/error/exception/ErrorCode.java
+++ b/src/main/java/com/habitpay/habitpay/global/error/exception/ErrorCode.java
@@ -34,13 +34,14 @@ public enum ErrorCode {
     CHALLENGE_START_TIME_INVALID(HttpStatus.BAD_REQUEST, "챌린지 시작 시간은 현재 시간 이후만 가능합니다."),
     ONLY_HOST_CAN_MODIFY(HttpStatus.FORBIDDEN, "챌린지 주최자만 수정 가능합니다."),
     DUPLICATED_CHALLENGE_DESCRIPTION(HttpStatus.BAD_REQUEST, "변경 사항이 없습니다."),
+    INVALID_CHALLENGE_PARTICIPATING_DAYS(HttpStatus.BAD_REQUEST, "챌린지 진행 기간에 선택한 챌린지 참여 요일이 포함되지 않았습니다."),
     INVALID_CHALLENGE_REGISTRATION_TIME(HttpStatus.BAD_REQUEST, "챌린지 등록 가능 시간이 아닙니다."),
     INVALID_CHALLENGE_CANCELLATION_TIME(HttpStatus.BAD_REQUEST, "챌린지 취소 가능한 시간이 지났습니다."),
     ALREADY_ENROLLED_IN_CHALLENGE(HttpStatus.CONFLICT, "이미 참여한 챌린지 입니다."),
     NOT_ENROLLED_IN_CHALLENGE(HttpStatus.BAD_REQUEST, "참여하지 않은 챌린지 입니다."),
     NOT_ALLOWED_TO_CANCEL_ENROLLMENT_OF_HOST(HttpStatus.BAD_REQUEST, "챌린지 주최자는 참여 취소가 불가능 합니다."),
     NOT_ALLOWED_TO_DELETE_CHALLENGE(HttpStatus.FORBIDDEN, "챌린지 삭제는 챌린지 주최자만 가능합니다."),
-  
+
     // Challenge Participation Record
     RECORD_NOT_FOUND(HttpStatus.NOT_FOUND, "챌린지 참여 기록이 존재하지 않습니다."),
     MANDATORY_RECORD_NOT_FOUND(HttpStatus.NOT_FOUND, "챌린지 참여 기록 연결 중 문제가 발생했습니다. 관리자에게 문의하십시오."),

--- a/src/test/java/com/habitpay/habitpay/domain/challenge/api/ChallengeApiTest.java
+++ b/src/test/java/com/habitpay/habitpay/domain/challenge/api/ChallengeApiTest.java
@@ -261,9 +261,6 @@ public class ChallengeApiTest extends AbstractRestDocsTests {
         // then
         result.andExpect(status().isNotFound())
                 .andDo(document("challenge/get-challenge-details-not-found-exception",
-                        requestHeaders(
-                                headerWithName(HttpHeaders.AUTHORIZATION).description("액세스 토큰")
-                        ),
                         responseFields(
                                 fieldWithPath("code").description("오류 응답 코드"),
                                 fieldWithPath("message").description("오류 메세지")
@@ -291,9 +288,6 @@ public class ChallengeApiTest extends AbstractRestDocsTests {
         // then
         result.andExpect(status().isOk())
                 .andDo(document("challenge/get-challenge-fee-per-absence",
-                        requestHeaders(
-                                headerWithName(HttpHeaders.AUTHORIZATION).description("액세스 토큰")
-                        ),
                         responseFields(
                                 fieldWithPath("message").description("메세지"),
                                 fieldWithPath("data.feePerAbsence").description("미참여 1회당 벌금")
@@ -317,9 +311,6 @@ public class ChallengeApiTest extends AbstractRestDocsTests {
         // then
         result.andExpect(status().isNotFound())
                 .andDo(document("challenge/get-challenge-fee-per-absence-not-found-exception",
-                        requestHeaders(
-                                headerWithName(HttpHeaders.AUTHORIZATION).description("액세스 토큰")
-                        ),
                         responseFields(
                                 fieldWithPath("code").description("오류 응답 코드"),
                                 fieldWithPath("message").description("오류 메세지")
@@ -375,9 +366,6 @@ public class ChallengeApiTest extends AbstractRestDocsTests {
         // then
         result.andExpect(status().isNotFound())
                 .andDo(document("challenge/get-challenge-dates-not-found-exception",
-                        requestHeaders(
-                                headerWithName(HttpHeaders.AUTHORIZATION).description("액세스 토큰")
-                        ),
                         responseFields(
                                 fieldWithPath("code").description("오류 응답 코드"),
                                 fieldWithPath("message").description("오류 메세지")
@@ -432,9 +420,6 @@ public class ChallengeApiTest extends AbstractRestDocsTests {
         // then
         result.andExpect(status().isNotFound())
                 .andDo(document("challenge/get-challenge-participating-days-not-found-exception",
-                        requestHeaders(
-                                headerWithName(HttpHeaders.AUTHORIZATION).description("액세스 토큰")
-                        ),
                         responseFields(
                                 fieldWithPath("code").description("오류 응답 코드"),
                                 fieldWithPath("message").description("오류 메세지")
@@ -533,17 +518,6 @@ public class ChallengeApiTest extends AbstractRestDocsTests {
         // then
         result.andExpect(status().isBadRequest())
                 .andDo(document("challenge/create-challenge-invalid-start-time",
-                        requestHeaders(
-                                headerWithName(HttpHeaders.AUTHORIZATION).description("액세스 토큰")
-                        ),
-                        requestFields(
-                                fieldWithPath("title").description("챌린지 제목"),
-                                fieldWithPath("description").description("챌린지 설명"),
-                                fieldWithPath("startDate").description("챌린지 시작 일시"),
-                                fieldWithPath("endDate").description("챌린지 종료 일시"),
-                                fieldWithPath("participatingDays").description("챌린지 참여 요일"),
-                                fieldWithPath("feePerAbsence").description("미참여 1회당 벌금")
-                        ),
                         responseFields(
                                 fieldWithPath("code").description("오류 응답 코드"),
                                 fieldWithPath("message").description("오류 메세지")
@@ -579,9 +553,6 @@ public class ChallengeApiTest extends AbstractRestDocsTests {
         // then
         result.andExpect(status().isBadRequest())
                 .andDo(document("challenge/create-challenge-invalid-participating-days",
-                        requestHeaders(
-                                headerWithName(HttpHeaders.AUTHORIZATION).description("액세스 토큰")
-                        ),
                         responseFields(
                                 fieldWithPath("code").description("오류 응답 코드"),
                                 fieldWithPath("message").description("오류 메세지")
@@ -661,12 +632,6 @@ public class ChallengeApiTest extends AbstractRestDocsTests {
         // then
         result.andExpect(status().isBadRequest())
                 .andDo(document("challenge/patch-challenge-duplicated-description-exception",
-                        requestHeaders(
-                                headerWithName(HttpHeaders.AUTHORIZATION).description("액세스 토큰")
-                        ),
-                        requestFields(
-                                fieldWithPath("description").description("챌린지 설명")
-                        ),
                         responseFields(
                                 fieldWithPath("code").description("오류 응답 코드"),
                                 fieldWithPath("message").description("오류 메세지")
@@ -696,12 +661,6 @@ public class ChallengeApiTest extends AbstractRestDocsTests {
         // then
         result.andExpect(status().isForbidden())
                 .andDo(document("challenge/patch-challenge-forbidden-exception",
-                        requestHeaders(
-                                headerWithName(HttpHeaders.AUTHORIZATION).description("액세스 토큰")
-                        ),
-                        requestFields(
-                                fieldWithPath("description").description("챌린지 설명")
-                        ),
                         responseFields(
                                 fieldWithPath("code").description("오류 응답 코드"),
                                 fieldWithPath("message").description("오류 메세지")
@@ -752,9 +711,6 @@ public class ChallengeApiTest extends AbstractRestDocsTests {
         // then
         result.andExpect(status().isForbidden())
                 .andDo(document("challenge/delete-forbidden-exception",
-                        requestHeaders(
-                                headerWithName(HttpHeaders.AUTHORIZATION).description("액세스 토큰")
-                        ),
                         responseFields(
                                 fieldWithPath("code").description("오류 응답 코드"),
                                 fieldWithPath("message").description("오류 메세지")
@@ -778,15 +734,10 @@ public class ChallengeApiTest extends AbstractRestDocsTests {
         // then
         result.andExpect(status().isNotFound())
                 .andDo(document("challenge/delete-not-found-exception",
-                        requestHeaders(
-                                headerWithName(HttpHeaders.AUTHORIZATION).description("액세스 토큰")
-                        ),
                         responseFields(
                                 fieldWithPath("code").description("오류 응답 코드"),
                                 fieldWithPath("message").description("오류 메세지")
                         )
                 ));
     }
-
-
 }


### PR DESCRIPTION
# 작업 개요

챌린지 생성 시 챌린지 진행 기간에 챌린지 참여 요일이 하나라도 포함되지 않은 경우 챌린지 생성을 하지 못하도록 예외처리를 추가했습니다. 