### PR TITLE
[feat] 포스트 수정(이미지 파일 변경) 시, DTO에 빈 배열 대신 null이 있을 경우 null 방어 추가 #319

### DIFF
--- a/src/main/java/com/habitpay/habitpay/domain/challengepost/application/ChallengePostUpdateService.java
+++ b/src/main/java/com/habitpay/habitpay/domain/challengepost/application/ChallengePostUpdateService.java
@@ -10,6 +10,7 @@ import com.habitpay.habitpay.domain.challengepost.dto.ModifyPostRequest;
 import com.habitpay.habitpay.domain.member.domain.Member;
 import com.habitpay.habitpay.domain.postphoto.application.PostPhotoCreationService;
 import com.habitpay.habitpay.domain.postphoto.application.PostPhotoDeleteService;
+import com.habitpay.habitpay.domain.postphoto.application.PostPhotoUpdateService;
 import com.habitpay.habitpay.domain.postphoto.application.PostPhotoUtilService;
 import com.habitpay.habitpay.global.error.exception.ErrorCode;
 import com.habitpay.habitpay.global.error.exception.ForbiddenException;
@@ -28,6 +29,7 @@ import java.util.List;
 public class ChallengePostUpdateService {
 
     private final PostPhotoCreationService postPhotoCreationService;
+    private final PostPhotoUpdateService postPhotoUpdateService;
     private final PostPhotoUtilService postPhotoUtilService;
     private final PostPhotoDeleteService postPhotoDeleteService;
     private final ChallengeSearchService challengeSearchService;
@@ -57,8 +59,7 @@ public class ChallengePostUpdateService {
         challengePostRepository.save(post);
 
         postPhotoDeleteService.deleteByIds(postId, request.getDeletedPhotoIds());
-        request.getModifiedPhotos().forEach(photo -> postPhotoUtilService.changeViewOrder(photo.getPhotoId(), photo.getViewOrder()));
-
+        postPhotoUpdateService.changePhotoViewOrder(request.getModifiedPhotos());
         List<String> presignedUrlList = postPhotoCreationService.createPhotoUrlList(
                 challengePostSearchService.getChallengePostById(postId), request.getNewPhotos()
         );

--- a/src/main/java/com/habitpay/habitpay/domain/postphoto/application/PostPhotoDeleteService.java
+++ b/src/main/java/com/habitpay/habitpay/domain/postphoto/application/PostPhotoDeleteService.java
@@ -9,8 +9,10 @@ import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
 
+import java.util.Collections;
 import java.util.List;
 import java.util.NoSuchElementException;
+import java.util.Optional;
 
 @RequiredArgsConstructor
 @Service
@@ -32,7 +34,8 @@ public class PostPhotoDeleteService {
     public void deleteByIds(Long postId, List<Long> photoIdList) {
         ChallengePost post = challengePostSearchService.getChallengePostById(postId);
 
-        photoIdList.forEach(photoId -> {
+        Optional.ofNullable(photoIdList).orElse(Collections.emptyList())
+        .forEach(photoId -> {
             if (postPhotoUtilService.photoBelongToPost(photoId, post)) {
                 this.deleteById(photoId);
             }

--- a/src/main/java/com/habitpay/habitpay/domain/postphoto/application/PostPhotoUpdateService.java
+++ b/src/main/java/com/habitpay/habitpay/domain/postphoto/application/PostPhotoUpdateService.java
@@ -1,0 +1,21 @@
+package com.habitpay.habitpay.domain.postphoto.application;
+
+import com.habitpay.habitpay.domain.postphoto.dto.ModifyPostPhotoData;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+import java.util.Collections;
+import java.util.List;
+import java.util.Optional;
+
+@RequiredArgsConstructor
+@Service
+public class PostPhotoUpdateService {
+
+    private final PostPhotoUtilService postPhotoUtilService;
+
+    public void changePhotoViewOrder(List<ModifyPostPhotoData> modifyPostPhotoDataList) {
+        Optional.ofNullable(modifyPostPhotoDataList).orElse(Collections.emptyList())
+                .forEach(photo -> postPhotoUtilService.changeViewOrder(photo.getPhotoId(), photo.getViewOrder()));
+    }
+}


### PR DESCRIPTION
### 개요

* 포스트 수정 시 이미지 파일 변경이 발생하면, DTO에 `삭제할 포토 목록, 순서 변경되는 포토 목록, 새로 추가되는 포토 목록`이 각각 List로 전달됩니다.
* 이때 변경 내역이 없어 `List`가 `빈 배열`이 아닌 `null`로 전달되면 에러가 `exception`이 발생합니다.
* 변경 내역이 없을 경우 프론트엔드에서 빈 배열을 보내주기 때문에 에러가 발생하지는 않지만, 안전함을 위해 null 방어를 추가했습니다.
* 약간의 리팩토링을 진행했습니다.

---

### 코드 주요 내용

```java
...
 Optional.ofNullable(listFromDTO).orElse(Collections.emptyList())
...
```

* `새로 추가되는 포토 목록`은 이미 null 처리가 되어 있기 때문에, `삭제할 포토 목록, 순서 변경되는 포토 목록`의 경우에만 위처럼 `Optional`을 이용해 `null`일 경우 `빈 배열`을 반환해 처리하도록 했습니다.

---

### 약간 고민

* 변경 사항이 없을 경우 프론트엔드에서 `빈 list`를 보내기 때문에 `null`이 올 일은 없음
* 그러나 `Optional`의 비용을 써서까지 `null 방어`를 해야 할까?
* 하지만 확장성을 고려하면 시큐어 코딩해서 나쁠 건 없을지도?
   (프론트엔드 수정 전 null이 문제가 된 적이 있어 수정한 거긴 함)