### PR TITLE
[refact] 스케쥴러 서비스 메서드 리팩토링(코멘트 반영) #317

### DIFF
--- a/src/main/java/com/habitpay/habitpay/domain/challenge/dao/ChallengeRepository.java
+++ b/src/main/java/com/habitpay/habitpay/domain/challenge/dao/ChallengeRepository.java
@@ -13,8 +13,10 @@ import java.util.List;
 
 public interface ChallengeRepository extends JpaRepository<Challenge, Long> {
 
-    // todo : startDate 받는 방식에 따라 필요하면 수정
+    @Query("SELECT c FROM Challenge c WHERE :startOfMinute <= c.startDate AND c.startDate < :endOfMinute")
     List<Challenge> findAllByStartDateBetweenAndState(ZonedDateTime startOfMinute, ZonedDateTime endOfMinute, ChallengeState state);
+
+    @Query("SELECT c FROM Challenge c WHERE :startOfMinute <= c.endDate AND c.endDate < :endOfMinute")
     List<Challenge> findAllByEndDateBetweenAndState(ZonedDateTime startOfMinute, ZonedDateTime endOfMinute, ChallengeState state);
 
     @Query(value = "SELECT * FROM challenge WHERE state = :state AND participating_days & :day = :day", nativeQuery = true)

--- a/src/main/java/com/habitpay/habitpay/domain/challenge/dao/ChallengeRepository.java
+++ b/src/main/java/com/habitpay/habitpay/domain/challenge/dao/ChallengeRepository.java
@@ -13,10 +13,10 @@ import java.util.List;
 
 public interface ChallengeRepository extends JpaRepository<Challenge, Long> {
 
-    @Query("SELECT c FROM Challenge c WHERE :startOfMinute <= c.startDate AND c.startDate < :endOfMinute")
+    @Query("SELECT c FROM Challenge c WHERE :startOfMinute <= c.startDate AND c.startDate < :endOfMinute AND c.state = :state")
     List<Challenge> findAllByStartDateBetweenAndState(ZonedDateTime startOfMinute, ZonedDateTime endOfMinute, ChallengeState state);
 
-    @Query("SELECT c FROM Challenge c WHERE :startOfMinute <= c.endDate AND c.endDate < :endOfMinute")
+    @Query("SELECT c FROM Challenge c WHERE :startOfMinute <= c.endDate AND c.endDate < :endOfMinute AND c.state = :state")
     List<Challenge> findAllByEndDateBetweenAndState(ZonedDateTime startOfMinute, ZonedDateTime endOfMinute, ChallengeState state);
 
     @Query(value = "SELECT * FROM challenge WHERE state = :state AND participating_days & :day = :day", nativeQuery = true)

--- a/src/main/java/com/habitpay/habitpay/domain/challengescheduler/application/SchedulerTaskHelperService.java
+++ b/src/main/java/com/habitpay/habitpay/domain/challengescheduler/application/SchedulerTaskHelperService.java
@@ -36,7 +36,7 @@ public class SchedulerTaskHelperService {
     public List<Challenge> findStartingChallenges() {
         ZonedDateTime now = TimeZoneConverter.convertEtcToLocalTimeZone(ZonedDateTime.now());
         ZonedDateTime startOfMinute = now.withSecond(0).withNano(0);
-        ZonedDateTime endOfMinute = now.withSecond(59).withNano(999_999_999);
+        ZonedDateTime endOfMinute = now.plusMinutes(1).withSecond(0).withNano(0);
         log.info("Fetching challenges starting at {}", startOfMinute);
 
         return challengeRepository.findAllByStartDateBetweenAndState(startOfMinute, endOfMinute, ChallengeState.SCHEDULED);
@@ -120,7 +120,7 @@ public class SchedulerTaskHelperService {
     public List<Challenge> findEndingChallenges() {
         ZonedDateTime now = TimeZoneConverter.convertEtcToLocalTimeZone(ZonedDateTime.now());
         ZonedDateTime startOfMinute = now.withSecond(0).withNano(0);
-        ZonedDateTime endOfMinute = now.withSecond(59).withNano(999_999_999);
+        ZonedDateTime endOfMinute = now.plusMinutes(1).withSecond(0).withNano(0);
         log.info("Fetching challenges ending at {}", startOfMinute);
 
         return challengeRepository.findAllByEndDateBetweenAndState(startOfMinute, endOfMinute, ChallengeState.IN_PROGRESS);


### PR DESCRIPTION
### 변경사항

* 이전에는 챌린지 시작과 종료를 매 분마다 확인하는 스케쥴러 메서드가 나노초를 기준으로 작동했습니다.
```java
// before
// SchedulerTaskHelperService.java
ZonedDateTime startOfMinute = now.withSecond(0).withNano(0);
ZonedDateTime endOfMinute = now.withSecond(59).withNano(999);
```

* 의미를 살리고 더 정확하게 작동하도록, 1분을 더하는 메서드를 사용하도록 변경했습니다.
```java
// after
// SchedulerTaskHelperService.java
ZonedDateTime startOfMinute = now.withSecond(0).withNano(0);
ZonedDateTime endOfMinute = now.plusMinutes(1).withSecond(0).withNano(0);
```

* DB 조회 메서드에서 `startOfMinute`와 `endOfMinute` 변수를 인자로 받을 때, `이상 이하` 대신 `이상 미만`을 기준으로 작동하도록 쿼리문을 붙였습니다.

```java
// ChallengeRepository.java

@Query("SELECT c FROM Challenge c WHERE :startOfMinute <= c.startDate AND c.startDate < :endOfMinute AND c.state = :state")
List<Challenge> findAllByStartDateBetweenAndState(ZonedDateTime startOfMinute, ZonedDateTime endOfMinute, ChallengeState state);

@Query("SELECT c FROM Challenge c WHERE :startOfMinute <= c.endDate AND c.endDate < :endOfMinute AND c.state = :state")
List<Challenge> findAllByEndDateBetweenAndState(ZonedDateTime startOfMinute, ZonedDateTime endOfMinute, ChallengeState state);
```