### PR TITLE
[Feat] 챌린지 개별 데이터 조회 api : 전체 벌금 조회 추가 #268

### DIFF
--- a/src/docs/asciidoc/api/challenge.adoc
+++ b/src/docs/asciidoc/api/challenge.adoc
@@ -57,6 +57,20 @@ operation::challenge/get-challenge-fee-per-absence[snippets='http-request,http-r
 
 operation::challenge/get-challenge-fee-per-absence-not-found-exception[snippets='http-request,http-response,response-fields']
 
+=== 챌린지 전체 벌금 조회
+
+챌린지 내에 현재까지 모인 벌금의 총합을 조회합니다.
+
+operation::challenge/get-challenge-total-absence-fee[snippets='http-request,http-response,response-fields']
+
+==== 에러 응답
+
+===== 챌린지가 존재하지 않는 경우 (404 Not Found)
+
+존재하지 않는 챌린지를 조회한 경우입니다.
+
+operation::challenge/get-challenge-total-absence-fee-not-found-exception[snippets='http-request,http-response,response-fields']
+
 === 챌린지 진행 기간 조회
 
 첼린지 진행 기간을 조회합니다.

--- a/src/main/java/com/habitpay/habitpay/domain/challenge/api/ChallengeApi.java
+++ b/src/main/java/com/habitpay/habitpay/domain/challenge/api/ChallengeApi.java
@@ -51,6 +51,9 @@ public class ChallengeApi {
         return challengeDetailsService.getChallengeFeePerAbsence(id);
     }
 
+    @GetMapping("/challenges/{id}/fees/total")
+    public SuccessResponse<> getChallengeTotalFee() {}
+
     @GetMapping("/challenges/{id}/dates")
     public SuccessResponse<ChallengeDatesResponse> getChallengeDates(@PathVariable("id") Long id) {
         return challengeDetailsService.getChallengeDates(id);

--- a/src/main/java/com/habitpay/habitpay/domain/challenge/api/ChallengeApi.java
+++ b/src/main/java/com/habitpay/habitpay/domain/challenge/api/ChallengeApi.java
@@ -51,8 +51,10 @@ public class ChallengeApi {
         return challengeDetailsService.getChallengeFeePerAbsence(id);
     }
 
-    @GetMapping("/challenges/{id}/fees/total")
-    public SuccessResponse<> getChallengeTotalFee() {}
+    @GetMapping("/challenges/{id}/fees/absence/total")
+    public SuccessResponse<ChallengeTotalAbsenceFeeResponse> getChallengeTotalAbsenceFee(@PathVariable("id") Long id) {
+        return challengeDetailsService.getChallengeTotalAbsenceFee(id);
+    }
 
     @GetMapping("/challenges/{id}/dates")
     public SuccessResponse<ChallengeDatesResponse> getChallengeDates(@PathVariable("id") Long id) {

--- a/src/main/java/com/habitpay/habitpay/domain/challenge/application/ChallengeDetailsService.java
+++ b/src/main/java/com/habitpay/habitpay/domain/challenge/application/ChallengeDetailsService.java
@@ -1,10 +1,7 @@
 package com.habitpay.habitpay.domain.challenge.application;
 
 import com.habitpay.habitpay.domain.challenge.domain.Challenge;
-import com.habitpay.habitpay.domain.challenge.dto.ChallengeDatesResponse;
-import com.habitpay.habitpay.domain.challenge.dto.ChallengeDetailsResponse;
-import com.habitpay.habitpay.domain.challenge.dto.ChallengeFeePerAbsenceResponse;
-import com.habitpay.habitpay.domain.challenge.dto.ChallengeParticipatingDaysResponse;
+import com.habitpay.habitpay.domain.challenge.dto.*;
 import com.habitpay.habitpay.domain.challengeenrollment.dao.ChallengeEnrollmentRepository;
 import com.habitpay.habitpay.domain.challengeenrollment.domain.ChallengeEnrollment;
 import com.habitpay.habitpay.domain.member.domain.Member;
@@ -39,11 +36,7 @@ public class ChallengeDetailsService {
                 })
                 .toList();
 
-        List<ChallengeEnrollment> enrollmentList = challengeEnrollmentRepository.findAllByChallenge(challenge);
-        int totalAbsenceFee = enrollmentList
-                .stream()
-                .mapToInt(enrollment -> enrollment.getParticipationStat().getTotalFee())
-                .sum();
+        int totalAbsenceFee = sumAllFeesOfChallenge(challenge);
 
         return SuccessResponse.of(
                 SuccessCode.NO_MESSAGE,
@@ -63,6 +56,24 @@ public class ChallengeDetailsService {
                 SuccessCode.NO_MESSAGE,
                 ChallengeFeePerAbsenceResponse.from(challenge)
         );
+    }
+
+    public SuccessResponse<ChallengeTotalAbsenceFeeResponse> getChallengeTotalAbsenceFee(Long challengeId) {
+        Challenge challenge = challengeSearchService.getChallengeById(challengeId);
+        int totalAbsenceFee = sumAllFeesOfChallenge(challenge);
+
+        return SuccessResponse.of(
+                SuccessCode.NO_MESSAGE,
+                ChallengeTotalAbsenceFeeResponse.from(totalAbsenceFee)
+        );
+    }
+
+    private int sumAllFeesOfChallenge(Challenge challenge) {
+        List<ChallengeEnrollment> enrollmentList = challengeEnrollmentRepository.findAllByChallenge(challenge);
+        return enrollmentList
+                .stream()
+                .mapToInt(enrollment -> enrollment.getParticipationStat().getTotalFee())
+                .sum();
     }
 
     public SuccessResponse<ChallengeDatesResponse> getChallengeDates(Long challengeId) {

--- a/src/main/java/com/habitpay/habitpay/domain/challenge/dto/ChallengeTotalAbsenceFeeResponse.java
+++ b/src/main/java/com/habitpay/habitpay/domain/challenge/dto/ChallengeTotalAbsenceFeeResponse.java
@@ -1,0 +1,18 @@
+package com.habitpay.habitpay.domain.challenge.dto;
+
+import lombok.Builder;
+import lombok.Getter;
+
+@Builder
+@Getter
+public class ChallengeTotalAbsenceFeeResponse {
+
+    private int totalAbsenceFee;
+
+    public static ChallengeTotalAbsenceFeeResponse from(int totalAbsenceFee) {
+        return ChallengeTotalAbsenceFeeResponse
+                .builder()
+                .totalAbsenceFee(totalAbsenceFee)
+                .build();
+    }
+}

--- a/src/test/java/com/habitpay/habitpay/domain/challenge/api/ChallengeApiTest.java
+++ b/src/test/java/com/habitpay/habitpay/domain/challenge/api/ChallengeApiTest.java
@@ -322,6 +322,56 @@ public class ChallengeApiTest extends AbstractRestDocsTests {
 
     @Test
     @WithMockOAuth2User
+    @DisplayName("챌린지 전체 벌금 조회")
+    void getChallengeTotalAbsenceFee() throws Exception {
+
+        // given
+        ChallengeTotalAbsenceFeeResponse challengeTotalAbsenceFeeResponse = ChallengeTotalAbsenceFeeResponse.builder()
+                .totalAbsenceFee(3000)
+                .build();
+
+        given(challengeDetailsService.getChallengeTotalAbsenceFee(anyLong()))
+                .willReturn(SuccessResponse.of(SuccessCode.NO_MESSAGE, challengeTotalAbsenceFeeResponse));
+
+        // when
+        ResultActions result = mockMvc.perform(get("/api/challenges/{id}/fees/absence/total", 1L)
+                .header(HttpHeaders.AUTHORIZATION, AUTHORIZATION_HEADER_PREFIX + "ACCESS_TOKEN"));
+
+        // then
+        result.andExpect(status().isOk())
+                .andDo(document("challenge/get-challenge-total-absence-fee",
+                        responseFields(
+                                fieldWithPath("message").description("메세지"),
+                                fieldWithPath("data.totalAbsenceFee").description("현재까지 모인 챌린지 벌금 총액")
+                        )
+                ));
+    }
+
+    @Test
+    @WithMockOAuth2User
+    @DisplayName("챌린지 전체 벌금 조회 예외처리 - 존재하지 않는 챌린지 (404 Not Found)")
+    void getChallengeTotalAbsenceFeeNotFoundException() throws Exception {
+
+        // given
+        given(challengeDetailsService.getChallengeTotalAbsenceFee(anyLong()))
+                .willThrow(new ChallengeNotFoundException(0L));
+
+        // when
+        ResultActions result = mockMvc.perform(get("/api/challenges/{id}/fees/absence/total", 0L)
+                .header(HttpHeaders.AUTHORIZATION, AUTHORIZATION_HEADER_PREFIX + "ACCESS_TOKEN"));
+
+        // then
+        result.andExpect(status().isNotFound())
+                .andDo(document("challenge/get-challenge-total-absence-fee-not-found-exception",
+                        responseFields(
+                                fieldWithPath("code").description("오류 응답 코드"),
+                                fieldWithPath("message").description("오류 메세지")
+                        )
+                ));
+    }
+
+    @Test
+    @WithMockOAuth2User
     @DisplayName("챌린지 진행 기간 조회")
     void getChallengeDates() throws Exception {
 


### PR DESCRIPTION
### 개요

* 챌린지 개별 데이터 조회를 위한 API에, `챌린지 내 전체 벌금 조회` 메세드를 추가했습니다.

---

### 주요 내용

* `TotalAbsenceFee`를 조회하는 컨트롤러 메서드입니다.

```java
// ChallengeApi.java

 @GetMapping("/challenges/{id}/fees/absence/total")
public SuccessResponse<ChallengeTotalAbsenceFeeResponse> getChallengeTotalAbsenceFee(@PathVariable("id") Long id) {
    return challengeDetailsService.getChallengeTotalAbsenceFee(id);
}
```

---

* `TotalAbsenceFee`를 위한 DTO입니다.

```java
public class ChallengeTotalAbsenceFeeResponse {

  private int totalAbsenceFee;

  public static ChallengeTotalAbsenceFeeResponse from(int totalAbsenceFee) {
      return ChallengeTotalAbsenceFeeResponse
              .builder()
              .totalAbsenceFee(totalAbsenceFee)
              .build();
  }
}
```

* 추가 로직이 필요하여 `Challenge`를 바로 인자로 받진 않지만,
   비슷한 특성의 메서드로 보고 `from` 이름을 그대로 참고했습니다.

---

* `TotalAbsenceFee`값을 구하는 서비스 메서드입니다.

```java
// ChallengeDetailsService.java

public SuccessResponse<ChallengeTotalAbsenceFeeResponse> getChallengeTotalAbsenceFee(Long challengeId) {
    Challenge challenge = challengeSearchService.getChallengeById(challengeId);
    int totalAbsenceFee = sumAllFeesOfChallenge(challenge);

    return SuccessResponse.of(
            SuccessCode.NO_MESSAGE,
            ChallengeTotalAbsenceFeeResponse.from(totalAbsenceFee)
    );
}
```

* Challenge를 통해 벌금 총액 구하는 로직을 메서드화(`sumAllFeesOfChallenge`)했습니다.

---

* Challenge를 인자로 받아 전체 벌금 합을 구하는 메서드입니다.

```java
// ChallengeDetailsService.java

private int sumAllFeesOfChallenge(Challenge challenge) {
    List<ChallengeEnrollment> enrollmentList = challengeEnrollmentRepository.findAllByChallenge(challenge);
    return enrollmentList
            .stream()
            .mapToInt(enrollment -> enrollment.getParticipationStat().getTotalFee())
            .sum();
}
```

---

* 상응하는 테스트 코드 및 문서를 작성했습니다.