### PR TITLE
[Feat] Challenge 엔티티 클래스에 totalAbsenceFee 필드 추가에 따른 코드 수정 #275

### DIFF
--- a/src/main/java/com/habitpay/habitpay/domain/challenge/application/ChallengeDetailsService.java
+++ b/src/main/java/com/habitpay/habitpay/domain/challenge/application/ChallengeDetailsService.java
@@ -49,13 +49,4 @@ public class ChallengeDetailsService {
                         isMemberEnrolledInChallenge)
         );
     }
-
-    // TODO: Challenge 엔티티에 totalAbsenceFee 컬럼 추가 후 아래의 함수 삭제 부탁드립니다. (from. joonhan)
-    private int sumAllFeesOfChallenge(Challenge challenge) {
-        List<ChallengeEnrollment> enrollmentList = challengeEnrollmentRepository.findAllByChallenge(challenge);
-        return enrollmentList
-                .stream()
-                .mapToInt(enrollment -> enrollment.getParticipationStat().getTotalFee())
-                .sum();
-    }
 }

--- a/src/main/java/com/habitpay/habitpay/domain/challenge/application/ChallengeDetailsService.java
+++ b/src/main/java/com/habitpay/habitpay/domain/challenge/application/ChallengeDetailsService.java
@@ -36,15 +36,11 @@ public class ChallengeDetailsService {
                 })
                 .toList();
 
-        // TODO: Challenge 엔티티에 totalAbsenceFee 컬럼 추가 후 Response 생성 시 전달하는 매개변수도 함께 변경 부탁드립니다. (from. joonhan)
-        int totalAbsenceFee = sumAllFeesOfChallenge(challenge);
-
         return SuccessResponse.of(
                 SuccessCode.NO_MESSAGE,
                 ChallengeDetailsResponse.of(
                         member,
                         challenge,
-                        totalAbsenceFee,
                         enrolledMembersProfileImageList,
                         isMemberEnrolledInChallenge)
         );

--- a/src/main/java/com/habitpay/habitpay/domain/challenge/domain/Challenge.java
+++ b/src/main/java/com/habitpay/habitpay/domain/challenge/domain/Challenge.java
@@ -129,6 +129,8 @@ public class Challenge extends BaseTime {
         this.numberOfParticipants = numberOfParticipants;
     }
 
+    public void setTotalAbsenceFee(int value) { this.totalAbsenceFee = value; }
+
     public void setStateInProgress() {
         this.state = ChallengeState.IN_PROGRESS;
     }

--- a/src/main/java/com/habitpay/habitpay/domain/challenge/domain/Challenge.java
+++ b/src/main/java/com/habitpay/habitpay/domain/challenge/domain/Challenge.java
@@ -103,7 +103,7 @@ public class Challenge extends BaseTime {
         if (this == object) {
             return true;
         }
-        if (object == null || getClass() != object.getClass()) {
+        if (!(object instanceof Challenge)) {
             return false;
         }
         Challenge challenge = (Challenge) object;

--- a/src/main/java/com/habitpay/habitpay/domain/challenge/domain/Challenge.java
+++ b/src/main/java/com/habitpay/habitpay/domain/challenge/domain/Challenge.java
@@ -17,6 +17,7 @@ import java.time.temporal.TemporalAdjusters;
 import java.util.ArrayList;
 import java.util.EnumSet;
 import java.util.List;
+import java.util.Objects;
 
 @Getter
 @NoArgsConstructor
@@ -94,6 +95,23 @@ public class Challenge extends BaseTime {
                 .totalParticipatingDaysCount(calculateTotalParticipatingDays(challengeCreationRequest))
                 .feePerAbsence(challengeCreationRequest.getFeePerAbsence())
                 .build();
+    }
+
+    @Override
+    public boolean equals(Object object) {
+        if (this == object) {
+            return true;
+        }
+        if (object == null || getClass() != object.getClass()) {
+            return false;
+        }
+        Challenge challenge = (Challenge) object;
+        return Objects.equals(id, challenge.id);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(id);
     }
 
     private static int calculateTotalParticipatingDays(ChallengeCreationRequest challengeCreationRequest) {

--- a/src/main/java/com/habitpay/habitpay/domain/challenge/domain/Challenge.java
+++ b/src/main/java/com/habitpay/habitpay/domain/challenge/domain/Challenge.java
@@ -103,10 +103,9 @@ public class Challenge extends BaseTime {
         if (this == object) {
             return true;
         }
-        if (!(object instanceof Challenge)) {
+        if (!(object instanceof Challenge challenge)) {
             return false;
         }
-        Challenge challenge = (Challenge) object;
         return Objects.equals(id, challenge.id);
     }
 

--- a/src/main/java/com/habitpay/habitpay/domain/challenge/domain/Challenge.java
+++ b/src/main/java/com/habitpay/habitpay/domain/challenge/domain/Challenge.java
@@ -82,6 +82,7 @@ public class Challenge extends BaseTime {
         this.participatingDays = participatingDays;
         this.totalParticipatingDaysCount = totalParticipatingDaysCount;
         this.feePerAbsence = feePerAbsence;
+        this.totalAbsenceFee = 0;
     }
 
     public static Challenge of(Member host, ChallengeCreationRequest challengeCreationRequest) {

--- a/src/main/java/com/habitpay/habitpay/domain/challenge/dto/ChallengeDetailsResponse.java
+++ b/src/main/java/com/habitpay/habitpay/domain/challenge/dto/ChallengeDetailsResponse.java
@@ -26,7 +26,7 @@ public class ChallengeDetailsResponse {
     private Boolean isHost;
     private Boolean isMemberEnrolledInChallenge;
 
-    public static ChallengeDetailsResponse of(Member member, Challenge challenge, int totalAbsenceFee, List<String> enrolledMembersProfileImageList, Boolean isMemberEnrolledInChallenge) {
+    public static ChallengeDetailsResponse of(Member member, Challenge challenge, List<String> enrolledMembersProfileImageList, Boolean isMemberEnrolledInChallenge) {
         return ChallengeDetailsResponse.builder()
                 .title(challenge.getTitle())
                 .description(challenge.getDescription())
@@ -37,7 +37,9 @@ public class ChallengeDetailsResponse {
                 .isPaidAll(challenge.isPaidAll())
                 .participatingDays(challenge.getParticipatingDays())
                 .feePerAbsence(challenge.getFeePerAbsence())
-                .totalAbsenceFee(totalAbsenceFee)
+                // todo : 챌린지 엔티티에 전체 벌금 필드 살린 후 수정하기
+                .totalAbsenceFee(0)
+//                .totalAbsenceFee(challenge.getTotalAbsenceFee)
                 .hostNickname(challenge.getHost().getNickname())
                 .enrolledMembersProfileImageList(enrolledMembersProfileImageList)
                 .isHost(challenge.getHost().getId().equals(member.getId()))

--- a/src/main/java/com/habitpay/habitpay/domain/challenge/dto/ChallengeDetailsResponse.java
+++ b/src/main/java/com/habitpay/habitpay/domain/challenge/dto/ChallengeDetailsResponse.java
@@ -37,9 +37,7 @@ public class ChallengeDetailsResponse {
                 .isPaidAll(challenge.isPaidAll())
                 .participatingDays(challenge.getParticipatingDays())
                 .feePerAbsence(challenge.getFeePerAbsence())
-                // todo : 챌린지 엔티티에 전체 벌금 필드 살린 후 수정하기
-                .totalAbsenceFee(0)
-//                .totalAbsenceFee(challenge.getTotalAbsenceFee)
+                .totalAbsenceFee(challenge.getTotalAbsenceFee())
                 .hostNickname(challenge.getHost().getNickname())
                 .enrolledMembersProfileImageList(enrolledMembersProfileImageList)
                 .isHost(challenge.getHost().getId().equals(member.getId()))

--- a/src/main/java/com/habitpay/habitpay/domain/challengeabsencefee/application/ChallengeAbsenceFeeSearchService.java
+++ b/src/main/java/com/habitpay/habitpay/domain/challengeabsencefee/application/ChallengeAbsenceFeeSearchService.java
@@ -38,7 +38,7 @@ public class ChallengeAbsenceFeeSearchService {
                 .findMemberFeeViewByChallenge(challenge, totalParticipatingDaysCount);
 
         FeeStatusResponse feeStatusResponse = FeeStatusResponse.builder()
-                .totalFee(findTotalFeeOfChallenge(memberFeeViewList))
+                .totalFee(challenge.getTotalAbsenceFee())
                 .myFee(findPersonalTotalFeeOfChallenge(enrollment))
                 .memberFeeList(MemberFee.of(memberFeeViewList, member.getId()))
                 .build();
@@ -53,7 +53,4 @@ public class ChallengeAbsenceFeeSearchService {
         return enrollment.getParticipationStat().getTotalFee();
     }
 
-    private static int findTotalFeeOfChallenge(List<MemberFeeView> memberFeeList) {
-        return memberFeeList.stream().mapToInt(MemberFeeView::getTotalFee).sum();
-    }
 }

--- a/src/main/java/com/habitpay/habitpay/domain/challengescheduler/application/ChallengeSchedulerService.java
+++ b/src/main/java/com/habitpay/habitpay/domain/challengescheduler/application/ChallengeSchedulerService.java
@@ -23,8 +23,6 @@ import java.util.List;
 public class ChallengeSchedulerService {
 
     private final ChallengeRepository challengeRepository;
-    private final ParticipationStatRepository participationStatRepository;
-    private final ChallengeParticipationRecordRepository challengeParticipationRecordRepository;
     private final SchedulerTaskHelperService schedulerTaskHelperService;
 
     @Scheduled(cron = "0 0 0 * * *", zone = "Asia/Seoul")
@@ -48,12 +46,7 @@ public class ChallengeSchedulerService {
 
         if (challengeList.isEmpty()) { return; }
 
-        List<ParticipationStat> failStatList = new ArrayList<>();
-        List<ChallengeParticipationRecord> failRecordList = new ArrayList<>();
-        schedulerTaskHelperService.checkFailedParticipation(challengeList, yesterday, failStatList, failRecordList);
-
-        participationStatRepository.saveAll(failStatList);
-        challengeParticipationRecordRepository.deleteAll(failRecordList);
+        schedulerTaskHelperService.checkFailedParticipation(challengeList, yesterday);
     }
 
     @Scheduled(cron = "0 0 0 * * *", zone = "Asia/Seoul")
@@ -62,5 +55,6 @@ public class ChallengeSchedulerService {
         ZonedDateTime yesterday = ZonedDateTime.now().minusDays(1);
         List<Challenge> challengeList = schedulerTaskHelperService.findEndingChallenges(yesterday);
         challengeList.forEach(Challenge::setStateCompletedPendingSettlement);
+        challengeRepository.saveAll(challengeList);
     }
 }


### PR DESCRIPTION
### 개요

* `Challenge` 엔티티 클래스에 전체 벌금 총합을 가리키는 `totalAbsenceFee` 필드가 추가되며 코드 수정이 필요했습니다.
* 우선 `Challenge 객체`의 전체 벌금 총합을 구하는 로직을 변경했습니다.
* 챌린지 참가자가 참여 실패할 경우 개인 벌금만 수정하던 로직에 더해,
   챌린지 내 필드인 `totalAbsenceFee`에도 벌금을 더하는 코드를 추가했습니다.

---

### 코드 주요 내용

* `챌린지 벌금 현황 데이터`를 가공하는 서비스 메서드에서,
   `챌린지 전체 벌금 총합`은 챌린지 내 필드인 `totalAbsenceFee`값을 `getter`로 가져오도록 했습니다.
   (이전 : 챌린지 내 참가자들의 개인 벌금을 합하여 구했음)

```java
// ChallengeAbsenceFeeSearchService.java

public SuccessResponse<FeeStatusResponse> makeMemberFeeDataListOfChallenge(Long challengeId, Member member) {
    ...
    FeeStatusResponse feeStatusResponse = FeeStatusResponse.builder()
            .totalFee(challenge.getTotalAbsenceFee())
            ...
            .build();
    ...
}
```

---

* `챌린지 전체 벌금 총합` 데이터가 필요한 `ChallengeDetailsResponse` DTO의 생성 메서드도 수정했습니다.

```java
// ChallengeDetailsResponse.java

public static ChallengeDetailsResponse of(Member member, Challenge challenge, List<String> enrolledMembersProfileImageList, Boolean isMemberEnrolledInChallenge) {
    return ChallengeDetailsResponse.builder()
            ...
            .totalAbsenceFee(challenge.getTotalAbsenceFee())
            ...
}
```

* 해당 DTO를 이용하는 관련 코드도 그에 맞추어 수정했습니다.

---

* 챌린지 멤버가 참여 실패 시, `ParticipationStat` 엔티티의 `totalFee`에 개인 벌금이 더해집니다.
  이때 챌린지 내 `totalAbsenceFee` 필드에도 동일한 벌금 금액이 더해지도록 했습니다.

```java
/ / SchedulerTaskHelperService.java

public void checkFailedParticipation(List<Challenge> challengeList, ZonedDateTime yesterday) {
    List<Challenge> feeAddedChallengeList = new ArrayList<>();
    ...

    challengeParticipationRecordSearchService.findByChallengesAndTargetDate(challengeList, yesterday)
            .forEach(record -> {
                if (!record.existChallengePost()) {
                    ...
                    stat.setTotalFee(stat.getTotalFee() + challenge.getFeePerAbsence());
                    challenge.setTotalAbsenceFee(challenge.getTotalAbsenceFee() + challenge.getFeePerAbsence());
                    ...
                    saveOrUpdateChallengeList(feeAddedChallengeList, challenge);
                }
            });

    ...
    challengeRepository.saveAll(feeAddedChallengeList);
}
```

* (코드 수정하며 리팩토링도 했습니다.)

* 챌린지 객체에도 값 변화가 생기기 때문에, 이를 DB에 반영하기 위해
  `challengeRepository.saveAll()`에 인자로 넘겨줄 챌린지 목록인 `feeAddedChallengeList` 변수를 추가했습니다.
* 이때 `feeAddedChallengeList`에 추가할 challenge 객체를 선별하는 `saveOrUpdateChallengeList()` 메서드를 만들었습니다.

---

* `saveOrUpdateChallengeList()`의 내용은 다음과 같습니다.

```java
private void saveOrUpdateChallengeList(List<Challenge> challengeList, Challenge challenge) {
    int index = challengeList.indexOf(challenge);
    if (index != -1) {
        challengeList.set(index, challenge);
    } else {
        challengeList.add(challenge);
    }
}
```

* 기본적으로 `참여 실패한 기록`이 발생할 때마다, 해당 `challenge`는 위의 메서드에 인자로 들어옵니다.
* 목록에 없는 챌린지라면 `else 분기`로 들어와 추가됩니다.
* 목록에 있는 챌린지라면, `벌금 금액이 추가된 버전`으로 변경할 필요가 있습니다.
* 그래서 목록에 해당 `챌린지`가 이미 존재한다면, `index`를 이용해 `값이 새로워진 챌린지 객체`로 교체해줍니다.

---

* 위의 `saveOrUpdateChallengeList()`는 `indexOf()`가 의도대로 작동했을 때 의미가 있습니다.
* 의도대로 함은, `목록에 이미 존재하는 챌린지`가 `인자로 들어온 챌린지`와 동일한지 여부를 제대로 판별한다는 뜻입니다.
* 이때 `indexOf()` 메서드는 내부적으로 `equals()` 메서드를 이용한다고 합니다.
* 그러나 `equals()`는 기본적으로 참조 비교하기 때문에, 값이 같아도 메모리 주소가 다르면 `false`를 반환합니다.

---

* 그렇기 때문에, (참조 비교가 아닌) 두 챌린지 객체가 동일한지 여부를 원하는 대로 판별하도록 `equals() 메서드`를 오버라이딩했습니다.
* 이때 동일한지 여부를 판별하는 기준은 챌린지의 `id`값으로 설정했습니다.

```java
// Challenge.java

@Override
public boolean equals(Object object) {
    if (this == object) {
        return true;
    }
    if (!(object instanceof Challenge challenge)) {
        return false;
    }
    return Objects.equals(id, challenge.id);
}

@Override
public int hashCode() {
    return Objects.hash(id);
}
```

* `hashCode()` 오버라이딩은,
  해시 기반의 컬렉션(`HashSet`, `HashMap` 등)을 이용할 때 필요하다고 합니다.
* 당장 우리 코드에서 필요는 없으나, `equals()`를 오버라이딩할 때 보통 안정성 및 확장성을 위해 함께 세트로 묶어 가공하는 것 같습니다.
* 그래서 우리도 함,,!

---

* 챌린지 빌더 메서드에 `totalAbsenceFee`의 값을 `0`으로 설정하는 코드를 추가했습니다.

```java
// Challenge.java

@Builder
public Challenge(...) {
    ...
    this.totalAbsenceFee = 0;
}
```

* null값으로 만들지 않기 위해 기본값을 설정한 것인데, 혹시 더 적절한 위치나 다른 로직이 있을까 싶어 정리 겸 논의로 남겨놓습니다.