### PR TITLE
[refactor] SchedulerTaskHelperService 클래스의 checkfailedparticipation 리팩토링 #304

### DIFF
--- a/src/main/java/com/habitpay/habitpay/domain/challengescheduler/application/SchedulerTaskHelperService.java
+++ b/src/main/java/com/habitpay/habitpay/domain/challengescheduler/application/SchedulerTaskHelperService.java
@@ -84,7 +84,8 @@ public class SchedulerTaskHelperService {
                         ParticipationStat stat = record.getParticipationStat();
                         Challenge challenge = record.getChallenge();
 
-                        setFailureCountInChallengeMap(challengeFailureCountMap, challenge);
+                        int count = challengeFailureCountMap.getOrDefault(challenge, 0);
+                        challengeFailureCountMap.put(challenge, count + 1);
                         stat.setFailureCount(stat.getFailureCount() + 1);
                         stat.setTotalFee(stat.getTotalFee() + challenge.getFeePerAbsence());
 
@@ -98,15 +99,6 @@ public class SchedulerTaskHelperService {
         participationStatRepository.saveAll(failureStatList);
         challengeParticipationRecordRepository.deleteAll(failureRecordList);
         challengeRepository.saveAll(feeAddedChallengeList);
-    }
-
-    private void setFailureCountInChallengeMap(HashMap<Challenge, Integer> challengeFailureCountMap, Challenge challenge) {
-        if (challengeFailureCountMap.containsKey(challenge)) {
-            int currentFailures = challengeFailureCountMap.get(challenge);
-            challengeFailureCountMap.put(challenge, currentFailures + 1);
-        } else {
-            challengeFailureCountMap.put(challenge, 1);
-        }
     }
 
     private List<Challenge> calculateFeeForChallenges(HashMap<Challenge, Integer> challengeFailureCountMap) {

--- a/src/main/java/com/habitpay/habitpay/domain/challengescheduler/application/SchedulerTaskHelperService.java
+++ b/src/main/java/com/habitpay/habitpay/domain/challengescheduler/application/SchedulerTaskHelperService.java
@@ -104,16 +104,13 @@ public class SchedulerTaskHelperService {
     private List<Challenge> calculateFeeForChallenges(HashMap<Challenge, Integer> challengeFailureCountMap) {
         List<Challenge> feeAddedChallengeList = new ArrayList<>();
 
-        for (Map.Entry<Challenge, Integer> entry : challengeFailureCountMap.entrySet()) {
-            Challenge challenge = entry.getKey();
-            Integer failureCount = entry.getValue();
-
+        challengeFailureCountMap.forEach((challenge, failureCount) -> {
             int feePerAbsence = challenge.getFeePerAbsence();
             int currentTotalAbsenceFee = challenge.getTotalAbsenceFee();
             challenge.setTotalAbsenceFee(currentTotalAbsenceFee + (feePerAbsence * failureCount));
 
             feeAddedChallengeList.add(challenge);
-        }
+        });
 
         return feeAddedChallengeList;
     }


### PR DESCRIPTION
### 개요

* `SchedulerTaskHelperService` 클래스의 `checkfailedparticipation` 메서드를 리팩토링했습니다.
* 내용은 #293 의 코멘트를 반영했습니다. 리팩토링 제안 감사드립니다.

---

### 주요 내용

```java
* 챌린지 별 실패 횟수를 관리하기 위해 `setFailureCountInChallengeMap`이라는 커스텀 setter 메서드를 만들어 사용했었음
=> `HashMap`의 `getOrDefault()`이라는 기본 메서드를 이용하도록 리팩토링
```

```java
* `HashMap`을 순회하기 위해 `Entry`를 대상으로 하는 `for문` 이용했었음
=>`key`와 `value`값만 이용해 `forEach문`을 이용하도록 리팩토링
```