### PR TITLE
[add] 누락 커밋 추가 : 챌린지 디테일 DTO에 '오늘이 참여일인지 여부' 속성 추가 #286

### DIFF
--- a/src/main/java/com/habitpay/habitpay/domain/challenge/dto/ChallengeDetailsResponse.java
+++ b/src/main/java/com/habitpay/habitpay/domain/challenge/dto/ChallengeDetailsResponse.java
@@ -21,6 +21,7 @@ public class ChallengeDetailsResponse {
     private int feePerAbsence;
     private int totalAbsenceFee;
     private Boolean isPaidAll;
+    private Boolean isTodayParticipatingDay;
     private Boolean isParticipatedToday;
     private String hostNickname;
     private List<String> enrolledMembersProfileImageList;
@@ -36,6 +37,7 @@ public class ChallengeDetailsResponse {
                 .stopDate(challenge.getStopDate())
                 .numberOfParticipants(challenge.getNumberOfParticipants())
                 .isPaidAll(challenge.isPaidAll())
+                .isTodayParticipatingDay(challenge.isTodayParticipatingDay())
                 .isParticipatedToday(isParticipatedToday)
                 .participatingDays(challenge.getParticipatingDays())
                 .feePerAbsence(challenge.getFeePerAbsence())

--- a/src/test/java/com/habitpay/habitpay/domain/challenge/api/ChallengeApiTest.java
+++ b/src/test/java/com/habitpay/habitpay/domain/challenge/api/ChallengeApiTest.java
@@ -212,6 +212,7 @@ public class ChallengeApiTest extends AbstractRestDocsTests {
                 .enrolledMembersProfileImageList(List.of("imageLink1", "imageLink2", "imageLink3"))
                 .isHost(true)
                 .isMemberEnrolledInChallenge(true)
+                .isTodayParticipatingDay(true)
                 .isParticipatedToday(true)
                 .build();
 
@@ -244,6 +245,7 @@ public class ChallengeApiTest extends AbstractRestDocsTests {
                                 fieldWithPath("data.enrolledMembersProfileImageList").description("챌린지 참여자 프로필 이미지 (최대 3명)"),
                                 fieldWithPath("data.isHost").description("현재 접속한 사용자 == 챌린지 주최자"),
                                 fieldWithPath("data.isMemberEnrolledInChallenge").description("현재 접속한 사용자의 챌린지 참여 여부"),
+                                fieldWithPath("data.isTodayParticipatingDay").description("금일이 챌린지 참여일인지 여부"),
                                 fieldWithPath("data.isParticipatedToday").description("현재 접속한 사용자가 챌린지의 참가자일 경우, 금일 참여했는지 여부(참가자가 아니어도 false)")
                         )
                 ));


### PR DESCRIPTION
### 작업 내용

* 이전 커밋을 푸쉬 안 하고 누락한 채 풀리퀘를 하여서 수습했습니다.

```java
// ChallengeDetailsResponse.java

public class ChallengeDetailsResponse {
  ...
  private Boolean isTodayParticipatingDay;
  ...
}
```

* 위의 속성을 추가하고 관련 코드와 테스트 코드를 수정했습니다.