### PR TITLE
[feat] 스케쥴러 서비스 메서드에 타임존 컨터버 적용하기 #281

### DIFF
--- a/src/main/java/com/habitpay/habitpay/domain/challengeparticipationrecord/application/ChallengeParticipationRecordSearchService.java
+++ b/src/main/java/com/habitpay/habitpay/domain/challengeparticipationrecord/application/ChallengeParticipationRecordSearchService.java
@@ -6,6 +6,7 @@ import com.habitpay.habitpay.domain.challengeparticipationrecord.dao.ChallengePa
 import com.habitpay.habitpay.domain.challengeparticipationrecord.domain.ChallengeParticipationRecord;
 import com.habitpay.habitpay.domain.challengeparticipationrecord.exception.MandatoryRecordNotFoundException;
 import com.habitpay.habitpay.domain.challengeparticipationrecord.exception.RecordNotFoundException;
+import com.habitpay.habitpay.global.config.timezone.TimeZoneConverter;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
@@ -32,7 +33,7 @@ public class ChallengeParticipationRecordSearchService {
     }
 
     public boolean hasParticipationPostForToday(ChallengeEnrollment challengeEnrollment) {
-        ZonedDateTime startOfToday = ZonedDateTime.now().withZoneSameInstant(ZoneId.of("Asia/Seoul")).with(LocalTime.MIDNIGHT);
+        ZonedDateTime startOfToday = TimeZoneConverter.convertEtcToLocalTimeZone(ZonedDateTime.now()).with(LocalTime.MIDNIGHT);
 
         return challengeParticipationRecordRepository.findByChallengeEnrollmentAndTargetDate(challengeEnrollment, startOfToday)
                 .map(ChallengeParticipationRecord::existsChallengePost)

--- a/src/main/java/com/habitpay/habitpay/domain/challengescheduler/application/ChallengeSchedulerService.java
+++ b/src/main/java/com/habitpay/habitpay/domain/challengescheduler/application/ChallengeSchedulerService.java
@@ -53,8 +53,8 @@ public class ChallengeSchedulerService {
 
     @Scheduled(cron = "0 0 0 * * *", zone = "Asia/Seoul")
     public void setChallengeForEnd() {
-
-        ZonedDateTime yesterday = ZonedDateTime.now().minusDays(1);
+        ZonedDateTime today = TimeZoneConverter.convertEtcToLocalTimeZone(ZonedDateTime.now());
+        ZonedDateTime yesterday = today.minusDays(1);
         List<Challenge> challengeList = schedulerTaskHelperService.findEndingChallenges(yesterday);
         challengeList.forEach(Challenge::setStateCompletedPendingSettlement);
         challengeRepository.saveAll(challengeList);

--- a/src/main/java/com/habitpay/habitpay/domain/challengescheduler/application/ChallengeSchedulerService.java
+++ b/src/main/java/com/habitpay/habitpay/domain/challengescheduler/application/ChallengeSchedulerService.java
@@ -9,6 +9,7 @@ import com.habitpay.habitpay.domain.challengeparticipationrecord.dao.ChallengePa
 import com.habitpay.habitpay.domain.challengeparticipationrecord.domain.ChallengeParticipationRecord;
 import com.habitpay.habitpay.domain.participationstat.dao.ParticipationStatRepository;
 import com.habitpay.habitpay.domain.participationstat.domain.ParticipationStat;
+import com.habitpay.habitpay.global.config.timezone.TimeZoneConverter;
 import lombok.RequiredArgsConstructor;
 import org.springframework.scheduling.annotation.Scheduled;
 import org.springframework.stereotype.Service;
@@ -41,7 +42,8 @@ public class ChallengeSchedulerService {
     @Scheduled(cron = "0 0 0 * * *", zone = "Asia/Seoul")
     public void checkParticipationForChallenge() {
 
-        ZonedDateTime yesterday = ZonedDateTime.now().minusDays(1).with(LocalTime.MIDNIGHT);
+        ZonedDateTime today = TimeZoneConverter.convertEtcToLocalTimeZone(ZonedDateTime.now());
+        ZonedDateTime yesterday = today.minusDays(1).with(LocalTime.MIDNIGHT);
         List<Challenge> challengeList = schedulerTaskHelperService.findChallengesForTodayParticipation(yesterday);
 
         if (challengeList.isEmpty()) { return; }

--- a/src/main/java/com/habitpay/habitpay/domain/challengescheduler/application/SchedulerTaskHelperService.java
+++ b/src/main/java/com/habitpay/habitpay/domain/challengescheduler/application/SchedulerTaskHelperService.java
@@ -10,6 +10,7 @@ import com.habitpay.habitpay.domain.challengeparticipationrecord.dao.ChallengePa
 import com.habitpay.habitpay.domain.challengeparticipationrecord.domain.ChallengeParticipationRecord;
 import com.habitpay.habitpay.domain.participationstat.dao.ParticipationStatRepository;
 import com.habitpay.habitpay.domain.participationstat.domain.ParticipationStat;
+import com.habitpay.habitpay.global.config.timezone.TimeZoneConverter;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 
@@ -31,10 +32,9 @@ public class SchedulerTaskHelperService {
     private final ChallengeParticipationRecordSearchService challengeParticipationRecordSearchService;
 
     public List<Challenge> findStartingChallenges() {
-        // todo : 시간대 확인
-        ZoneId zoneId = ZoneId.systemDefault();
-        ZonedDateTime startOfDay = ZonedDateTime.now(zoneId).toLocalDate().atStartOfDay(zoneId);
-        ZonedDateTime endOfDay = ZonedDateTime.now(zoneId).toLocalDate().atTime(LocalTime.MAX).atZone(zoneId);
+        ZonedDateTime today = TimeZoneConverter.convertEtcToLocalTimeZone(ZonedDateTime.now());
+        ZonedDateTime startOfDay = today.toLocalDate().atStartOfDay(today.getZone());
+        ZonedDateTime endOfDay = today.toLocalDate().atTime(LocalTime.MAX).atZone(today.getZone());
 
         return challengeRepository.findAllByStartDateBetweenAndState(startOfDay, endOfDay, ChallengeState.SCHEDULED);
     }


### PR DESCRIPTION
### 개요

* 스케쥴러 서비스 메서드에 타임존 컨터버 메서드(`ETC` -> `Asia/Seoul`)를 적용했습니다.
* `요일 비교`나 `서울 시간대 기준 작업`이 필요한 경우에 한해서입니다.

---

### 주요 내용

* 시간대를 수동으로 설정하던 부분을 메서드 사용으로 바꿨습니다.

```java
ZonedDateTime startOfToday = ZonedDateTime.now().withZoneSameInstant(ZoneId.of("Asia/Seoul")).with(LocalTime.MIDNIGHT);

=>
ZonedDateTime startOfToday = TimeZoneConverter.convertEtcToLocalTimeZone(ZonedDateTime.now()).with(LocalTime.MIDNIGHT);

```

* DB에 데이터 조회가 필요한 경우에 데이터를 서울 시간대로 변경하였습니다.

```java
ZonedDateTime yesterday = ZonedDateTime.now().minusDays(1).with(LocalTime.MIDNIGHT);

=>
ZonedDateTime today = TimeZoneConverter.convertEtcToLocalTimeZone(ZonedDateTime.now());
ZonedDateTime yesterday = today.minusDays(1).with(LocalTime.MIDNIGHT);
```