### PR TITLE
[feat] 챌린지 상세 페이지에서 챌린지 전체 벌금값 확인하기 #265

### DIFF
--- a/src/main/java/com/habitpay/habitpay/domain/challenge/application/ChallengeDetailsService.java
+++ b/src/main/java/com/habitpay/habitpay/domain/challenge/application/ChallengeDetailsService.java
@@ -39,12 +39,18 @@ public class ChallengeDetailsService {
                 })
                 .toList();
 
+        List<ChallengeEnrollment> enrollmentList = challengeEnrollmentRepository.findAllByChallenge(challenge);
+        int totalAbsenceFee = enrollmentList
+                .stream()
+                .mapToInt(enrollment -> enrollment.getParticipationStat().getTotalFee())
+                .sum();
 
         return SuccessResponse.of(
                 SuccessCode.NO_MESSAGE,
                 ChallengeDetailsResponse.of(
                         member,
                         challenge,
+                        totalAbsenceFee,
                         enrolledMembersProfileImageList,
                         isMemberEnrolledInChallenge)
         );

--- a/src/main/java/com/habitpay/habitpay/domain/challenge/domain/Challenge.java
+++ b/src/main/java/com/habitpay/habitpay/domain/challenge/domain/Challenge.java
@@ -65,10 +65,6 @@ public class Challenge extends BaseTime {
     @Column(nullable = false)
     private int feePerAbsence;
 
-    // todo : 지우기
-    @Column(nullable = false)
-    private int totalAbsenceFee;
-
     @Column(nullable = false)
     private boolean isPaidAll;
 

--- a/src/main/java/com/habitpay/habitpay/domain/challenge/dto/ChallengeDetailsResponse.java
+++ b/src/main/java/com/habitpay/habitpay/domain/challenge/dto/ChallengeDetailsResponse.java
@@ -26,7 +26,7 @@ public class ChallengeDetailsResponse {
     private Boolean isHost;
     private Boolean isMemberEnrolledInChallenge;
 
-    public static ChallengeDetailsResponse of(Member member, Challenge challenge, List<String> enrolledMembersProfileImageList, Boolean isMemberEnrolledInChallenge) {
+    public static ChallengeDetailsResponse of(Member member, Challenge challenge, int totalAbsenceFee, List<String> enrolledMembersProfileImageList, Boolean isMemberEnrolledInChallenge) {
         return ChallengeDetailsResponse.builder()
                 .title(challenge.getTitle())
                 .description(challenge.getDescription())
@@ -37,6 +37,7 @@ public class ChallengeDetailsResponse {
                 .isPaidAll(challenge.isPaidAll())
                 .participatingDays(challenge.getParticipatingDays())
                 .feePerAbsence(challenge.getFeePerAbsence())
+                .totalAbsenceFee(totalAbsenceFee)
                 .hostNickname(challenge.getHost().getNickname())
                 .enrolledMembersProfileImageList(enrolledMembersProfileImageList)
                 .isHost(challenge.getHost().getId().equals(member.getId()))

--- a/src/main/java/com/habitpay/habitpay/domain/challenge/dto/ChallengeDetailsResponse.java
+++ b/src/main/java/com/habitpay/habitpay/domain/challenge/dto/ChallengeDetailsResponse.java
@@ -19,7 +19,7 @@ public class ChallengeDetailsResponse {
     private int numberOfParticipants;
     private int participatingDays;
     private int feePerAbsence;
-    private int totalFee;
+    private int totalAbsenceFee;
     private Boolean isPaidAll;
     private String hostNickname;
     private List<String> enrolledMembersProfileImageList;

--- a/src/main/java/com/habitpay/habitpay/domain/challenge/dto/ChallengeDetailsResponse.java
+++ b/src/main/java/com/habitpay/habitpay/domain/challenge/dto/ChallengeDetailsResponse.java
@@ -19,6 +19,7 @@ public class ChallengeDetailsResponse {
     private int numberOfParticipants;
     private int participatingDays;
     private int feePerAbsence;
+    private int totalFee;
     private Boolean isPaidAll;
     private String hostNickname;
     private List<String> enrolledMembersProfileImageList;

--- a/src/main/resources/application-dev.yaml
+++ b/src/main/resources/application-dev.yaml
@@ -1,7 +1,7 @@
 spring:
   jpa:
     hibernate:
-      ddl-auto: create
+      ddl-auto: update
     show-sql: true
   devtools:
     livereload:

--- a/src/main/resources/application-dev.yaml
+++ b/src/main/resources/application-dev.yaml
@@ -1,7 +1,7 @@
 spring:
   jpa:
     hibernate:
-      ddl-auto: update
+      ddl-auto: create
     show-sql: true
   devtools:
     livereload:

--- a/src/test/java/com/habitpay/habitpay/domain/challenge/api/ChallengeApiTest.java
+++ b/src/test/java/com/habitpay/habitpay/domain/challenge/api/ChallengeApiTest.java
@@ -206,6 +206,7 @@ public class ChallengeApiTest extends AbstractRestDocsTests {
                 .numberOfParticipants(1)
                 .participatingDays(1 << 2)
                 .feePerAbsence(1000)
+                .totalAbsenceFee(0)
                 .isPaidAll(false)
                 .hostNickname("챌린지 주최자 닉네임")
                 .enrolledMembersProfileImageList(List.of("imageLink1", "imageLink2", "imageLink3"))
@@ -236,6 +237,7 @@ public class ChallengeApiTest extends AbstractRestDocsTests {
                                 fieldWithPath("data.numberOfParticipants").description("챌린지 참여 인"),
                                 fieldWithPath("data.participatingDays").description("챌린지 참여 요일"),
                                 fieldWithPath("data.feePerAbsence").description("미참여 1회당 벌금"),
+                                fieldWithPath("data.totalAbsenceFee").description("챌린지 전체 벌금"),
                                 fieldWithPath("data.isPaidAll").description("최종 정산 여부"),
                                 fieldWithPath("data.hostNickname").description("챌린지 주최자 닉네임"),
                                 fieldWithPath("data.enrolledMembersProfileImageList").description("챌린지 참여자 프로필 이미지 (최대 3명)"),


### PR DESCRIPTION
### 개요

* 챌린지 상세 페이지(`http://localhost:3000/challenges/{id}/main`)에서 `챌린지 전체 벌금` 데이터를 아직 확인할 수 없었습니다.
* 이를 해결하기 위해 `ChallengeDetailsResponse DTO`에 `챌린지 전체 벌금` 속성을 추가했습니다.
    (챌린지 상세 페이지에 데이터를 보내는 DTO)

---

### 코드 내용

* `ChallengeDetailsResponse DTO`에 전체 벌금(`totalAbsenceFee`) 속성 추가

```java
public class ChallengeDetailsResponse {
  ...
  private int totalAbsenceFee;
  ...
}
```

---

* `getChallengeDetails` 메서드에 로직 추가
    * `챌린지 상세 페이지` 요청 시 작동하는 메서드
    * `ChallengeDetailsResponse DTO`의 값을 채우는 실질적인 메서드

```java
public SuccessResponse<ChallengeDetailsResponse> getChallengeDetails(Long challengeId, Member member) {
    ...

    List<ChallengeEnrollment> enrollmentList = challengeEnrollmentRepository.findAllByChallenge(challenge);
    int totalAbsenceFee = enrollmentList
            .stream()
            .mapToInt(enrollment -> enrollment.getParticipationStat().getTotalFee())
            .sum();

    return SuccessResponse.of(
            SuccessCode.NO_MESSAGE,
            ChallengeDetailsResponse.of(
                    ...
                    totalAbsenceFee,
                    ...)
    );
}
```

* 챌린지에 등록한 모든 멤버의 데이터를 `enrollment list`를 통해 얻습니다.
* `enrollment` 엔티티에 외래키로 연결된 `stat` 데이터를 불러옵니다.
* `stat`을 통해, `챌린지 내 개인 벌금 총합`을 알 수 있습니다.
* `챌린지 내 개인 벌금`들을 모두 합치면 정확하게 `챌린지 벌금`을 구할 수 있습니다.

---

* `Challenge 엔티티`의 `totalAbsenceFee` 필드 삭제
    * `전체 벌금`은 `챌린지 등록 멤버`들의 `Stat`을 통해 구할 수 있기 때문입니다.
    (정합성을 목표로 이렇게 구현했지만, 추후 빠른 데이터 처리가 필요해지면 다시 수정할지도,,?)

---

* 연관된 테스트 코드 수정