### PR TITLE
[feat] 챌린지 정보 조회 시 사용자의 중도 포기 여부 추가#302

### DIFF
--- a/src/main/java/com/habitpay/habitpay/domain/challenge/application/ChallengeSearchService.java
+++ b/src/main/java/com/habitpay/habitpay/domain/challenge/application/ChallengeSearchService.java
@@ -12,7 +12,6 @@ import com.habitpay.habitpay.domain.challengeparticipationrecord.dao.ChallengePa
 import com.habitpay.habitpay.domain.member.domain.Member;
 import com.habitpay.habitpay.domain.participationstat.domain.ParticipationStat;
 import com.habitpay.habitpay.global.config.aws.S3FileService;
-import com.habitpay.habitpay.global.config.timezone.TimeZoneConverter;
 import com.habitpay.habitpay.global.response.PageResponse;
 import com.habitpay.habitpay.global.response.SuccessCode;
 import com.habitpay.habitpay.global.response.SuccessResponse;
@@ -52,7 +51,7 @@ public class ChallengeSearchService {
     public SuccessResponse<List<ChallengeEnrolledListItemResponse>> getEnrolledChallengeList(Member member) {
         List<ChallengeEnrollment> challengeEnrollmentList = challengeEnrollmentRepository.findAllByMember(member);
         List<ChallengeEnrolledListItemResponse> response = challengeEnrollmentList.stream()
-                .map(this::mapToResponse)
+                .map(this::toChallengeEnrolledListItemResponse)
                 .toList();
 
         return SuccessResponse.of(SuccessCode.NO_MESSAGE, response);
@@ -64,7 +63,7 @@ public class ChallengeSearchService {
                 .orElseThrow(() -> new ChallengeNotFoundException(id));
     }
 
-    private ChallengeEnrolledListItemResponse mapToResponse(ChallengeEnrollment challengeEnrollment) {
+    private ChallengeEnrolledListItemResponse toChallengeEnrolledListItemResponse(ChallengeEnrollment challengeEnrollment) {
         Challenge challenge = challengeEnrollment.getChallenge();
         ParticipationStat stat = challengeEnrollment.getParticipationStat();
         boolean isParticipatedToday = challengeParticipationRecordSearchService.hasParticipationPostForToday(challengeEnrollment);

--- a/src/main/java/com/habitpay/habitpay/domain/challenge/application/ChallengeSearchService.java
+++ b/src/main/java/com/habitpay/habitpay/domain/challenge/application/ChallengeSearchService.java
@@ -8,7 +8,6 @@ import com.habitpay.habitpay.domain.challenge.exception.ChallengeNotFoundExcepti
 import com.habitpay.habitpay.domain.challengeenrollment.dao.ChallengeEnrollmentRepository;
 import com.habitpay.habitpay.domain.challengeenrollment.domain.ChallengeEnrollment;
 import com.habitpay.habitpay.domain.challengeparticipationrecord.application.ChallengeParticipationRecordSearchService;
-import com.habitpay.habitpay.domain.challengeparticipationrecord.dao.ChallengeParticipationRecordRepository;
 import com.habitpay.habitpay.domain.member.domain.Member;
 import com.habitpay.habitpay.domain.participationstat.domain.ParticipationStat;
 import com.habitpay.habitpay.global.config.aws.S3FileService;
@@ -33,7 +32,6 @@ public class ChallengeSearchService {
     private final S3FileService s3FileService;
     private final ChallengeRepository challengeRepository;
     private final ChallengeEnrollmentRepository challengeEnrollmentRepository;
-    private final ChallengeParticipationRecordRepository challengeParticipationRecordRepository;
     private final ChallengeParticipationRecordSearchService challengeParticipationRecordSearchService;
 
     public SuccessResponse<PageResponse<ChallengePageResponse>> getChallengePage(Pageable pageable) {
@@ -49,12 +47,15 @@ public class ChallengeSearchService {
     }
 
     public SuccessResponse<List<ChallengeEnrolledListItemResponse>> getEnrolledChallengeList(Member member) {
-        List<ChallengeEnrollment> challengeEnrollmentList = challengeEnrollmentRepository.findAllByMember(member);
-        List<ChallengeEnrolledListItemResponse> response = challengeEnrollmentList.stream()
-                .map(this::toChallengeEnrolledListItemResponse)
-                .toList();
+        List<ChallengeEnrolledListItemResponse> response = mapEnrollmentsToResponses(member);
 
         return SuccessResponse.of(SuccessCode.NO_MESSAGE, response);
+    }
+
+    private List<ChallengeEnrolledListItemResponse> mapEnrollmentsToResponses(Member member) {
+        return challengeEnrollmentRepository.findAllByMember(member).stream()
+                .map(this::toChallengeEnrolledListItemResponse)
+                .toList();
     }
 
     @Transactional(readOnly = true)

--- a/src/main/java/com/habitpay/habitpay/domain/challenge/application/ChallengeSearchService.java
+++ b/src/main/java/com/habitpay/habitpay/domain/challenge/application/ChallengeSearchService.java
@@ -58,12 +58,6 @@ public class ChallengeSearchService {
                 .toList();
     }
 
-    @Transactional(readOnly = true)
-    public Challenge getChallengeById(Long id) {
-        return challengeRepository.findById(id)
-                .orElseThrow(() -> new ChallengeNotFoundException(id));
-    }
-
     private ChallengeEnrolledListItemResponse toChallengeEnrolledListItemResponse(ChallengeEnrollment challengeEnrollment) {
         Challenge challenge = challengeEnrollment.getChallenge();
         ParticipationStat stat = challengeEnrollment.getParticipationStat();
@@ -73,4 +67,11 @@ public class ChallengeSearchService {
                 .orElse("");
         return ChallengeEnrolledListItemResponse.of(challenge, challengeEnrollment, stat, hostProfileImageUrl, isParticipatedToday);
     }
+
+    @Transactional(readOnly = true)
+    public Challenge getChallengeById(Long id) {
+        return challengeRepository.findById(id)
+                .orElseThrow(() -> new ChallengeNotFoundException(id));
+    }
+
 }

--- a/src/main/java/com/habitpay/habitpay/domain/challenge/dto/ChallengeDetailsResponse.java
+++ b/src/main/java/com/habitpay/habitpay/domain/challenge/dto/ChallengeDetailsResponse.java
@@ -27,8 +27,11 @@ public class ChallengeDetailsResponse {
     private List<String> enrolledMembersProfileImageList;
     private Boolean isHost;
     private Boolean isMemberEnrolledInChallenge;
+    private Boolean isGivenUp;
 
-    public static ChallengeDetailsResponse of(Member member, Challenge challenge, List<String> enrolledMembersProfileImageList, Boolean isMemberEnrolledInChallenge, Boolean isParticipatedToday) {
+    public static ChallengeDetailsResponse of(Member member, Challenge challenge,
+                                              List<String> enrolledMembersProfileImageList,
+                                              Boolean isMemberEnrolledInChallenge, Boolean isParticipatedToday, Boolean isGivenUp) {
         return ChallengeDetailsResponse.builder()
                 .title(challenge.getTitle())
                 .description(challenge.getDescription())
@@ -46,6 +49,7 @@ public class ChallengeDetailsResponse {
                 .enrolledMembersProfileImageList(enrolledMembersProfileImageList)
                 .isHost(challenge.getHost().getId().equals(member.getId()))
                 .isMemberEnrolledInChallenge(isMemberEnrolledInChallenge)
+                .isGivenUp(isGivenUp)
                 .build();
     }
 }

--- a/src/test/java/com/habitpay/habitpay/domain/challenge/api/ChallengeApiTest.java
+++ b/src/test/java/com/habitpay/habitpay/domain/challenge/api/ChallengeApiTest.java
@@ -224,6 +224,7 @@ public class ChallengeApiTest extends AbstractRestDocsTests {
                 .isMemberEnrolledInChallenge(true)
                 .isTodayParticipatingDay(true)
                 .isParticipatedToday(true)
+                .isGivenUp(false)
                 .build();
 
         given(challengeDetailsService.getChallengeDetails(anyLong(), any(Member.class)))
@@ -256,7 +257,8 @@ public class ChallengeApiTest extends AbstractRestDocsTests {
                                 fieldWithPath("data.isHost").description("현재 접속한 사용자 == 챌린지 주최자"),
                                 fieldWithPath("data.isMemberEnrolledInChallenge").description("현재 접속한 사용자의 챌린지 참여 여부"),
                                 fieldWithPath("data.isTodayParticipatingDay").description("금일이 챌린지 참여일인지 여부"),
-                                fieldWithPath("data.isParticipatedToday").description("현재 접속한 사용자가 챌린지의 참가자일 경우, 금일 참여했는지 여부(참가자가 아니어도 false)")
+                                fieldWithPath("data.isParticipatedToday").description("현재 접속한 사용자가 챌린지의 참가자일 경우, 금일 참여했는지 여부(참가자가 아니어도 false)"),
+                                fieldWithPath("data.isGivenUp").description("챌린지 중도 포기 여부")
                         )
                 ));
     }


### PR DESCRIPTION
# 개요

챌린지 상세 정보 조회 컨트롤러 `GET /challenges/{id}` 의 response DTO 에 `중도 포기 여부`를 보여주는 `isGivenUp` 필드를 추가했습니다.

그리고 가독성 향상을 위해 일부 메서드는 리팩토링 했습니다.

## 작업 상세 내용

### 1. 중도 포기 여부 추가

`ChallengeDetailsResponse` DTO 에 `isGivenUp` 필드를 추가했습니다.

```java
@Getter
@Builder
public class ChallengeDetailsResponse {
    // ...중략
    private Boolean isHost;
    private Boolean isMemberEnrolledInChallenge;
    private Boolean isGivenUp; // 추가한 필드
}
```

### 2. 테스트 코드 수정

추가된 필드에 맞게 테스트 코드를 수정했습니다.

### 3. 서비스 일부 메서드 리팩토링

서비스 메서드의 가독성을 높이기 위해 별도의 메서드로 분리하는 작업을 했습니다. 