### PR TITLE
[refactor] 챌린지 참여 기록을 위한 메서드 리팩토링 #294

### DIFF
--- a/src/main/java/com/habitpay/habitpay/domain/challenge/application/ChallengeRecordsService.java
+++ b/src/main/java/com/habitpay/habitpay/domain/challenge/application/ChallengeRecordsService.java
@@ -39,15 +39,15 @@ public class ChallengeRecordsService {
         recordList
                 .forEach(record -> {
                     LocalDate targetDate = TimeZoneConverter.convertEtcToLocalTimeZone(record.getTargetDate()).toLocalDate();
+                    List<LocalDate> targetList;
                     if (targetDate.isBefore(today)) {
-                        List<LocalDate> targetList = record.existsChallengePost() ? successDayList : failDayList;
-                        targetList.add(targetDate);
+                        targetList = record.existsChallengePost() ? successDayList : failDayList;
                     } else if (targetDate.isEqual(today)) {
-                        List<LocalDate> targetList = record.existsChallengePost() ? successDayList : upcomingDayList;
-                        targetList.add(targetDate);
+                        targetList = record.existsChallengePost() ? successDayList : upcomingDayList;
                     } else {
-                        upcomingDayList.add(targetDate);
+                        targetList = upcomingDayList;
                     }
+                    targetList.add(targetDate);
                 });
 
         return SuccessResponse.of(

--- a/src/main/java/com/habitpay/habitpay/domain/challenge/application/ChallengeRecordsService.java
+++ b/src/main/java/com/habitpay/habitpay/domain/challenge/application/ChallengeRecordsService.java
@@ -16,7 +16,6 @@ import org.springframework.stereotype.Service;
 
 import java.time.LocalDate;
 import java.time.ZonedDateTime;
-import java.util.ArrayList;
 import java.util.List;
 
 @Service
@@ -41,7 +40,7 @@ public class ChallengeRecordsService {
                 SuccessCode.NO_MESSAGE,
                 ChallengeRecordsResponse.builder()
                         .successDayList(challengeRecords.getSuccessDayList())
-                        .failDayList(challengeRecords.getFailDayList())
+                        .failureDayList(challengeRecords.getFailureDayList())
                         .upcomingDayList(challengeRecords.getUpcomingDayList())
                         .build()
         );
@@ -54,7 +53,7 @@ public class ChallengeRecordsService {
             if (record.existsChallengePost()) {
                 challengeRecords.addSuccessDay(targetDate);
             } else {
-                challengeRecords.addFailDay(targetDate);
+                challengeRecords.addFailureDay(targetDate);
             }
         } else if (targetDate.isEqual(today)) {
             if (record.existsChallengePost()) {

--- a/src/main/java/com/habitpay/habitpay/domain/challenge/application/ChallengeRecordsService.java
+++ b/src/main/java/com/habitpay/habitpay/domain/challenge/application/ChallengeRecordsService.java
@@ -1,6 +1,7 @@
 package com.habitpay.habitpay.domain.challenge.application;
 
 import com.habitpay.habitpay.domain.challenge.domain.Challenge;
+import com.habitpay.habitpay.domain.challenge.dto.ChallengeRecords;
 import com.habitpay.habitpay.domain.challenge.dto.ChallengeRecordsResponse;
 import com.habitpay.habitpay.domain.challengeenrollment.application.ChallengeEnrollmentSearchService;
 import com.habitpay.habitpay.domain.challengeenrollment.domain.ChallengeEnrollment;
@@ -30,33 +31,39 @@ public class ChallengeRecordsService {
         Challenge challenge = challengeSearchService.getChallengeById(challengeId);
         ChallengeEnrollment enrollment = challengeEnrollmentSearchService.getByMemberAndChallenge(member, challenge);
 
-        List<LocalDate> successDayList = new ArrayList<>();
-        List<LocalDate> failDayList = new ArrayList<>();
-        List<LocalDate> upcomingDayList = new ArrayList<>();
-
+        ChallengeRecords challengeRecords = new ChallengeRecords();
         List<ChallengeParticipationRecord> recordList = challengeParticipationRecordSearchService.findAllByChallengeEnrollment(enrollment);
         LocalDate today = TimeZoneConverter.convertEtcToLocalTimeZone(ZonedDateTime.now()).toLocalDate();
-        recordList
-                .forEach(record -> {
-                    LocalDate targetDate = TimeZoneConverter.convertEtcToLocalTimeZone(record.getTargetDate()).toLocalDate();
-                    List<LocalDate> targetList;
-                    if (targetDate.isBefore(today)) {
-                        targetList = record.existsChallengePost() ? successDayList : failDayList;
-                    } else if (targetDate.isEqual(today)) {
-                        targetList = record.existsChallengePost() ? successDayList : upcomingDayList;
-                    } else {
-                        targetList = upcomingDayList;
-                    }
-                    targetList.add(targetDate);
-                });
+
+        recordList.forEach(record -> categorizeRecord(record, today, challengeRecords));
 
         return SuccessResponse.of(
                 SuccessCode.NO_MESSAGE,
                 ChallengeRecordsResponse.builder()
-                        .successDayList(successDayList)
-                        .failDayList(failDayList)
-                        .upcomingDayList(upcomingDayList)
+                        .successDayList(challengeRecords.getSuccessDayList())
+                        .failDayList(challengeRecords.getFailDayList())
+                        .upcomingDayList(challengeRecords.getUpcomingDayList())
                         .build()
         );
+    }
+
+    private void categorizeRecord(ChallengeParticipationRecord record, LocalDate today, ChallengeRecords challengeRecords) {
+        LocalDate targetDate = TimeZoneConverter.convertEtcToLocalTimeZone(record.getTargetDate()).toLocalDate();
+
+        if (targetDate.isBefore(today)) {
+            if (record.existsChallengePost()) {
+                challengeRecords.addSuccessDay(targetDate);
+            } else {
+                challengeRecords.addFailDay(targetDate);
+            }
+        } else if (targetDate.isEqual(today)) {
+            if (record.existsChallengePost()) {
+                challengeRecords.addSuccessDay(targetDate);
+            } else {
+                challengeRecords.addUpcomingDay(targetDate);
+            }
+        } else {
+            challengeRecords.addUpcomingDay(targetDate);
+        }
     }
 }

--- a/src/main/java/com/habitpay/habitpay/domain/challenge/dto/ChallengeRecords.java
+++ b/src/main/java/com/habitpay/habitpay/domain/challenge/dto/ChallengeRecords.java
@@ -10,15 +10,15 @@ import java.util.List;
 @Setter
 public class ChallengeRecords {
     private List<LocalDate> successDayList;
-    private List<LocalDate> failDayList;
+    private List<LocalDate> failureDayList;
     private List<LocalDate> upcomingDayList;
 
     public void addSuccessDay(LocalDate date) {
         successDayList.add(date);
     }
 
-    public void addFailDay(LocalDate date) {
-        failDayList.add(date);
+    public void addFailureDay(LocalDate date) {
+        failureDayList.add(date);
     }
 
     public void addUpcomingDay(LocalDate date) {

--- a/src/main/java/com/habitpay/habitpay/domain/challenge/dto/ChallengeRecords.java
+++ b/src/main/java/com/habitpay/habitpay/domain/challenge/dto/ChallengeRecords.java
@@ -1,9 +1,11 @@
 package com.habitpay.habitpay.domain.challenge.dto;
 
 import lombok.Getter;
+import lombok.RequiredArgsConstructor;
 import lombok.Setter;
 
 import java.time.LocalDate;
+import java.util.ArrayList;
 import java.util.List;
 
 @Getter
@@ -12,6 +14,12 @@ public class ChallengeRecords {
     private List<LocalDate> successDayList;
     private List<LocalDate> failureDayList;
     private List<LocalDate> upcomingDayList;
+
+    public ChallengeRecords() {
+        successDayList = new ArrayList<>();
+        failureDayList = new ArrayList<>();
+        upcomingDayList = new ArrayList<>();
+    }
 
     public void addSuccessDay(LocalDate date) {
         successDayList.add(date);

--- a/src/main/java/com/habitpay/habitpay/domain/challenge/dto/ChallengeRecords.java
+++ b/src/main/java/com/habitpay/habitpay/domain/challenge/dto/ChallengeRecords.java
@@ -1,0 +1,27 @@
+package com.habitpay.habitpay.domain.challenge.dto;
+
+import lombok.Getter;
+import lombok.Setter;
+
+import java.time.LocalDate;
+import java.util.List;
+
+@Getter
+@Setter
+public class ChallengeRecords {
+    private List<LocalDate> successDayList;
+    private List<LocalDate> failDayList;
+    private List<LocalDate> upcomingDayList;
+
+    public void addSuccessDay(LocalDate date) {
+        successDayList.add(date);
+    }
+
+    public void addFailDay(LocalDate date) {
+        failDayList.add(date);
+    }
+
+    public void addUpcomingDay(LocalDate date) {
+        upcomingDayList.add(date);
+    }
+}

--- a/src/main/java/com/habitpay/habitpay/domain/challenge/dto/ChallengeRecordsResponse.java
+++ b/src/main/java/com/habitpay/habitpay/domain/challenge/dto/ChallengeRecordsResponse.java
@@ -9,7 +9,7 @@ import java.util.List;
 @Getter
 @Builder
 public class ChallengeRecordsResponse {
-    List<LocalDate> successDayList;
-    List<LocalDate> failureDayList;
-    List<LocalDate> upcomingDayList;
+    private List<LocalDate> successDayList;
+    private List<LocalDate> failureDayList;
+    private List<LocalDate> upcomingDayList;
 }

--- a/src/main/java/com/habitpay/habitpay/domain/challenge/dto/ChallengeRecordsResponse.java
+++ b/src/main/java/com/habitpay/habitpay/domain/challenge/dto/ChallengeRecordsResponse.java
@@ -4,13 +4,12 @@ import lombok.Builder;
 import lombok.Getter;
 
 import java.time.LocalDate;
-import java.time.ZonedDateTime;
 import java.util.List;
 
 @Getter
 @Builder
 public class ChallengeRecordsResponse {
     List<LocalDate> successDayList;
-    List<LocalDate> failDayList;
+    List<LocalDate> failureDayList;
     List<LocalDate> upcomingDayList;
 }

--- a/src/test/java/com/habitpay/habitpay/domain/challenge/api/ChallengeApiTest.java
+++ b/src/test/java/com/habitpay/habitpay/domain/challenge/api/ChallengeApiTest.java
@@ -293,7 +293,7 @@ public class ChallengeApiTest extends AbstractRestDocsTests {
         LocalDate today = LocalDate.now();
         ChallengeRecordsResponse challengeRecordsResponse = ChallengeRecordsResponse.builder()
                 .successDayList(List.of(today))
-                .failDayList(new ArrayList<>())
+                .failureDayList(new ArrayList<>())
                 .upcomingDayList(List.of(today.plusWeeks(1)))
                 .build();
 

--- a/src/test/java/com/habitpay/habitpay/domain/challenge/api/ChallengeApiTest.java
+++ b/src/test/java/com/habitpay/habitpay/domain/challenge/api/ChallengeApiTest.java
@@ -313,7 +313,7 @@ public class ChallengeApiTest extends AbstractRestDocsTests {
                         responseFields(
                                 fieldWithPath("message").description("메세지"),
                                 fieldWithPath("data.successDayList").description("특정 챌린지 참여에 성공한 날짜 리스트"),
-                                fieldWithPath("data.failDayList").description("특정 챌린지 참여에 실패한 날짜 리스트"),
+                                fieldWithPath("data.failureDayList").description("특정 챌린지 참여에 실패한 날짜 리스트"),
                                 fieldWithPath("data.upcomingDayList").description("특정 챌린지 참여가 예정되어 있는 날짜 리스트")
                         )
                 ));


### PR DESCRIPTION
### 개요

* 챌린지 별 참여 기록 데이터를 생성하는 `ChallengeRecordsService` 클래스를 중심으로 서비스 메서드는 비즈니스 로직에 집중하도록 리팩토링했습니다.

---

### 코드 주요 내용

* `챌린지 별 참여 기록` 데이터에는 `성공 날짜 목록`, `실패 날짜 목록`, `다가오는 날짜 목록`의 세 요소가 존재합니다.
* 이 세 요소를 관리하기 위한 `ChallengeRecords DTO`가 추가됐습니다.

```java
// ChallengeRecords.java

public class ChallengeRecords {
    private List<LocalDate> successDayList;
    private List<LocalDate> failureDayList;
    private List<LocalDate> upcomingDayList;

    public ChallengeRecords() {
        successDayList = new ArrayList<>();
        failureDayList = new ArrayList<>();
        upcomingDayList = new ArrayList<>();
    }

    public void addSuccessDay(LocalDate date) {
        successDayList.add(date);
    }

    public void addFailureDay(LocalDate date) {
        failureDayList.add(date);
    }

    public void addUpcomingDay(LocalDate date) {
        upcomingDayList.add(date);
    }
}
```

---

* 위의 DTO를 활용해 비즈니스 로직을 리팩토링했습니다.

```java
// ChallengeRecordsService.java

public SuccessResponse<ChallengeRecordsResponse> getChallengeRecords(Long challengeId, Member member) {
    ...

    ChallengeRecords challengeRecords = new ChallengeRecords();
    List<ChallengeParticipationRecord> recordList = challengeParticipationRecordSearchService.findAllByChallengeEnrollment(enrollment);
    LocalDate today = TimeZoneConverter.convertEtcToLocalTimeZone(ZonedDateTime.now()).toLocalDate();

    recordList.forEach(record -> categorizeRecord(record, today, challengeRecords));

    return SuccessResponse.of(
            SuccessCode.NO_MESSAGE,
            ChallengeRecordsResponse.builder()
                    .successDayList(challengeRecords.getSuccessDayList())
                    .failureDayList(challengeRecords.getFailureDayList())
                    .upcomingDayList(challengeRecords.getUpcomingDayList())
                    .build()
    );
}
```

* `recordList`를 순회하며 `categorizeRecord()` 메서드를 이용해 분류합니다.
*  `categorizeRecord()` 메서드를 통해 분류된 날짜 데이터는 `ChallengeRecords` 내 적절한 목록에 담기게 됩니다.

---

* `categorizeRecord()` 메서드입니다.

```java
private void categorizeRecord(ChallengeParticipationRecord record, LocalDate today, ChallengeRecords challengeRecords) {
    LocalDate targetDate = TimeZoneConverter.convertEtcToLocalTimeZone(record.getTargetDate()).toLocalDate();

    if (targetDate.isBefore(today)) {
        if (record.existsChallengePost()) {
            challengeRecords.addSuccessDay(targetDate);
        } else {
            challengeRecords.addFailureDay(targetDate);
        }
    } else if (targetDate.isEqual(today)) {
        if (record.existsChallengePost()) {
            challengeRecords.addSuccessDay(targetDate);
        } else {
            challengeRecords.addUpcomingDay(targetDate);
        }
    } else {
        challengeRecords.addUpcomingDay(targetDate);
    }
}
```

* `record`의 `성공/실패 여부`, `API 요청일과 날짜 비교` 등을 통해,
   `성공 날짜 목록`, `실패 날짜 목록`, `다가오는 날짜 목록`에 날짜 데이터를 추가합니다.

---

### 기타

* 변수의 의미를 명확히 하기 위해, `fail`을 사용하는 변수명은 `failure`로 교체했습니다.
   (동사 -> 명사)

```java
// ex

failDayList => failureDayList
```

---

* 변수명이 변경되어 관련 테스트 코드를 수정했습니다.