### PR TITLE
[feat] 챌린지 중도포기 api 구현#300

### DIFF
--- a/src/docs/asciidoc/api/challenge.adoc
+++ b/src/docs/asciidoc/api/challenge.adoc
@@ -102,54 +102,6 @@ operation::challenge/patch-challenge-duplicated-description-exception[snippets='
 
 operation::challenge/patch-challenge-forbidden-exception[snippets='http-request,http-response,response-fields']
 
-=== 챌린지 참여자 등록
-
-사용자를 챌린지 참여자에 등록합니다.
-
-operation::challenge/enroll-challenge[snippets='http-request,http-response,response-fields']
-
-==== 에러 응답
-
-===== 챌린지 등록 시간이 지난 경우 (400 Bad Request)
-
-챌린지 시작 시간이 지나고 나서 등록하는 경우입니다.
-
-operation::challenge/enroll-challenge-invalid-registration-time-exception[snippets='http-request,http-response,response-fields']
-
-===== 이미 참여한 챌린지인 경우 (409 Conflict)
-
-이미 챌린지에 등록한 사용자가 다시 챌린지 등록하는 신청한 경우입니다.
-
-operation::challenge/enroll-challenge-already-enrolled-exception[snippets='http-request,http-response,response-fields']
-
-=== 챌린지 등록 취소
-
-등록한 챌린지를 취소합니다.
-
-취소는 챌린지 시작 시간 이전까지만 가능합니다.
-
-operation::challenge/cancel-challenge-enrollment[snippets='http-request,http-response,response-fields']
-
-==== 에러 응답
-
-===== 챌린지 주최자가 등록 취소 하는 경우 (400 Bad Request)
-
-챌린지 주최자는 등록을 취소할 수 없습니다.
-
-operation::challenge/cancel-challenge-enrollment-host-not-allowed-exception[snippets='http-request,http-response,response-fields']
-
-===== 챌린지에 참여하지 않은 경우 (400 Bad Request)
-
-참여하지 않은 챌린지를 취소하는 경우입니다.
-
-operation::challenge/cancel-challenge-enrollment-not-enrolled-exception[snippets='http-request,http-response,response-fields']
-
-===== 챌린지 등록 취소 시간을 지난 경우 (400 Bad Request)
-
-챌린지가 시작하고 나서 등록 취소를 하는 경우입니다.
-
-operation::challenge/cancel-challenge-enrollment-invalid-cancellation-time-exception[snippets='http-request,http-response,response-fields']
-
 === 챌린지 삭제
 
 챌린지를 삭제합니다.

--- a/src/docs/asciidoc/api/challengeEnrollment.adoc
+++ b/src/docs/asciidoc/api/challengeEnrollment.adoc
@@ -1,0 +1,78 @@
+== 챌린지 등록 관련 API
+:doctype: book
+:source-highlighter: highlightjs
+:toc: left
+:toclevels: 2
+:seclinks:
+
+챌린지 등록 관련 API 목록입니다.
+
+=== 챌린지 참여자 등록
+
+사용자를 챌린지 참여자에 등록합니다.
+
+operation::challenge/enroll-challenge[snippets='http-request,http-response,response-fields']
+
+==== 에러 응답
+
+===== 챌린지 등록 시간이 지난 경우 (400 Bad Request)
+
+챌린지 시작 시간이 지나고 나서 등록하는 경우입니다.
+
+operation::challenge/enroll-challenge-invalid-registration-time-exception[snippets='http-request,http-response,response-fields']
+
+===== 이미 참여한 챌린지인 경우 (409 Conflict)
+
+이미 챌린지에 등록한 사용자가 다시 챌린지 등록하는 신청한 경우입니다.
+
+operation::challenge/enroll-challenge-already-enrolled-exception[snippets='http-request,http-response,response-fields']
+
+=== 챌린지 등록 취소
+
+등록한 챌린지를 취소합니다.
+
+취소는 챌린지 시작 시간 이전까지만 가능합니다.
+
+operation::challenge/cancel-challenge-enrollment[snippets='http-request,http-response,response-fields']
+
+==== 에러 응답
+
+===== 챌린지 주최자가 등록 취소 하는 경우 (400 Bad Request)
+
+챌린지 주최자는 등록을 취소할 수 없습니다.
+
+operation::challenge/cancel-challenge-enrollment-host-not-allowed-exception[snippets='http-request,http-response,response-fields']
+
+===== 챌린지에 참여하지 않은 경우 (400 Bad Request)
+
+참여하지 않은 챌린지를 취소하는 경우입니다.
+
+operation::challenge/cancel-challenge-enrollment-not-enrolled-exception[snippets='http-request,http-response,response-fields']
+
+===== 챌린지 등록 취소 시간을 지난 경우 (400 Bad Request)
+
+챌린지가 시작하고 나서 등록 취소를 하는 경우입니다.
+
+operation::challenge/cancel-challenge-enrollment-invalid-cancellation-time-exception[snippets='http-request,http-response,response-fields']
+
+=== 챌린지 중도 포기
+
+시작한 챌린지를 중도 포기합니다.
+
+중도 포기 이후에는 해당 챌린지에 게시물 생성, 수정, 삭제가 불가능 합니다.
+
+operation::challenge/give-up-challenge[snippets='http-request,http-response,response-fields']
+
+==== 에러 응답
+
+===== 챌린지 시작 시간 이전 (400 Bad Request)
+
+이미 중도 포기한 경우 다시 중도 포기 요청을 보낼 수 없습니다.
+
+operation::challenge/giving-up-challenge-too-early-exception[snippets='http-request,http-response,response-fields']
+
+===== 이미 중도 포기한 경우 (400 Bad Request)
+
+이미 중도 포기한 경우 다시 중도 포기 요청을 보낼 수 없습니다.
+
+operation::challenge/already-given-up-challenge-exception[snippets='http-request,http-response,response-fields']

--- a/src/docs/asciidoc/api/challengePost.adoc
+++ b/src/docs/asciidoc/api/challengePost.adoc
@@ -28,9 +28,7 @@ data의 pageable 객체에는 페이지네이션 정보가 담겨있습니다.
 그러나 pageable 객체에 접근하지 않아도 바로 사용할 수 있는 메타 데이터가 추가로 존재합니다.
 
 data에서 content 배열, pageable 객체를 지나면 바로 페이징 메타 데이터가 존재합니다.
-특히 현재 페이지가 마지막 페이지인지 boolean으로 알려주는 "last" 속성이 있으므로,
-이를 활용할 수 있습니다.
-
+특히 현재 페이지가 마지막 페이지인지 boolean으로 알려주는 "last" 속성이 있으므로, 이를 활용할 수 있습니다.
 
 operation::challengePost/get-challenge-posts[snippets='http-request,http-response,response-fields']
 
@@ -55,12 +53,28 @@ operation::challengePost/get-challenge-posts-by-me[snippets='http-request,http-r
 
 operation::challengePost/create-challenge-post[snippets='http-request,http-response,request-fields,response-fields']
 
+==== 에러 응답
+
+===== 중도 포기한 경우 (403 Forbidden)
+
+챌린지를 중도 포기한 이후 게시물을 생성할 수 없습니다.
+
+operation::challenge/challenge-post-creation-forbidden-exception[snippets='http-request,http-response,response-fields']
+
 === 챌린지 포스트 수정
 
 경로 변수로 받은 post의 id값에 해당하는 포스트를 수정합니다.
 수정은 포스트 내용 변경, 공지 포스트 여부 변경과 함께 포스트 내 이미지 파일의 추가, 삭제 및 정렬 순서 변경을 포함합니다.
 
 operation::challengePost/patch-challenge-post[snippets='http-request,http-response,request-fields,response-fields']
+
+==== 에러 응답
+
+===== 중도 포기한 경우 (403 Forbidden)
+
+챌린지를 중도 포기한 이후 게시물을 수정할 수 없습니다.
+
+operation::challenge/challenge-post-modification-forbidden-exception[snippets='http-request,http-response,response-fields']
 
 === 챌린지 포스트 삭제
 
@@ -69,3 +83,11 @@ operation::challengePost/patch-challenge-post[snippets='http-request,http-respon
 공지 포스트만 챌린지 호스트가 삭제할 수 있습니다.
 
 operation::challengePost/delete-challenge-post[snippets='http-request,http-response,response-fields']
+
+==== 에러 응답
+
+===== 중도 포기한 경우 (403 Forbidden)
+
+챌린지를 중도 포기한 이후 게시물을 삭제할 수 없습니다.
+
+operation::challenge/challenge-post-deletion-forbidden-exception[snippets='http-request,http-response,response-fields']

--- a/src/docs/asciidoc/index.adoc
+++ b/src/docs/asciidoc/index.adoc
@@ -7,6 +7,7 @@
 
 include::api/member.adoc[]
 include::api/challenge.adoc[]
+include::api/challengeEnrollment.adoc[]
 include::api/challengePost.adoc[]
 include::api/refreshToken.adoc[]
 include::api/challengeAbsenceFee.adoc[]

--- a/src/main/java/com/habitpay/habitpay/domain/challenge/domain/Challenge.java
+++ b/src/main/java/com/habitpay/habitpay/domain/challenge/domain/Challenge.java
@@ -130,7 +130,7 @@ public class Challenge extends BaseTime {
         // 2. 챌린지 총 참여 일수 계산
         ZonedDateTime date = challengeCreationRequest.getStartDate();
         ZonedDateTime endDate = challengeCreationRequest.getEndDate();
-        while (date.isBefore(endDate)) {
+        while (date.isBefore(endDate) || date.isEqual(endDate)) {
             if (daysOfParticipatingDays.contains(date.getDayOfWeek())) {
                 count += 1;
             }
@@ -148,7 +148,9 @@ public class Challenge extends BaseTime {
         this.numberOfParticipants = numberOfParticipants;
     }
 
-    public void setTotalAbsenceFee(int value) { this.totalAbsenceFee = value; }
+    public void setTotalAbsenceFee(int value) {
+        this.totalAbsenceFee = value;
+    }
 
     public void setStateInProgress() {
         this.state = ChallengeState.IN_PROGRESS;

--- a/src/main/java/com/habitpay/habitpay/domain/challengeenrollment/api/ChallengeEnrollmentApi.java
+++ b/src/main/java/com/habitpay/habitpay/domain/challengeenrollment/api/ChallengeEnrollmentApi.java
@@ -31,4 +31,8 @@ public class ChallengeEnrollmentApi {
         return challengeEnrollmentCancellationService.cancel(id, user.getMember());
     }
 
+    @PostMapping("/challenges/{id}/give-up")
+    public SuccessResponse<Void> giveUpChallenge(@PathVariable("id") Long id, @AuthenticationPrincipal CustomUserDetails user) {
+        return challengeEnrollmentCancellationService.giveUp(id, user.getMember());
+    }
 }

--- a/src/main/java/com/habitpay/habitpay/domain/challengeenrollment/application/ChallengeEnrollmentCancellationService.java
+++ b/src/main/java/com/habitpay/habitpay/domain/challengeenrollment/application/ChallengeEnrollmentCancellationService.java
@@ -4,8 +4,11 @@ import com.habitpay.habitpay.domain.challenge.application.ChallengeSearchService
 import com.habitpay.habitpay.domain.challenge.domain.Challenge;
 import com.habitpay.habitpay.domain.challengeenrollment.dao.ChallengeEnrollmentRepository;
 import com.habitpay.habitpay.domain.challengeenrollment.domain.ChallengeEnrollment;
+import com.habitpay.habitpay.domain.challengeenrollment.exception.AlreadyGivenUpChallengeException;
 import com.habitpay.habitpay.domain.challengeenrollment.exception.NotEnrolledChallengeException;
+import com.habitpay.habitpay.domain.challengeparticipationrecord.dao.ChallengeParticipationRecordRepository;
 import com.habitpay.habitpay.domain.member.domain.Member;
+import com.habitpay.habitpay.global.config.timezone.TimeZoneConverter;
 import com.habitpay.habitpay.global.error.exception.BadRequestException;
 import com.habitpay.habitpay.global.error.exception.ErrorCode;
 import com.habitpay.habitpay.global.response.SuccessCode;
@@ -15,6 +18,7 @@ import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
 
+import java.time.LocalTime;
 import java.time.ZonedDateTime;
 
 @Slf4j
@@ -22,7 +26,9 @@ import java.time.ZonedDateTime;
 @RequiredArgsConstructor
 public class ChallengeEnrollmentCancellationService {
     private final ChallengeEnrollmentRepository challengeEnrollmentRepository;
+    private final ChallengeParticipationRecordRepository challengeParticipationRecordRepository;
     private final ChallengeSearchService challengeSearchService;
+    private final ChallengeEnrollmentSearchService challengeEnrollmentSearchService;
 
     @Transactional
     public SuccessResponse<Void> cancel(Long challengeId, Member member) {
@@ -37,7 +43,7 @@ public class ChallengeEnrollmentCancellationService {
 
         challenge.setNumberOfParticipants(challenge.getNumberOfParticipants() - 1);
         challengeEnrollmentRepository.delete(challengeEnrollment);
-        return SuccessResponse.<Void>of(SuccessCode.CANCEL_CHALLENGE_ENROLLMENT_SUCCESS);
+        return SuccessResponse.of(SuccessCode.CANCEL_CHALLENGE_ENROLLMENT_SUCCESS);
     }
 
     private void validateCancellationTime(Challenge challenge) {
@@ -52,6 +58,30 @@ public class ChallengeEnrollmentCancellationService {
         if (host.getId().equals(member.getId())) {
             throw new BadRequestException(ErrorCode.NOT_ALLOWED_TO_CANCEL_ENROLLMENT_OF_HOST);
         }
+    }
+
+    @Transactional
+    public SuccessResponse<Void> giveUp(Long challengeId, Member member) {
+
+        Challenge challenge = challengeSearchService.getChallengeById(challengeId);
+        ChallengeEnrollment challengeEnrollment = challengeEnrollmentSearchService.getByMemberAndChallenge(member, challenge);
+        ZonedDateTime now = TimeZoneConverter.convertEtcToLocalTimeZone(ZonedDateTime.now());
+
+        if (now.isBefore(challenge.getStartDate())) {
+            throw new BadRequestException(ErrorCode.TOO_EARLY_GIVEN_UP_CHALLENGE);
+        }
+
+        if (challengeEnrollment.isGivenUp()) {
+            throw new AlreadyGivenUpChallengeException(member.getId(), challengeId);
+        }
+
+        challengeEnrollment.setGivenUp(true);
+
+        challenge.setNumberOfParticipants(challenge.getNumberOfParticipants() - 1);
+
+        challengeParticipationRecordRepository.deleteAllByChallengeEnrollmentAndTargetDateAfterOrTargetDate(challengeEnrollment, now.with(LocalTime.MIDNIGHT));
+
+        return SuccessResponse.of(SuccessCode.GIVING_UP_CHALLENGE);
     }
 
 }

--- a/src/main/java/com/habitpay/habitpay/domain/challengeenrollment/exception/AlreadyGivenUpChallengeException.java
+++ b/src/main/java/com/habitpay/habitpay/domain/challengeenrollment/exception/AlreadyGivenUpChallengeException.java
@@ -8,7 +8,7 @@ public class AlreadyGivenUpChallengeException extends BadRequestException {
     public AlreadyGivenUpChallengeException(Long memberId, Long challengeId) {
         super(
                 String.format("[Member: %d] is already given up [Challenge: %d]", memberId, challengeId),
-                ErrorCode.ALREADY_ENROLLED_IN_CHALLENGE
+                ErrorCode.ALREADY_GIVEN_UP_CHALLENGE
         );
     }
 }

--- a/src/main/java/com/habitpay/habitpay/domain/challengeenrollment/exception/AlreadyGivenUpChallengeException.java
+++ b/src/main/java/com/habitpay/habitpay/domain/challengeenrollment/exception/AlreadyGivenUpChallengeException.java
@@ -1,0 +1,14 @@
+package com.habitpay.habitpay.domain.challengeenrollment.exception;
+
+import com.habitpay.habitpay.global.error.exception.BadRequestException;
+import com.habitpay.habitpay.global.error.exception.ErrorCode;
+
+public class AlreadyGivenUpChallengeException extends BadRequestException {
+
+    public AlreadyGivenUpChallengeException(Long memberId, Long challengeId) {
+        super(
+                String.format("[Member: %d] is already given up [Challenge: %d]", memberId, challengeId),
+                ErrorCode.ALREADY_ENROLLED_IN_CHALLENGE
+        );
+    }
+}

--- a/src/main/java/com/habitpay/habitpay/domain/challengeparticipationrecord/dao/ChallengeParticipationRecordRepository.java
+++ b/src/main/java/com/habitpay/habitpay/domain/challengeparticipationrecord/dao/ChallengeParticipationRecordRepository.java
@@ -4,9 +4,10 @@ import com.habitpay.habitpay.domain.challenge.domain.Challenge;
 import com.habitpay.habitpay.domain.challengeenrollment.domain.ChallengeEnrollment;
 import com.habitpay.habitpay.domain.challengeparticipationrecord.domain.ChallengeParticipationRecord;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Modifying;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 
-import java.time.LocalDate;
-import java.time.LocalDateTime;
 import java.time.ZonedDateTime;
 import java.util.Collection;
 import java.util.List;
@@ -21,4 +22,8 @@ public interface ChallengeParticipationRecordRepository extends JpaRepository<Ch
     Optional<ChallengeParticipationRecord> findByChallengeEnrollmentAndTargetDate(ChallengeEnrollment challengeEnrollment, ZonedDateTime startOfTargetDate);
 
     List<ChallengeParticipationRecord> findByChallengeInAndTargetDate(Collection<Challenge> challenge, ZonedDateTime startOfTargetDate);
+
+    @Modifying
+    @Query("DELETE FROM ChallengeParticipationRecord r WHERE r.challengeEnrollment = :challengeEnrollment AND (r.targetDate > :date OR r.targetDate = :date)")
+    void deleteAllByChallengeEnrollmentAndTargetDateAfterOrTargetDate(@Param("challengeEnrollment") ChallengeEnrollment challengeEnrollment, @Param("date") ZonedDateTime date);
 }

--- a/src/main/java/com/habitpay/habitpay/domain/challengepost/api/ChallengePostApi.java
+++ b/src/main/java/com/habitpay/habitpay/domain/challengepost/api/ChallengePostApi.java
@@ -75,7 +75,7 @@ public class ChallengePostApi {
 //    }
     // -------------------------------------------------------------------------------
 
-    @PostMapping("/challenges/{id}/post")
+    @PostMapping("/challenges/{id}/posts")
     public SuccessResponse<List<String>> createPost(
             @RequestBody AddPostRequest request,
             @PathVariable("id") Long id,

--- a/src/main/java/com/habitpay/habitpay/domain/challengepost/api/ChallengePostApi.java
+++ b/src/main/java/com/habitpay/habitpay/domain/challengepost/api/ChallengePostApi.java
@@ -1,6 +1,9 @@
 package com.habitpay.habitpay.domain.challengepost.api;
 
-import com.habitpay.habitpay.domain.challengepost.application.*;
+import com.habitpay.habitpay.domain.challengepost.application.ChallengePostCreationService;
+import com.habitpay.habitpay.domain.challengepost.application.ChallengePostDeleteService;
+import com.habitpay.habitpay.domain.challengepost.application.ChallengePostSearchService;
+import com.habitpay.habitpay.domain.challengepost.application.ChallengePostUpdateService;
 import com.habitpay.habitpay.domain.challengepost.dto.AddPostRequest;
 import com.habitpay.habitpay.domain.challengepost.dto.ModifyPostRequest;
 import com.habitpay.habitpay.domain.challengepost.dto.PostViewResponse;
@@ -75,7 +78,7 @@ public class ChallengePostApi {
     @PostMapping("/challenges/{id}/post")
     public SuccessResponse<List<String>> createPost(
             @RequestBody AddPostRequest request,
-            @PathVariable Long id,
+            @PathVariable("id") Long id,
             @AuthenticationPrincipal CustomUserDetails user) {
 
         return challengePostCreationService.createPost(request, id, user.getMember());

--- a/src/main/java/com/habitpay/habitpay/domain/challengepost/api/ChallengePostApi.java
+++ b/src/main/java/com/habitpay/habitpay/domain/challengepost/api/ChallengePostApi.java
@@ -92,10 +92,12 @@ public class ChallengePostApi {
         return challengePostUpdateService.patchPost(request, challengeId, postId, user.getMember());
     }
 
-    @DeleteMapping("/posts/{id}")
+    @DeleteMapping("/challenges/{challengeId}/posts/{postId}")
     public SuccessResponse<Void> deletePost(
-            @PathVariable Long id, @AuthenticationPrincipal CustomUserDetails user) {
+            @PathVariable("challengeId") Long challengeId,
+            @PathVariable("postId") Long postId,
+            @AuthenticationPrincipal CustomUserDetails user) {
 
-        return challengePostDeleteService.deletePost(id, user.getMember());
+        return challengePostDeleteService.deletePost(challengeId, postId, user.getMember());
     }
 }

--- a/src/main/java/com/habitpay/habitpay/domain/challengepost/api/ChallengePostApi.java
+++ b/src/main/java/com/habitpay/habitpay/domain/challengepost/api/ChallengePostApi.java
@@ -39,7 +39,7 @@ public class ChallengePostApi {
 
     @GetMapping("/challenges/{id}/posts")
     public SuccessResponse<Slice<PostViewResponse>> getChallengePosts(
-            @PathVariable Long id,
+            @PathVariable("id") Long id,
             @PageableDefault(sort = "id", direction = Sort.Direction.DESC) Pageable pageable) {
 
         return challengePostSearchService.findPostViewListByChallengeId(id, pageable);
@@ -80,15 +80,16 @@ public class ChallengePostApi {
             @RequestBody AddPostRequest request,
             @PathVariable("id") Long id,
             @AuthenticationPrincipal CustomUserDetails user) {
-
         return challengePostCreationService.createPost(request, id, user.getMember());
     }
 
-    @PatchMapping("/posts/{id}")
+    @PatchMapping("/challenges/{challengeId}/posts/{postId}")
     public SuccessResponse<List<String>> patchPost(
-            @RequestBody ModifyPostRequest request, @PathVariable Long id, @AuthenticationPrincipal CustomUserDetails user) {
+            @RequestBody ModifyPostRequest request, @PathVariable("challengeId") Long challengeId,
+            @PathVariable("postId") Long postId,
+            @AuthenticationPrincipal CustomUserDetails user) {
 
-        return challengePostUpdateService.patchPost(request, id, user.getMember());
+        return challengePostUpdateService.patchPost(request, challengeId, postId, user.getMember());
     }
 
     @DeleteMapping("/posts/{id}")

--- a/src/main/java/com/habitpay/habitpay/global/error/exception/ErrorCode.java
+++ b/src/main/java/com/habitpay/habitpay/global/error/exception/ErrorCode.java
@@ -60,7 +60,8 @@ public enum ErrorCode {
     PHOTO_NOT_FOUND(HttpStatus.NOT_FOUND, "포스트 포토가 존재하지 않습니다."),
     NEED_TO_WAIT_FOR_CHALLENGE_SET(HttpStatus.BAD_REQUEST, "챌린지 시작을 위한 설정 진행 중입니다. 잠시 후 다시 시도해주세요."),
     POST_EDITABLE_ONLY_WITHIN_CHALLENGE_PERIOD(HttpStatus.BAD_REQUEST, "챌린지 유효 기간에만 포스트를 작성 및 수정할 수 있습니다."),
-    POST_CREATION_FORBIDDEN_DUE_TO_GIVE_UP(HttpStatus.FORBIDDEN, "챌린지 중도 포기 이후에는 게시물을 생성할 수 없습니다.");
+    POST_CREATION_FORBIDDEN_DUE_TO_GIVE_UP(HttpStatus.FORBIDDEN, "챌린지 중도 포기 이후에는 게시물을 생성할 수 없습니다."),
+    POST_MODIFICATION_FORBIDDEN_DUE_TO_GIVE_UP(HttpStatus.FORBIDDEN, "챌린지 중도 포기 이후에는 게시물을 수정할 수 없습니다.");
 
     private HttpStatus status;
     private final String message;

--- a/src/main/java/com/habitpay/habitpay/global/error/exception/ErrorCode.java
+++ b/src/main/java/com/habitpay/habitpay/global/error/exception/ErrorCode.java
@@ -59,7 +59,8 @@ public enum ErrorCode {
     POST_PHOTO_IMAGE_SIZE_TOO_LARGE(HttpStatus.BAD_REQUEST, "이미지 파일의 크기가 제한을 초과했습니다. (최대 1MB)"),
     PHOTO_NOT_FOUND(HttpStatus.NOT_FOUND, "포스트 포토가 존재하지 않습니다."),
     NEED_TO_WAIT_FOR_CHALLENGE_SET(HttpStatus.BAD_REQUEST, "챌린지 시작을 위한 설정 진행 중입니다. 잠시 후 다시 시도해주세요."),
-    POST_EDITABLE_ONLY_WITHIN_CHALLENGE_PERIOD(HttpStatus.BAD_REQUEST, "챌린지 유효 기간에만 포스트를 작성 및 수정할 수 있습니다.");
+    POST_EDITABLE_ONLY_WITHIN_CHALLENGE_PERIOD(HttpStatus.BAD_REQUEST, "챌린지 유효 기간에만 포스트를 작성 및 수정할 수 있습니다."),
+    POST_CREATION_FORBIDDEN_DUE_TO_GIVE_UP(HttpStatus.FORBIDDEN, "챌린지 중도 포기 이후에는 게시물을 생성할 수 없습니다.");
 
     private HttpStatus status;
     private final String message;

--- a/src/main/java/com/habitpay/habitpay/global/error/exception/ErrorCode.java
+++ b/src/main/java/com/habitpay/habitpay/global/error/exception/ErrorCode.java
@@ -61,7 +61,8 @@ public enum ErrorCode {
     NEED_TO_WAIT_FOR_CHALLENGE_SET(HttpStatus.BAD_REQUEST, "챌린지 시작을 위한 설정 진행 중입니다. 잠시 후 다시 시도해주세요."),
     POST_EDITABLE_ONLY_WITHIN_CHALLENGE_PERIOD(HttpStatus.BAD_REQUEST, "챌린지 유효 기간에만 포스트를 작성 및 수정할 수 있습니다."),
     POST_CREATION_FORBIDDEN_DUE_TO_GIVE_UP(HttpStatus.FORBIDDEN, "챌린지 중도 포기 이후에는 게시물을 생성할 수 없습니다."),
-    POST_MODIFICATION_FORBIDDEN_DUE_TO_GIVE_UP(HttpStatus.FORBIDDEN, "챌린지 중도 포기 이후에는 게시물을 수정할 수 없습니다.");
+    POST_MODIFICATION_FORBIDDEN_DUE_TO_GIVE_UP(HttpStatus.FORBIDDEN, "챌린지 중도 포기 이후에는 게시물을 수정할 수 없습니다."),
+    POST_DELETION_FORBIDDEN_DUE_TO_GIVE_UP(HttpStatus.FORBIDDEN, "챌린지 중도 포기 이후에는 게시물을 삭제할 수 없습니다.");
 
     private HttpStatus status;
     private final String message;

--- a/src/main/java/com/habitpay/habitpay/global/error/exception/ErrorCode.java
+++ b/src/main/java/com/habitpay/habitpay/global/error/exception/ErrorCode.java
@@ -37,6 +37,8 @@ public enum ErrorCode {
     INVALID_CHALLENGE_PARTICIPATING_DAYS(HttpStatus.BAD_REQUEST, "챌린지 진행 기간에 선택한 챌린지 참여 요일이 포함되지 않았습니다."),
     INVALID_CHALLENGE_REGISTRATION_TIME(HttpStatus.BAD_REQUEST, "챌린지 등록 가능 시간이 아닙니다."),
     INVALID_CHALLENGE_CANCELLATION_TIME(HttpStatus.BAD_REQUEST, "챌린지 취소 가능한 시간이 지났습니다."),
+    TOO_EARLY_GIVEN_UP_CHALLENGE(HttpStatus.BAD_REQUEST, "챌린지 중도 포기는 챌린지 시작 이후에만 가능합니다."),
+    ALREADY_GIVEN_UP_CHALLENGE(HttpStatus.BAD_REQUEST, "이미 중도 포기한 챌린지 입니다."),
     ALREADY_ENROLLED_IN_CHALLENGE(HttpStatus.CONFLICT, "이미 참여한 챌린지 입니다."),
     NOT_ENROLLED_IN_CHALLENGE(HttpStatus.BAD_REQUEST, "참여하지 않은 챌린지 입니다."),
     NOT_ALLOWED_TO_CANCEL_ENROLLMENT_OF_HOST(HttpStatus.BAD_REQUEST, "챌린지 주최자는 참여 취소가 불가능 합니다."),

--- a/src/main/java/com/habitpay/habitpay/global/handler/GlobalExceptionHandler.java
+++ b/src/main/java/com/habitpay/habitpay/global/handler/GlobalExceptionHandler.java
@@ -3,6 +3,7 @@ package com.habitpay.habitpay.global.handler;
 import com.habitpay.habitpay.global.error.ErrorResponse;
 import com.habitpay.habitpay.global.error.exception.BusinessException;
 import com.habitpay.habitpay.global.error.exception.ErrorCode;
+import com.habitpay.habitpay.global.error.exception.ForbiddenException;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
@@ -16,6 +17,14 @@ public class GlobalExceptionHandler {
     @ExceptionHandler(BusinessException.class)
     protected ResponseEntity<ErrorResponse> handleBusinessException(final BusinessException ex) {
         log.error("handleBusinessException: ", ex);
+        final ErrorCode errorCode = ex.getErrorCode();
+        final ErrorResponse response = ErrorResponse.of(errorCode);
+        return ResponseEntity.status(errorCode.getStatus()).body(response);
+    }
+
+    @ExceptionHandler(ForbiddenException.class)
+    protected ResponseEntity<ErrorResponse> handleForbiddenException(final ForbiddenException ex) {
+        log.error("handleForbiddenException: ", ex);
         final ErrorCode errorCode = ex.getErrorCode();
         final ErrorResponse response = ErrorResponse.of(errorCode);
         return ResponseEntity.status(errorCode.getStatus()).body(response);

--- a/src/main/java/com/habitpay/habitpay/global/response/SuccessCode.java
+++ b/src/main/java/com/habitpay/habitpay/global/response/SuccessCode.java
@@ -20,6 +20,7 @@ public enum SuccessCode {
     PATCH_CHALLENGE_SUCCESS("정상적으로 챌린지 정보 수정이 반영되었습니다."),
     ENROLL_CHALLENGE_SUCCESS("정상적으로 챌린지에 등록했습니다."),
     CANCEL_CHALLENGE_ENROLLMENT_SUCCESS("정상적으로 챌린지 등록을 취소했습니다."),
+    GIVING_UP_CHALLENGE("정상적으로 챌린지 중도 포기 처리가 되었습니다."),
     DELETE_CHALLENGE_SUCCESS("정상적으로 챌린지를 삭제했습니다."),
 
     // Post

--- a/src/test/java/com/habitpay/habitpay/domain/challegepost/api/ChallengePostApiTest.java
+++ b/src/test/java/com/habitpay/habitpay/domain/challegepost/api/ChallengePostApiTest.java
@@ -441,11 +441,11 @@ public class ChallengePostApiTest extends AbstractRestDocsTests {
 
         List<String> presignedUrlList = List.of("https://please.upload/your-photo/here");
 
-        given(challengePostUpdateService.patchPost(any(ModifyPostRequest.class), anyLong(), any(Member.class)))
+        given(challengePostUpdateService.patchPost(any(ModifyPostRequest.class), anyLong(), anyLong(), any(Member.class)))
                 .willReturn(SuccessResponse.of(SuccessCode.PATCH_POST_SUCCESS, presignedUrlList));
 
         //when
-        ResultActions result = mockMvc.perform(patch("/api/posts/{id}", 1L)
+        ResultActions result = mockMvc.perform(patch("/api/challenges/{challengeId}/posts/{postId}", 1L, 1L)
                 .header(HttpHeaders.AUTHORIZATION, AUTHORIZATION_HEADER_PREFIX + "ACCESS_TOKEN")
                 .content(objectMapper.writeValueAsString(mockmodifyPostRequest))
                 .contentType(MediaType.APPLICATION_JSON));

--- a/src/test/java/com/habitpay/habitpay/domain/challegepost/api/ChallengePostApiTest.java
+++ b/src/test/java/com/habitpay/habitpay/domain/challegepost/api/ChallengePostApiTest.java
@@ -13,6 +13,8 @@ import com.habitpay.habitpay.domain.postphoto.dto.ModifyPostPhotoData;
 import com.habitpay.habitpay.domain.postphoto.dto.PostPhotoView;
 import com.habitpay.habitpay.global.config.jwt.TokenProvider;
 import com.habitpay.habitpay.global.config.jwt.TokenService;
+import com.habitpay.habitpay.global.error.exception.ErrorCode;
+import com.habitpay.habitpay.global.error.exception.ForbiddenException;
 import com.habitpay.habitpay.global.response.SuccessCode;
 import com.habitpay.habitpay.global.response.SuccessResponse;
 import com.habitpay.habitpay.global.security.WithMockOAuth2User;
@@ -383,7 +385,7 @@ public class ChallengePostApiTest extends AbstractRestDocsTests {
 
     @Test
     @WithMockOAuth2User
-    @DisplayName("챌린지 포스트 생성")
+    @DisplayName("챌린지 게시물 생성")
     void createPost() throws Exception {
 
         //given
@@ -399,7 +401,7 @@ public class ChallengePostApiTest extends AbstractRestDocsTests {
                 .willReturn(SuccessResponse.of(SuccessCode.CREATE_POST_SUCCESS, presignedUrlList));
 
         //when
-        ResultActions result = mockMvc.perform(post("/api/challenges/{id}/post", 1L)
+        ResultActions result = mockMvc.perform(post("/api/challenges/{id}/posts", 1L)
                 .header(HttpHeaders.AUTHORIZATION, AUTHORIZATION_HEADER_PREFIX + "ACCESS_TOKEN")
                 .content(objectMapper.writeValueAsString(mockAddPostRequest))
                 .contentType(MediaType.APPLICATION_JSON));
@@ -421,6 +423,40 @@ public class ChallengePostApiTest extends AbstractRestDocsTests {
                         responseFields(
                                 fieldWithPath("message").description("메시지"),
                                 fieldWithPath("data").description("AWS S3 업로드를 위한 preSignedUrl List<String>")
+                        )
+                ));
+    }
+
+    @Test
+    @WithMockOAuth2User
+    @DisplayName("챌린지 게시물 생성 - 챌린지 중도 포기 이후 (403 Forbidden)")
+    void challengePostCreationForbiddenException() throws Exception {
+
+        // given
+        AddPostRequest mockAddPostRequest = AddPostRequest.builder()
+                .content("I want to create this post.")
+                .isAnnouncement(false)
+                .photos(List.of(new AddPostPhotoData(1L, "jpg", 100L)))
+                .build();
+
+        given(challengePostCreationService.createPost(any(AddPostRequest.class), anyLong(), any(Member.class)))
+                .willThrow(new ForbiddenException(ErrorCode.POST_CREATION_FORBIDDEN_DUE_TO_GIVE_UP));
+
+        // when
+        ResultActions result = mockMvc.perform(post("/api/challenges/{id}/posts", 1L)
+                .header(HttpHeaders.AUTHORIZATION, AUTHORIZATION_HEADER_PREFIX + "ACCESS_TOKEN")
+                .content(objectMapper.writeValueAsString(mockAddPostRequest))
+                .contentType(MediaType.APPLICATION_JSON));
+
+        // then
+        result.andExpect(status().isForbidden())
+                .andDo(document("challenge/challenge-post-creation-forbidden-exception",
+                        requestHeaders(
+                                headerWithName(HttpHeaders.AUTHORIZATION).description("액세스 토큰")
+                        ),
+                        responseFields(
+                                fieldWithPath("code").description("오류 응답 코드"),
+                                fieldWithPath("message").description("오류 메세지")
                         )
                 ));
     }
@@ -477,6 +513,40 @@ public class ChallengePostApiTest extends AbstractRestDocsTests {
 
     @Test
     @WithMockOAuth2User
+    @DisplayName("챌린지 게시물 수정 - 챌린지 중도 포기 이후 (403 Forbidden)")
+    void challengePostModificationForbiddenException() throws Exception {
+
+        // given
+        AddPostRequest mockPatchRequest = AddPostRequest.builder()
+                .content("I want to create this post.")
+                .isAnnouncement(false)
+                .photos(List.of(new AddPostPhotoData(1L, "jpg", 100L)))
+                .build();
+
+        given(challengePostUpdateService.patchPost(any(ModifyPostRequest.class), anyLong(), anyLong(), any(Member.class)))
+                .willThrow(new ForbiddenException(ErrorCode.POST_MODIFICATION_FORBIDDEN_DUE_TO_GIVE_UP));
+
+        // when
+        ResultActions result = mockMvc.perform(patch("/api/challenges/{challengeId}/posts/{postId}", 1L, 1L)
+                .header(HttpHeaders.AUTHORIZATION, AUTHORIZATION_HEADER_PREFIX + "ACCESS_TOKEN")
+                .content(objectMapper.writeValueAsString(mockPatchRequest))
+                .contentType(MediaType.APPLICATION_JSON));
+
+        // then
+        result.andExpect(status().isForbidden())
+                .andDo(document("challenge/challenge-post-modification-forbidden-exception",
+                        requestHeaders(
+                                headerWithName(HttpHeaders.AUTHORIZATION).description("액세스 토큰")
+                        ),
+                        responseFields(
+                                fieldWithPath("code").description("오류 응답 코드"),
+                                fieldWithPath("message").description("오류 메세지")
+                        )
+                ));
+    }
+
+    @Test
+    @WithMockOAuth2User
     @DisplayName("챌린지 포스트 삭제")
     void deletePost() throws Exception {
 
@@ -485,7 +555,7 @@ public class ChallengePostApiTest extends AbstractRestDocsTests {
                 .willReturn(SuccessResponse.of(SuccessCode.DELETE_POST_SUCCESS));
 
         //when
-        ResultActions result = mockMvc.perform(delete("/api/posts/{id}", 1L)
+        ResultActions result = mockMvc.perform(delete("/api/challenges/{challengeId}/posts/{postId}", 1L, 1L)
                 .header(HttpHeaders.AUTHORIZATION, AUTHORIZATION_HEADER_PREFIX + "ACCESS_TOKEN"));
 
         //then
@@ -497,6 +567,32 @@ public class ChallengePostApiTest extends AbstractRestDocsTests {
                         responseFields(
                                 fieldWithPath("message").description("메시지"),
                                 fieldWithPath("data").description("삭제된 포스트 id")
+                        )
+                ));
+    }
+
+    @Test
+    @WithMockOAuth2User
+    @DisplayName("챌린지 게시물 삭제 - 챌린지 중도 포기 이후 (403 Forbidden)")
+    void challengePostDeletionForbiddenException() throws Exception {
+
+        // given
+        given(challengePostDeleteService.deletePost(anyLong(), anyLong(), any(Member.class)))
+                .willThrow(new ForbiddenException(ErrorCode.POST_DELETION_FORBIDDEN_DUE_TO_GIVE_UP));
+
+        // when
+        ResultActions result = mockMvc.perform(delete("/api/challenges/{challengeId}/posts/{postId}", 1L, 1L)
+                .header(HttpHeaders.AUTHORIZATION, AUTHORIZATION_HEADER_PREFIX + "ACCESS_TOKEN"));
+
+        // then
+        result.andExpect(status().isForbidden())
+                .andDo(document("challenge/challenge-post-deletion-forbidden-exception",
+                        requestHeaders(
+                                headerWithName(HttpHeaders.AUTHORIZATION).description("액세스 토큰")
+                        ),
+                        responseFields(
+                                fieldWithPath("code").description("오류 응답 코드"),
+                                fieldWithPath("message").description("오류 메세지")
                         )
                 ));
     }

--- a/src/test/java/com/habitpay/habitpay/domain/challegepost/api/ChallengePostApiTest.java
+++ b/src/test/java/com/habitpay/habitpay/domain/challegepost/api/ChallengePostApiTest.java
@@ -481,7 +481,7 @@ public class ChallengePostApiTest extends AbstractRestDocsTests {
     void deletePost() throws Exception {
 
         //given
-        given(challengePostDeleteService.deletePost(anyLong(), any(Member.class)))
+        given(challengePostDeleteService.deletePost(anyLong(), anyLong(), any(Member.class)))
                 .willReturn(SuccessResponse.of(SuccessCode.DELETE_POST_SUCCESS));
 
         //when


### PR DESCRIPTION
# 개요

챌린지 시작 이후 중도 포기를 위한 API 를 구현했습니다.

# 상세 작업 내용

## 1. 챌린지 중도 포기 API 구현

### 컨트롤러

중도 포기는 챌린지 등록 관련 로직이라 생각하여 `ChallengeEnrollment` 도메인에 챌린지 중도 포기 컨트롤러를 추가했습니다.

```java
@PostMapping("/challenges/{id}/give-up")
public SuccessResponse<Void> giveUpChallenge(@PathVariable("id") Long id, @AuthenticationPrincipal CustomUserDetails user) {
    return challengeEnrollmentCancellationService.giveUp(id, user.getMember());
}
```

### 서비스

챌린지 중도 포기 시, DB 에서 수행되는 작업은 다음과 같이 3가지 입니다. 

1. `ChallengeEnrollment` 엔티티의 `isGivenUp` 을 true 로 설정합니다.
2. `Challenge` 엔티티의 전체 참여자 수를 1만큼 감소시킵니다.
3. `challenge_participation_record` 테이블에서 오늘을 포함한 이후 날짜에 해당하는 모든 참여 기록을 삭제합니다.

```java
@Transactional
public SuccessResponse<Void> giveUp(Long challengeId, Member member) {

    Challenge challenge = challengeSearchService.getChallengeById(challengeId);
    ChallengeEnrollment challengeEnrollment = challengeEnrollmentSearchService.getByMemberAndChallenge(member, challenge);
    ZonedDateTime now = TimeZoneConverter.convertEtcToLocalTimeZone(ZonedDateTime.now());

    if (now.isBefore(challenge.getStartDate())) {
        throw new BadRequestException(ErrorCode.TOO_EARLY_GIVEN_UP_CHALLENGE);
    }

    if (challengeEnrollment.isGivenUp()) {
        throw new AlreadyGivenUpChallengeException(member.getId(), challengeId);
    }

    challengeEnrollment.setGivenUp(true);

    challenge.setNumberOfParticipants(challenge.getNumberOfParticipants() - 1);

    challengeParticipationRecordRepository.deleteAllByChallengeEnrollmentAndTargetDateAfterOrTargetDate(challengeEnrollment, now.with(LocalTime.MIDNIGHT));

    return SuccessResponse.of(SuccessCode.GIVING_UP_CHALLENGE);
}
```

`deleteAllByChallengeEnrollmentAndTargetDateAfterOrTargetDate` 메서드는 다음과 같이 JPQL 을 활용하여 작성하였습니다.

```java
@Modifying
@Query("DELETE FROM ChallengeParticipationRecord r WHERE r.challengeEnrollment = :challengeEnrollment AND (r.targetDate > :date OR r.targetDate = :date)")
void deleteAllByChallengeEnrollmentAndTargetDateAfterOrTargetDate(@Param("challengeEnrollment") ChallengeEnrollment challengeEnrollment, @Param("date") ZonedDateTime date);
```

- 데이터를 삭제하기 위해 `@Modifying` 어노테이션을 사용했습니다.
- `date` 매개변수는 `targetDate` 와 시간 형식을 맞추기 위해 00시 00분으로 전달됩니다.

### 테스트

챌린지 중도 포기 테스트 코드와 이에 해당하는 예외처리 테스트 코드를 작성했습니다.

## 2. 챌린지 중도 포기 이후 게시물 생성, 수정, 삭제 요청 예외처리 추가

중도 포기한 챌린지에서는 게시물 생성, 수정, 삭제가 불가능하도록 예외처리를 추가했습니다.

### 서비스

`ChallengeEnrollment` 엔티티의 `isGivenUp` 값에 따라 예외를 처리하도록 구현했습니다. 

```java
@Transactional
public SuccessResponse<List<String>> createPost(AddPostRequest request, Long challengeId, Member member) {

    // <-- 추가한 부분
    Challenge challenge = challengeSearchService.getChallengeById(challengeId);
    ChallengeEnrollment enrollment = challengeEnrollmentSearchService.getByMemberAndChallenge(member, challenge);

    if (enrollment.isGivenUp()) {
        throw new ForbiddenException(ErrorCode.POST_CREATION_FORBIDDEN_DUE_TO_GIVE_UP);
    }

    // -->

    challengePostUtilService.checkChallengePeriodForPost(challenge);

    ChallengePost challengePost = this.savePost(request, challenge, member, enrollment);
    if (!challengePost.getIsAnnouncement()) {
        challengePostUtilService.verifyChallengePostForRecord(challengePost);
    }
    List<String> presignedUrlList = postPhotoCreationService.createPhotoUrlList(challengePost, request.getPhotos());

    return SuccessResponse.of(
            SuccessCode.CREATE_POST_SUCCESS,
            presignedUrlList
    );
}

```

### 테스트

챌린지 생성, 수정, 삭제에서 추가한 예외처리 테스트 코드를 작성했습니다.

## 3. 챌린지 게시물 생성 컨트롤러의 `@PathVariable` 어노테이션 필드명 추가

챌린지 게시물 생성 테스트 중, `@PathVariable` 어노테이션 필드명이 명시되지 않아 다음과 같은 오류가 발생했습니다.

> Name for argument of type [java.lang.Long] not specified, and parameter name information not available via reflection. Ensure that the compiler uses the '-parameters' flag.

이를 해결하기 위해 `@PathVariable("id") Long id` 와 같이 필드명을 명시했습니다.

```java
@PostMapping("/challenges/{id}/post")
public SuccessResponse<List<String>> createPost(
        @RequestBody AddPostRequest request,
        @PathVariable("id") Long id,
        @AuthenticationPrincipal CustomUserDetails user) {
    return challengePostCreationService.createPost(request, id, user.getMember());
}
```

챌린지 게시물 생성 컨트롤러 뿐만 아니라 다른 컨트롤러에서도 동일한 오류가 발생하여 일부 수정했습니다. 
추후 챌린지 게시물 관련 컨트롤러 작업할 때 추가 확인이 필요합니다. 
