### PR TITLE
[feat] 챌린지 시작과 종료를 매 분마다 확인 및 처리 #310

### DIFF
--- a/src/main/java/com/habitpay/habitpay/domain/challenge/application/ChallengeCreationService.java
+++ b/src/main/java/com/habitpay/habitpay/domain/challenge/application/ChallengeCreationService.java
@@ -50,13 +50,6 @@ public class ChallengeCreationService {
         challengeEnrollmentRepository.save(challengeEnrollment);
         participationStatRepository.save(participationStat);
 
-        if (isStartDateIsToday(challengeCreationRequest.getStartDate())) {
-            challenge.setStateInProgress();
-            List<Challenge> challengeList = Collections.singletonList(challenge);
-            schedulerTaskHelperService.createRecordsForChallenges(challengeList);
-            challengeRepository.save(challenge);
-        }
-
         return SuccessResponse.of(
                 SuccessCode.CREATE_CHALLENGE_SUCCESS,
                 ChallengeCreationResponse.of(member, challenge)
@@ -96,13 +89,4 @@ public class ChallengeCreationService {
         }
     }
 
-    private boolean isStartDateIsToday(ZonedDateTime startDate) {
-        ZonedDateTime now = ZonedDateTime.now();
-
-        if (startDate.isBefore(now)) {
-            throw new ChallengeStartTimeInvalidException(startDate);
-        }
-
-        return startDate.toLocalDate().equals(now.toLocalDate());
-    }
 }

--- a/src/main/java/com/habitpay/habitpay/domain/challenge/dao/ChallengeRepository.java
+++ b/src/main/java/com/habitpay/habitpay/domain/challenge/dao/ChallengeRepository.java
@@ -14,8 +14,8 @@ import java.util.List;
 public interface ChallengeRepository extends JpaRepository<Challenge, Long> {
 
     // todo : startDate 받는 방식에 따라 필요하면 수정
-    List<Challenge> findAllByStartDateBetweenAndState(ZonedDateTime startOfStartDate, ZonedDateTime endOfStartDate, ChallengeState state);
-    List<Challenge> findAllByEndDateBetweenAndState(ZonedDateTime startOfStartDate, ZonedDateTime endOfStartDate, ChallengeState state);
+    List<Challenge> findAllByStartDateBetweenAndState(ZonedDateTime startOfMinute, ZonedDateTime endOfMinute, ChallengeState state);
+    List<Challenge> findAllByEndDateBetweenAndState(ZonedDateTime startOfMinute, ZonedDateTime endOfMinute, ChallengeState state);
 
     @Query(value = "SELECT * FROM challenge WHERE state = :state AND participating_days & :day = :day", nativeQuery = true)
     List<Challenge> findAllByStateAndParticipatingDays(

--- a/src/main/java/com/habitpay/habitpay/domain/challenge/domain/Challenge.java
+++ b/src/main/java/com/habitpay/habitpay/domain/challenge/domain/Challenge.java
@@ -177,7 +177,7 @@ public class Challenge extends BaseTime {
             if ((daysOfWeek & (1 << i)) != 0) {
 
                 DayOfWeek targetDay = DayOfWeek.of(7 - i);
-                ZonedDateTime startDateInLocal = TimeZoneConverter.convertEtcToLocalTimeZone(this.getStartDate());
+                ZonedDateTime startDateInLocal = TimeZoneConverter.convertEtcToLocalTimeZone(startDate);
                 ZonedDateTime targetDate = startDateInLocal.with(TemporalAdjusters.nextOrSame(targetDay));
 
                 // todo : 해결되면 삭제
@@ -187,7 +187,7 @@ public class Challenge extends BaseTime {
                 log.debug("first targetDate : {}", targetDate);
 
                 // todo
-                ZonedDateTime endDateInLocal = TimeZoneConverter.convertEtcToLocalTimeZone(this.getEndDate());
+                ZonedDateTime endDateInLocal = TimeZoneConverter.convertEtcToLocalTimeZone(endDate);
                 ZonedDateTime endDate = endDateInLocal.toLocalDate().atTime(LocalTime.MAX).atZone(endDateInLocal.getZone());
 
                 // todo : 해결되면 삭제

--- a/src/main/java/com/habitpay/habitpay/domain/challengescheduler/application/ChallengeSchedulerService.java
+++ b/src/main/java/com/habitpay/habitpay/domain/challengescheduler/application/ChallengeSchedulerService.java
@@ -11,6 +11,7 @@ import com.habitpay.habitpay.domain.participationstat.dao.ParticipationStatRepos
 import com.habitpay.habitpay.domain.participationstat.domain.ParticipationStat;
 import com.habitpay.habitpay.global.config.timezone.TimeZoneConverter;
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.scheduling.annotation.Scheduled;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -28,11 +29,8 @@ public class ChallengeSchedulerService {
 
     @Scheduled(cron = "0 * * * * *", zone = "Asia/Seoul")
     public void setChallengeForStart() {
-
         List<Challenge> challengeList = schedulerTaskHelperService.findStartingChallenges();
-
         challengeList.forEach(Challenge::setStateInProgress);
-
         schedulerTaskHelperService.createRecordsForChallenges(challengeList);
         challengeRepository.saveAll(challengeList);
     }
@@ -52,9 +50,7 @@ public class ChallengeSchedulerService {
 
     @Scheduled(cron = "0 * * * * *", zone = "Asia/Seoul")
     public void setChallengeForEnd() {
-        ZonedDateTime today = TimeZoneConverter.convertEtcToLocalTimeZone(ZonedDateTime.now());
-        ZonedDateTime yesterday = today.minusDays(1);
-        List<Challenge> challengeList = schedulerTaskHelperService.findEndingChallenges(yesterday);
+        List<Challenge> challengeList = schedulerTaskHelperService.findEndingChallenges();
         challengeList.forEach(Challenge::setStateCompletedPendingSettlement);
         challengeRepository.saveAll(challengeList);
     }

--- a/src/main/java/com/habitpay/habitpay/domain/challengescheduler/application/ChallengeSchedulerService.java
+++ b/src/main/java/com/habitpay/habitpay/domain/challengescheduler/application/ChallengeSchedulerService.java
@@ -26,10 +26,9 @@ public class ChallengeSchedulerService {
     private final ChallengeRepository challengeRepository;
     private final SchedulerTaskHelperService schedulerTaskHelperService;
 
-    @Scheduled(cron = "0 0 0 * * *", zone = "Asia/Seoul")
+    @Scheduled(cron = "0 * * * * *", zone = "Asia/Seoul")
     public void setChallengeForStart() {
 
-        // todo : 시작 날짜 ZonedDateTime으로 받고 있음 -> 날짜 데이터(without 시간)만으로 데이터 타입 바꾸기(프론트, 백 모두)
         List<Challenge> challengeList = schedulerTaskHelperService.findStartingChallenges();
 
         challengeList.forEach(Challenge::setStateInProgress);
@@ -51,7 +50,7 @@ public class ChallengeSchedulerService {
         schedulerTaskHelperService.checkFailedParticipation(challengeList, yesterday);
     }
 
-    @Scheduled(cron = "0 0 0 * * *", zone = "Asia/Seoul")
+    @Scheduled(cron = "0 * * * * *", zone = "Asia/Seoul")
     public void setChallengeForEnd() {
         ZonedDateTime today = TimeZoneConverter.convertEtcToLocalTimeZone(ZonedDateTime.now());
         ZonedDateTime yesterday = today.minusDays(1);

--- a/src/main/java/com/habitpay/habitpay/domain/challengescheduler/application/SchedulerTaskHelperService.java
+++ b/src/main/java/com/habitpay/habitpay/domain/challengescheduler/application/SchedulerTaskHelperService.java
@@ -20,7 +20,6 @@ import java.time.ZonedDateTime;
 import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
-import java.util.Map;
 
 @Service
 @RequiredArgsConstructor

--- a/src/main/java/com/habitpay/habitpay/domain/challengescheduler/application/SchedulerTaskHelperService.java
+++ b/src/main/java/com/habitpay/habitpay/domain/challengescheduler/application/SchedulerTaskHelperService.java
@@ -12,6 +12,7 @@ import com.habitpay.habitpay.domain.participationstat.dao.ParticipationStatRepos
 import com.habitpay.habitpay.domain.participationstat.domain.ParticipationStat;
 import com.habitpay.habitpay.global.config.timezone.TimeZoneConverter;
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
 
 import java.time.DayOfWeek;
@@ -23,6 +24,7 @@ import java.util.List;
 
 @Service
 @RequiredArgsConstructor
+@Slf4j
 public class SchedulerTaskHelperService {
 
     private final ChallengeRepository challengeRepository;
@@ -32,11 +34,12 @@ public class SchedulerTaskHelperService {
     private final ChallengeParticipationRecordSearchService challengeParticipationRecordSearchService;
 
     public List<Challenge> findStartingChallenges() {
-        ZonedDateTime today = TimeZoneConverter.convertEtcToLocalTimeZone(ZonedDateTime.now());
-        ZonedDateTime startOfDay = today.with(LocalTime.MIDNIGHT);
-        ZonedDateTime endOfDay = today.with(LocalTime.MAX);
+        ZonedDateTime now = TimeZoneConverter.convertEtcToLocalTimeZone(ZonedDateTime.now());
+        ZonedDateTime startOfMinute = now.withSecond(0).withNano(0);
+        ZonedDateTime endOfMinute = now.withSecond(59).withNano(999_999_999);
+        log.info("Fetching challenges starting at {}", startOfMinute);
 
-        return challengeRepository.findAllByStartDateBetweenAndState(startOfDay, endOfDay, ChallengeState.SCHEDULED);
+        return challengeRepository.findAllByStartDateBetweenAndState(startOfMinute, endOfMinute, ChallengeState.SCHEDULED);
     }
 
     public void createRecordsForChallenges(List<Challenge> challengeList) {
@@ -114,10 +117,12 @@ public class SchedulerTaskHelperService {
         return feeAddedChallengeList;
     }
 
-    public List<Challenge> findEndingChallenges(ZonedDateTime targetDay) {
-        ZonedDateTime startOfDay = targetDay.with(LocalTime.MIDNIGHT);
-        ZonedDateTime endOfDay = targetDay.with(LocalTime.MAX);
+    public List<Challenge> findEndingChallenges() {
+        ZonedDateTime now = TimeZoneConverter.convertEtcToLocalTimeZone(ZonedDateTime.now());
+        ZonedDateTime startOfMinute = now.withSecond(0).withNano(0);
+        ZonedDateTime endOfMinute = now.withSecond(59).withNano(999_999_999);
+        log.info("Fetching challenges ending at {}", startOfMinute);
 
-        return challengeRepository.findAllByEndDateBetweenAndState(startOfDay, endOfDay, ChallengeState.IN_PROGRESS);
+        return challengeRepository.findAllByEndDateBetweenAndState(startOfMinute, endOfMinute, ChallengeState.IN_PROGRESS);
     }
 }


### PR DESCRIPTION
### 개요

* 이전에는 `챌린지 시작 및 종료`를 매일 자정에 한 번씩 확인했습니다.
* 이제는 `챌린지 시작 및 종료`를 매 분마다 확인해 처리합니다.
* 덕분에 `챌린지 생성` 시 입력한 `시작 및 종료 시간대`에 맞춰 작동합니다.

---

### 코드 주요 내용

* 스케쥴러 메서드의 cron 설정을 매 분마다 작동하도록 변경했습니다.

```java
// ChallengeSchedulerService.java

@Scheduled(cron = "0 * * * * *", zone = "Asia/Seoul")
public void setChallengeForStart() {
    ...
}

...

@Scheduled(cron = "0 * * * * *", zone = "Asia/Seoul")
public void setChallengeForEnd() {
    ...
}
```

---

* 매 분 시작 및 종료하는 `챌린지`를 검색하기 위해서,
  현재 시간 `분 대에 해당하는 시작과 끝 초`를 이용한 변수를 사용하도록 변경했습니다.
  (이전에는 하루의 `시작(00:00)`과 `끝(23:59:999..)` 시간대를 사용했음)

```java
ZonedDateTime now = TimeZoneConverter.convertEtcToLocalTimeZone(ZonedDateTime.now());
ZonedDateTime startOfMinute = now.withSecond(0).withNano(0);
ZonedDateTime endOfMinute = now.withSecond(59).withNano(999_999_999);
...
return challengeRepository.findAllByStartDateBetweenAndState(startOfMinute, endOfMinute, ...);

```

---

* 챌린지 `생성일`과 `시작일`이 동일한 경우의 예외 처리 로직을 삭제했습니다.
* 이제 챌린지 `생성 시간`과 `시작 시간`이 동일할 수 없어 필요 없어졌기 때문입니다.
   (`현재 시간 이후`에만 챌린지가 가능하도록 되어있음)

---

* 기타 자잘한 리팩토링을 진행했습니다.