### PR TITLE
[Feat] 챌린지 상세 페이지 API 데이터에 '오늘 참여 여부' 추가 #283

### DIFF
--- a/src/main/java/com/habitpay/habitpay/domain/challenge/application/ChallengeSearchService.java
+++ b/src/main/java/com/habitpay/habitpay/domain/challenge/application/ChallengeSearchService.java
@@ -70,8 +70,7 @@ public class ChallengeSearchService {
     private ChallengeEnrolledListItemResponse mapToResponse(ChallengeEnrollment challengeEnrollment) {
         Challenge challenge = challengeEnrollment.getChallenge();
         ParticipationStat stat = challengeEnrollment.getParticipationStat();
-        ZonedDateTime startOfToday = ZonedDateTime.now().withZoneSameInstant(ZoneId.of("Asia/Seoul")).with(LocalTime.MIDNIGHT);
-        boolean isParticipatedToday = challengeParticipationRecordUtilService.getIsParticipatedToday(challengeEnrollment, startOfToday);
+        boolean isParticipatedToday = challengeParticipationRecordUtilService.getIsParticipatedToday(challengeEnrollment);
         String hostProfileImageUrl = Optional.ofNullable(challenge.getHost().getImageFileName())
                 .map((imageFileName) -> s3FileService.getGetPreSignedUrl("profiles", imageFileName))
                 .orElse("");

--- a/src/main/java/com/habitpay/habitpay/domain/challenge/application/ChallengeSearchService.java
+++ b/src/main/java/com/habitpay/habitpay/domain/challenge/application/ChallengeSearchService.java
@@ -7,6 +7,7 @@ import com.habitpay.habitpay.domain.challenge.dto.ChallengePageResponse;
 import com.habitpay.habitpay.domain.challenge.exception.ChallengeNotFoundException;
 import com.habitpay.habitpay.domain.challengeenrollment.dao.ChallengeEnrollmentRepository;
 import com.habitpay.habitpay.domain.challengeenrollment.domain.ChallengeEnrollment;
+import com.habitpay.habitpay.domain.challengeparticipationrecord.application.ChallengeParticipationRecordUtilService;
 import com.habitpay.habitpay.domain.challengeparticipationrecord.dao.ChallengeParticipationRecordRepository;
 import com.habitpay.habitpay.domain.challengeparticipationrecord.domain.ChallengeParticipationRecord;
 import com.habitpay.habitpay.domain.member.domain.Member;
@@ -37,6 +38,7 @@ public class ChallengeSearchService {
     private final ChallengeRepository challengeRepository;
     private final ChallengeEnrollmentRepository challengeEnrollmentRepository;
     private final ChallengeParticipationRecordRepository challengeParticipationRecordRepository;
+    private final ChallengeParticipationRecordUtilService challengeParticipationRecordUtilService;
 
     public SuccessResponse<PageResponse<ChallengePageResponse>> getChallengePage(Pageable pageable) {
         Page<ChallengePageResponse> challengePage = challengeRepository.findAll(pageable)
@@ -69,10 +71,7 @@ public class ChallengeSearchService {
         Challenge challenge = challengeEnrollment.getChallenge();
         ParticipationStat stat = challengeEnrollment.getParticipationStat();
         ZonedDateTime startOfToday = ZonedDateTime.now().withZoneSameInstant(ZoneId.of("Asia/Seoul")).with(LocalTime.MIDNIGHT);
-        boolean isParticipatedToday = challengeParticipationRecordRepository
-                .findByChallengeEnrollmentAndTargetDate(challengeEnrollment, startOfToday)
-                .map(ChallengeParticipationRecord::existChallengePost)
-                .orElseGet(() -> false);
+        boolean isParticipatedToday = challengeParticipationRecordUtilService.getIsParticipatedToday(challengeEnrollment, startOfToday);
         String hostProfileImageUrl = Optional.ofNullable(challenge.getHost().getImageFileName())
                 .map((imageFileName) -> s3FileService.getGetPreSignedUrl("profiles", imageFileName))
                 .orElse("");

--- a/src/main/java/com/habitpay/habitpay/domain/challenge/dto/ChallengeDetailsResponse.java
+++ b/src/main/java/com/habitpay/habitpay/domain/challenge/dto/ChallengeDetailsResponse.java
@@ -21,6 +21,7 @@ public class ChallengeDetailsResponse {
     private int feePerAbsence;
     private int totalAbsenceFee;
     private Boolean isPaidAll;
+    private Boolean isTodayParticipatingDay;
     private String hostNickname;
     private List<String> enrolledMembersProfileImageList;
     private Boolean isHost;

--- a/src/main/java/com/habitpay/habitpay/domain/challenge/dto/ChallengeDetailsResponse.java
+++ b/src/main/java/com/habitpay/habitpay/domain/challenge/dto/ChallengeDetailsResponse.java
@@ -21,7 +21,7 @@ public class ChallengeDetailsResponse {
     private int feePerAbsence;
     private int totalAbsenceFee;
     private Boolean isPaidAll;
-    private Boolean isTodayParticipatingDay;
+    private Boolean isParticipatedToday;
     private String hostNickname;
     private List<String> enrolledMembersProfileImageList;
     private Boolean isHost;

--- a/src/main/java/com/habitpay/habitpay/domain/challenge/dto/ChallengeDetailsResponse.java
+++ b/src/main/java/com/habitpay/habitpay/domain/challenge/dto/ChallengeDetailsResponse.java
@@ -36,6 +36,7 @@ public class ChallengeDetailsResponse {
                 .stopDate(challenge.getStopDate())
                 .numberOfParticipants(challenge.getNumberOfParticipants())
                 .isPaidAll(challenge.isPaidAll())
+                .isParticipatedToday()
                 .participatingDays(challenge.getParticipatingDays())
                 .feePerAbsence(challenge.getFeePerAbsence())
                 .totalAbsenceFee(challenge.getTotalAbsenceFee())

--- a/src/main/java/com/habitpay/habitpay/domain/challenge/dto/ChallengeDetailsResponse.java
+++ b/src/main/java/com/habitpay/habitpay/domain/challenge/dto/ChallengeDetailsResponse.java
@@ -27,7 +27,7 @@ public class ChallengeDetailsResponse {
     private Boolean isHost;
     private Boolean isMemberEnrolledInChallenge;
 
-    public static ChallengeDetailsResponse of(Member member, Challenge challenge, List<String> enrolledMembersProfileImageList, Boolean isMemberEnrolledInChallenge) {
+    public static ChallengeDetailsResponse of(Member member, Challenge challenge, List<String> enrolledMembersProfileImageList, Boolean isMemberEnrolledInChallenge, Boolean isParticipatedToday) {
         return ChallengeDetailsResponse.builder()
                 .title(challenge.getTitle())
                 .description(challenge.getDescription())
@@ -36,7 +36,7 @@ public class ChallengeDetailsResponse {
                 .stopDate(challenge.getStopDate())
                 .numberOfParticipants(challenge.getNumberOfParticipants())
                 .isPaidAll(challenge.isPaidAll())
-                .isParticipatedToday()
+                .isParticipatedToday(isParticipatedToday)
                 .participatingDays(challenge.getParticipatingDays())
                 .feePerAbsence(challenge.getFeePerAbsence())
                 .totalAbsenceFee(challenge.getTotalAbsenceFee())

--- a/src/main/java/com/habitpay/habitpay/domain/challengeparticipationrecord/application/ChallengeParticipationRecordUtilService.java
+++ b/src/main/java/com/habitpay/habitpay/domain/challengeparticipationrecord/application/ChallengeParticipationRecordUtilService.java
@@ -6,6 +6,8 @@ import com.habitpay.habitpay.domain.challengeparticipationrecord.domain.Challeng
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 
+import java.time.LocalTime;
+import java.time.ZoneId;
 import java.time.ZonedDateTime;
 
 @Service
@@ -14,9 +16,11 @@ public class ChallengeParticipationRecordUtilService {
 
     private final ChallengeParticipationRecordRepository challengeParticipationRecordRepository;
 
-    public boolean getIsParticipatedToday(ChallengeEnrollment enrollment, ZonedDateTime targetDay) {
+    public boolean getIsParticipatedToday(ChallengeEnrollment enrollment) {
+        ZonedDateTime startOfToday = ZonedDateTime.now().withZoneSameInstant(ZoneId.of("Asia/Seoul")).with(LocalTime.MIDNIGHT);
+
         return challengeParticipationRecordRepository
-                .findByChallengeEnrollmentAndTargetDate(enrollment, targetDay)
+                .findByChallengeEnrollmentAndTargetDate(enrollment, startOfToday)
                 .map(ChallengeParticipationRecord::existChallengePost)
                 .orElseGet(() -> false);
     }

--- a/src/main/java/com/habitpay/habitpay/domain/challengeparticipationrecord/application/ChallengeParticipationRecordUtilService.java
+++ b/src/main/java/com/habitpay/habitpay/domain/challengeparticipationrecord/application/ChallengeParticipationRecordUtilService.java
@@ -1,0 +1,23 @@
+package com.habitpay.habitpay.domain.challengeparticipationrecord.application;
+
+import com.habitpay.habitpay.domain.challengeenrollment.domain.ChallengeEnrollment;
+import com.habitpay.habitpay.domain.challengeparticipationrecord.dao.ChallengeParticipationRecordRepository;
+import com.habitpay.habitpay.domain.challengeparticipationrecord.domain.ChallengeParticipationRecord;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+import java.time.ZonedDateTime;
+
+@Service
+@RequiredArgsConstructor
+public class ChallengeParticipationRecordUtilService {
+
+    private final ChallengeParticipationRecordRepository challengeParticipationRecordRepository;
+
+    public boolean getIsParticipatedToday(ChallengeEnrollment enrollment, ZonedDateTime targetDay) {
+        return challengeParticipationRecordRepository
+                .findByChallengeEnrollmentAndTargetDate(enrollment, targetDay)
+                .map(ChallengeParticipationRecord::existChallengePost)
+                .orElseGet(() -> false);
+    }
+}

--- a/src/test/java/com/habitpay/habitpay/domain/challenge/api/ChallengeApiTest.java
+++ b/src/test/java/com/habitpay/habitpay/domain/challenge/api/ChallengeApiTest.java
@@ -212,6 +212,7 @@ public class ChallengeApiTest extends AbstractRestDocsTests {
                 .enrolledMembersProfileImageList(List.of("imageLink1", "imageLink2", "imageLink3"))
                 .isHost(true)
                 .isMemberEnrolledInChallenge(true)
+                .isParticipatedToday(true)
                 .build();
 
         given(challengeDetailsService.getChallengeDetails(anyLong(), any(Member.class)))
@@ -242,7 +243,8 @@ public class ChallengeApiTest extends AbstractRestDocsTests {
                                 fieldWithPath("data.hostNickname").description("챌린지 주최자 닉네임"),
                                 fieldWithPath("data.enrolledMembersProfileImageList").description("챌린지 참여자 프로필 이미지 (최대 3명)"),
                                 fieldWithPath("data.isHost").description("현재 접속한 사용자 == 챌린지 주최자"),
-                                fieldWithPath("data.isMemberEnrolledInChallenge").description("현재 접속한 사용자의 챌린지 참여 여부")
+                                fieldWithPath("data.isMemberEnrolledInChallenge").description("현재 접속한 사용자의 챌린지 참여 여부"),
+                                fieldWithPath("data.isParticipatedToday").description("현재 접속한 사용자가 챌린지의 참가자일 경우, 금일 참여했는지 여부(참가자기 아니어도 false)")
                         )
                 ));
     }

--- a/src/test/java/com/habitpay/habitpay/domain/challenge/api/ChallengeApiTest.java
+++ b/src/test/java/com/habitpay/habitpay/domain/challenge/api/ChallengeApiTest.java
@@ -244,7 +244,7 @@ public class ChallengeApiTest extends AbstractRestDocsTests {
                                 fieldWithPath("data.enrolledMembersProfileImageList").description("챌린지 참여자 프로필 이미지 (최대 3명)"),
                                 fieldWithPath("data.isHost").description("현재 접속한 사용자 == 챌린지 주최자"),
                                 fieldWithPath("data.isMemberEnrolledInChallenge").description("현재 접속한 사용자의 챌린지 참여 여부"),
-                                fieldWithPath("data.isParticipatedToday").description("현재 접속한 사용자가 챌린지의 참가자일 경우, 금일 참여했는지 여부(참가자기 아니어도 false)")
+                                fieldWithPath("data.isParticipatedToday").description("현재 접속한 사용자가 챌린지의 참가자일 경우, 금일 참여했는지 여부(참가자가 아니어도 false)")
                         )
                 ));
     }


### PR DESCRIPTION
### 작업 개요

* 챌린지 상세 페이지를 위한 API인 `GET` `/api/challenges/{id}`를 통해 접속하면,
  웹 뷰에 `금일 챌린지에 참여했는지 여부`를 알리는 문구가 있습니다.
* 현재는 다음과 같은 문구로 고정되어 있습니다.
```java
오늘은 챌린지에 참여하지 않으셨습니다!
챌린지 인증 글을 작성해주세요.
```
* 이 문구를 상황에 맞게 바꿀 수 있도록, 해당 API 반환 데이터에 `'오늘 참여 여부'` 관련 정보를 추가합니다.

---

### 코드 주요 내용

* 챌린지 상세 페이지를 위한 DTO인 `ChallengeDetailsResponse`에  `isTodayParticipatingDay`, `isParticipatedToday` 속성을 추가했습니다.

```java
// ChallengeDetailsResponse.java

public class ChallengeDetailsResponse {
  ...
  private Boolean isTodayParticipatingDay;
  private Boolean isParticipatedToday;
  ...
}
```

* `ChallengeDetailsResponse` 생성 메서드인 `of`에도 해당 속성을 추가했습니다.

```java
public static ChallengeDetailsResponse of(Member member, Challenge challenge, List<String> enrolledMembersProfileImageList, Boolean isMemberEnrolledInChallenge, Boolean isParticipatedToday) {
    return ChallengeDetailsResponse.builder()
            ...
            .isTodayParticipatingDay(challenge.isTodayParticipatingDay())
            .isParticipatedToday(isParticipatedToday)
            ...
            .build();
}
```

---

* `ChallengeEnrollment` 데이터를 이용해 `오늘 참여 여부`를 구하는 로직을 메서드화했습니다.

```java
// ChallengeParticipationRecordUtilService.java

public boolean getIsParticipatedToday(ChallengeEnrollment enrollment) {
    ZonedDateTime startOfToday = ZonedDateTime.now().withZoneSameInstant(ZoneId.of("Asia/Seoul")).with(LocalTime.MIDNIGHT);
// 위의 코드는 타임존 변환 메서드를 이용해 리팩토링 예정

    return challengeParticipationRecordRepository
            .findByChallengeEnrollmentAndTargetDate(enrollment, startOfToday)
            .map(ChallengeParticipationRecord::existChallengePost)
            .orElseGet(() -> false);
}
```

* 위의 `getIsParticipatedToday()` 메서드가 사용되는 곳입니다.

```java
// ChallengeDetailsService.java

public SuccessResponse<ChallengeDetailsResponse> getChallengeDetails(Long challengeId, Member member) {
    ...
    Optional<ChallengeEnrollment> optionalEnrollment = challengeEnrollmentRepository.findByMemberAndChallenge(member, challenge);
    Boolean isMemberEnrolledInChallenge = optionalEnrollment.isPresent();
    boolean isParticipatedToday = isMemberEnrolledInChallenge && challengeParticipationRecordUtilService.getIsParticipatedToday(optionalEnrollment.get());
    ...

    return SuccessResponse.of(
            SuccessCode.NO_MESSAGE,
            ChallengeDetailsResponse.of(
                    ...
                    isParticipatedToday)
    );
}
```

```java
// ChallengeSearchService.java

private ChallengeEnrolledListItemResponse mapToResponse(ChallengeEnrollment challengeEnrollment) {
    ...
    boolean isParticipatedToday = challengeParticipationRecordUtilService.getIsParticipatedToday(challengeEnrollment);
    ...
    return ChallengeEnrolledListItemResponse.of(..., isParticipatedToday);
}
```

---

* 관련 테스트 코드를 수정했습니다.