### PR TITLE
[fix] 스케쥴러 서비스 메서드 : 매일 챌린지 참여 검사 시, totalAbsenceFee가 제대로 합산되지 않는 로직 수정 #292

### DIFF
--- a/src/main/java/com/habitpay/habitpay/domain/challengescheduler/application/SchedulerTaskHelperService.java
+++ b/src/main/java/com/habitpay/habitpay/domain/challengescheduler/application/SchedulerTaskHelperService.java
@@ -18,7 +18,9 @@ import java.time.DayOfWeek;
 import java.time.LocalTime;
 import java.time.ZonedDateTime;
 import java.util.ArrayList;
+import java.util.HashMap;
 import java.util.List;
+import java.util.Map;
 
 @Service
 @RequiredArgsConstructor
@@ -72,36 +74,56 @@ public class SchedulerTaskHelperService {
     }
 
     public void checkFailedParticipation(List<Challenge> challengeList, ZonedDateTime yesterday) {
-        List<Challenge> feeAddedChallengeList = new ArrayList<>();
-        List<ParticipationStat> failStatList = new ArrayList<>();
-        List<ChallengeParticipationRecord> failRecordList = new ArrayList<>();
+        HashMap<Challenge, Integer> challengeFailureCountMap = new HashMap<>();
+        List<ParticipationStat> failureStatList = new ArrayList<>();
+        List<ChallengeParticipationRecord> failureRecordList = new ArrayList<>();
 
         challengeParticipationRecordSearchService.findByChallengesAndTargetDate(challengeList, yesterday)
                 .forEach(record -> {
                     if (!record.existsChallengePost()) {
                         ParticipationStat stat = record.getParticipationStat();
-                        Challenge challenge = getChallengeInList(feeAddedChallengeList, record.getChallenge());
+                        Challenge challenge = record.getChallenge();
+
+                        setFailureCountInChallengeMap(challengeFailureCountMap, challenge);
                         stat.setFailureCount(stat.getFailureCount() + 1);
                         stat.setTotalFee(stat.getTotalFee() + challenge.getFeePerAbsence());
-                        challenge.setTotalAbsenceFee(challenge.getTotalAbsenceFee() + challenge.getFeePerAbsence());
-                        failStatList.add(record.getParticipationStat());
-                        failRecordList.add(record);
+
+                        failureStatList.add(record.getParticipationStat());
+                        failureRecordList.add(record);
                     }
                 });
 
-        participationStatRepository.saveAll(failStatList);
-        challengeParticipationRecordRepository.deleteAll(failRecordList);
+        List<Challenge> feeAddedChallengeList = calculateFeeForChallenges(challengeFailureCountMap);
+
+        participationStatRepository.saveAll(failureStatList);
+        challengeParticipationRecordRepository.deleteAll(failureRecordList);
         challengeRepository.saveAll(feeAddedChallengeList);
     }
 
-    private Challenge getChallengeInList(List<Challenge> challengeList, Challenge challenge) {
-        int index = challengeList.indexOf(challenge);
-        if (index != -1) {
-            return challengeList.get(index);
+    private void setFailureCountInChallengeMap(HashMap<Challenge, Integer> challengeFailureCountMap, Challenge challenge) {
+        if (challengeFailureCountMap.containsKey(challenge)) {
+            int currentFailures = challengeFailureCountMap.get(challenge);
+            challengeFailureCountMap.put(challenge, currentFailures + 1);
         } else {
-            challengeList.add(challenge);
-            return challenge;
+            challengeFailureCountMap.put(challenge, 1);
         }
+    }
+
+    private List<Challenge> calculateFeeForChallenges(HashMap<Challenge, Integer> challengeFailureCountMap) {
+        List<Challenge> feeAddedChallengeList = new ArrayList<>();
+
+        for (Map.Entry<Challenge, Integer> entry : challengeFailureCountMap.entrySet()) {
+            Challenge challenge = entry.getKey();
+            Integer failureCount = entry.getValue();
+
+            int feePerAbsence = challenge.getFeePerAbsence();
+            int currentTotalAbsenceFee = challenge.getTotalAbsenceFee();
+            challenge.setTotalAbsenceFee(currentTotalAbsenceFee + (feePerAbsence * failureCount));
+
+            feeAddedChallengeList.add(challenge);
+        }
+
+        return feeAddedChallengeList;
     }
 
     public List<Challenge> findEndingChallenges(ZonedDateTime targetDay) {

--- a/src/main/java/com/habitpay/habitpay/domain/challengescheduler/application/SchedulerTaskHelperService.java
+++ b/src/main/java/com/habitpay/habitpay/domain/challengescheduler/application/SchedulerTaskHelperService.java
@@ -16,7 +16,6 @@ import org.springframework.stereotype.Service;
 
 import java.time.DayOfWeek;
 import java.time.LocalTime;
-import java.time.ZoneId;
 import java.time.ZonedDateTime;
 import java.util.ArrayList;
 import java.util.List;
@@ -81,13 +80,12 @@ public class SchedulerTaskHelperService {
                 .forEach(record -> {
                     if (!record.existsChallengePost()) {
                         ParticipationStat stat = record.getParticipationStat();
-                        Challenge challenge = record.getChallenge();
+                        Challenge challenge = getChallengeInList(feeAddedChallengeList, record.getChallenge());
                         stat.setFailureCount(stat.getFailureCount() + 1);
                         stat.setTotalFee(stat.getTotalFee() + challenge.getFeePerAbsence());
                         challenge.setTotalAbsenceFee(challenge.getTotalAbsenceFee() + challenge.getFeePerAbsence());
                         failStatList.add(record.getParticipationStat());
                         failRecordList.add(record);
-                        saveOrUpdateChallengeList(feeAddedChallengeList, challenge);
                     }
                 });
 
@@ -96,12 +94,13 @@ public class SchedulerTaskHelperService {
         challengeRepository.saveAll(feeAddedChallengeList);
     }
 
-    private void saveOrUpdateChallengeList(List<Challenge> challengeList, Challenge challenge) {
+    private Challenge getChallengeInList(List<Challenge> challengeList, Challenge challenge) {
         int index = challengeList.indexOf(challenge);
         if (index != -1) {
-            challengeList.set(index, challenge);
+            return challengeList.get(index);
         } else {
             challengeList.add(challenge);
+            return challenge;
         }
     }
 


### PR DESCRIPTION
### 개요

* `스케쥴러 서비스`에 매일 챌린지 참여 여부를 검사하고 벌금을 집계하는 메서드가 있습니다.
* 핵심 로직은 `checkFailedParticipation`라는 메서드가 담당하고 있습니다.
* 이 메서드에서 `totalAbsenceFee`를 제대로 집계하지 않는 문제가 있어 코드를 수정했습니다.
* 또한 Challenge 목록을 순회할 때 복잡도를 줄이기 위해, `List` 대신 `HashMap`을 채택했습니다.

---

### 코드 주요 내용

```java
// SchedulerTaskHelperService.java

public void checkFailedParticipation(List<Challenge> challengeList, ZonedDateTime yesterday) {
      HashMap<Challenge, Integer> challengeFailureCountMap = new HashMap<>();
      ...

      challengeParticipationRecordSearchService.findByChallengesAndTargetDate(challengeList, yesterday)
              .forEach(record -> {
                  if (!record.existsChallengePost()) {
                      ...
                      Challenge challenge = record.getChallenge();
                      setFailureCountInChallengeMap(challengeFailureCountMap, challenge);
                      ...
                  }
              });

      List<Challenge> feeAddedChallengeList = calculateFeeForChallenges(challengeFailureCountMap);

      ...
      challengeRepository.saveAll(feeAddedChallengeList);
  }
```

* `HashMap` 타입인 `key : Challenge 객체`, `value : 실패 횟수`를 엔트리로 가진 변수를 추가했습니다.
* 참여 실패 확인된 멤버의 `record`는 `setFailureCountInChallengeMap()` 메서드를 통해 실패 횟수를 더합니다.
* 모든 검사가 끝나면, `calculateFeeForChallenges()`메서드를 통해 `challenge` 별 `실패 횟수`를 반영해 벌금을 집계합니다.
* 마지막으로 변경 값을 `challengeRepository`에 반영합니다.

---

* `setFailureCountInChallengeMap()` 메서드입니다.

```java
private void setFailureCountInChallengeMap(HashMap<Challenge, Integer> challengeFailureCountMap, Challenge challenge) {
    if (challengeFailureCountMap.containsKey(challenge)) {
        int currentFailures = challengeFailureCountMap.get(challenge);
        challengeFailureCountMap.put(challenge, currentFailures + 1);
    } else {
        challengeFailureCountMap.put(challenge, 1);
    }
}
```

* `맵`에 이미 존재하는 `챌린지` `키`라면, `실패 횟수`인 `value`에 `+1`을 더한 값으로 업데이트합니다.
* 아직 `맵`에 없는 `새로운 챌린지`가 들어왔다면, `새로운 키`로 등록하고 (챌린지 내 첫 실패이므로) `value`는 `1`로 설정해줍니다.

---

* `calculateFeeForChallenges()` 메서드입니다.

```java
private List<Challenge> calculateFeeForChallenges(HashMap<Challenge, Integer> challengeFailureCountMap) {
    List<Challenge> feeAddedChallengeList = new ArrayList<>();

    for (Map.Entry<Challenge, Integer> entry : challengeFailureCountMap.entrySet()) {
        Challenge challenge = entry.getKey();
        Integer failureCount = entry.getValue();

        int feePerAbsence = challenge.getFeePerAbsence();
        int currentTotalAbsenceFee = challenge.getTotalAbsenceFee();
        challenge.setTotalAbsenceFee(currentTotalAbsenceFee + (feePerAbsence * failureCount));

        feeAddedChallengeList.add(challenge);
    }

    return feeAddedChallengeList;
}
```

* 인자로 들어온 `challengeFailureCountMap`을 순회합니다.
* 각 `챌린지`에 `실패 횟수`를 반영한 `벌금`을 더합니다.
* 이 `챌린지`를 모아 `repository`가 저장할 수 있도록 `List`에 담아 반환합니다.