### PR TITLE
[Debug] 디버깅 목적의 로그 추가 : 운영 서버에서 챌린지 생성 시 records가 적절하게 생성되지 않는 문제 #308

### DIFF
--- a/src/main/java/com/habitpay/habitpay/domain/challenge/domain/Challenge.java
+++ b/src/main/java/com/habitpay/habitpay/domain/challenge/domain/Challenge.java
@@ -182,8 +182,8 @@ public class Challenge extends BaseTime {
 
                 // todo : 해결되면 삭제
                 log.debug("challenge.getId() : {}", this.getId());
-                log.debug("challenge.getStartDate() : {}", this.getStartDate());
-                log.debug("TimeZoneConverter.convertEtcToLocalTimeZone(this.getStartDate()) : {}", startDateInLocal);
+                log.debug("[startDate(UTC), startDate(KST)]");
+                log.debug("{}, {}", this.getStartDate(), startDateInLocal);
                 log.debug("first targetDate : {}", targetDate);
 
                 // todo
@@ -191,8 +191,8 @@ public class Challenge extends BaseTime {
                 ZonedDateTime endDate = endDateInLocal.toLocalDate().atTime(LocalTime.MAX).atZone(endDateInLocal.getZone());
 
                 // todo : 해결되면 삭제
-                log.debug("challenge.getEndDate() : {}", this.getEndDate());
-                log.debug("TimeZoneConverter.convertEtcToLocalTimeZone(this.getEndDate()) : {}", endDateInLocal);
+                log.debug("[endDate(UTC), endDate(KST)]");
+                log.debug("{}, {}", this.getEndDate(), endDateInLocal);
                 log.debug("endDate(timeMax) : {}", endDate);
 
                 while (!targetDate.isAfter(endDate)) {

--- a/src/main/java/com/habitpay/habitpay/domain/challenge/domain/Challenge.java
+++ b/src/main/java/com/habitpay/habitpay/domain/challenge/domain/Challenge.java
@@ -180,12 +180,27 @@ public class Challenge extends BaseTime {
                 ZonedDateTime startDateInLocal = TimeZoneConverter.convertEtcToLocalTimeZone(this.getStartDate());
                 ZonedDateTime targetDate = startDateInLocal.with(TemporalAdjusters.nextOrSame(targetDay));
 
+                // todo : 해결되면 삭제
+                log.debug("challenge.getId() : {}", this.getId());
+                log.debug("challenge.getStartDate() : {}", this.getStartDate());
+                log.debug("TimeZoneConverter.convertEtcToLocalTimeZone(this.getStartDate()) : {}", startDateInLocal);
+                log.debug("first targetDate : {}", targetDate);
+
                 // todo
-                ZonedDateTime tempEndDate = TimeZoneConverter.convertEtcToLocalTimeZone(this.getEndDate());
-                ZonedDateTime endDate = tempEndDate.toLocalDate().atTime(LocalTime.MAX).atZone(tempEndDate.getZone());
+                ZonedDateTime endDateInLocal = TimeZoneConverter.convertEtcToLocalTimeZone(this.getEndDate());
+                ZonedDateTime endDate = endDateInLocal.toLocalDate().atTime(LocalTime.MAX).atZone(endDateInLocal.getZone());
+
+                // todo : 해결되면 삭제
+                log.debug("challenge.getEndDate() : {}", this.getEndDate());
+                log.debug("TimeZoneConverter.convertEtcToLocalTimeZone(this.getEndDate()) : {}", endDateInLocal);
+                log.debug("endDate(timeMax) : {}", endDate);
 
                 while (!targetDate.isAfter(endDate)) {
                     dates.add(targetDate);
+
+                    // todo : 해결되면 삭제
+                    log.debug("Record를 위한 targetDate 리스트에 다음 날짜를 더함 : {}", targetDate);
+
                     targetDate = targetDate.plusWeeks(1);
                 }
             }


### PR DESCRIPTION
### 개요

* 문제 파악을 위한 디버깅 목적의 로그를 추가했습니다.
* 문제가 해결되면 삭제할 예정입니다(혹은 더 정제해서 아예 `log.info()`로 변경).
* 해결하고자 하는 문제는 운영 서버에서 챌린지 생성 시 DB에 `records`가 적절하게 생성되지 않는 문제입니다.
   (여러 개의 record가 생성되어야 함에도, 챌린지 당 1개씩만 생성되는 문제)

---

### 추가한 부분

```java
// domain/Challenge

public List<ZonedDateTime> getParticipationDates() {

    ...
            ZonedDateTime startDateInLocal = TimeZoneConverter.convertEtcToLocalTimeZone(this.getStartDate());
            ZonedDateTime targetDate = startDateInLocal.with(TemporalAdjusters.nextOrSame(targetDay));

            // todo : 해결되면 삭제
            log.debug("challenge.getId() : {}", this.getId());
            log.debug("[startDate(UTC), startDate(KST)]");
            log.debug("{}, {}", this.getStartDate(), startDateInLocal);
            log.debug("first targetDate : {}", targetDate);

            ZonedDateTime endDateInLocal = TimeZoneConverter.convertEtcToLocalTimeZone(this.getEndDate());
            ZonedDateTime endDate = endDateInLocal.toLocalDate().atTime(LocalTime.MAX).atZone(endDateInLocal.getZone());

            // todo : 해결되면 삭제
            log.debug("[endDate(UTC), endDate(KST)]");
            log.debug("{}, {}", this.getEndDate(), endDateInLocal);
            log.debug("endDate(timeMax) : {}", endDate);

            while (!targetDate.isAfter(endDate)) {
                dates.add(targetDate);

                // todo : 해결되면 삭제
                log.debug("Record를 위한 targetDate 리스트에 다음 날짜를 더함 : {}", targetDate);

                targetDate = targetDate.plusWeeks(1);
            }
        }
    }

    return dates;
}
```

* 챌린지 도메인 내의 `getParticipationDates()`에서, DB 상 `record`가 맞추어 생성해야 할 `targetDate`를 계산합니다.
* record가 제대로 생성되지 않는 문제가, `targetDate`가 제대로 판별되지 않기 때문이라고 생각했습니다.
* 위의 메서드를 이용해 `targetDate를 담은 리스트`를 받아 모든 record를 생성하는 로직이기 때문입니다.

