### PR TITLE
Fix/게시물 pageable response dto 1부터 반환하도록 수정#322

### DIFF
--- a/src/main/java/com/habitpay/habitpay/domain/challengepost/api/ChallengePostApi.java
+++ b/src/main/java/com/habitpay/habitpay/domain/challengepost/api/ChallengePostApi.java
@@ -8,7 +8,9 @@ import com.habitpay.habitpay.domain.challengepost.dto.AddPostRequest;
 import com.habitpay.habitpay.domain.challengepost.dto.ModifyPostRequest;
 import com.habitpay.habitpay.domain.challengepost.dto.PostViewResponse;
 import com.habitpay.habitpay.global.config.auth.CustomUserDetails;
+import com.habitpay.habitpay.global.response.SliceResponse;
 import com.habitpay.habitpay.global.response.SuccessResponse;
+import java.util.List;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.data.domain.Pageable;
@@ -16,9 +18,14 @@ import org.springframework.data.domain.Slice;
 import org.springframework.data.domain.Sort;
 import org.springframework.data.web.PageableDefault;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
-import org.springframework.web.bind.annotation.*;
-
-import java.util.List;
+import org.springframework.web.bind.annotation.DeleteMapping;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PatchMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
 
 @RestController
 @RequiredArgsConstructor
@@ -33,35 +40,37 @@ public class ChallengePostApi {
 
     @GetMapping("/posts/{id}")
     public SuccessResponse<PostViewResponse> getPost(
-            @PathVariable Long id,
-            @AuthenticationPrincipal CustomUserDetails user) {
+        @PathVariable Long id,
+        @AuthenticationPrincipal CustomUserDetails user) {
 
         return challengePostSearchService.getPostViewByPostId(id, user.getMember());
     }
 
     @GetMapping("/challenges/{id}/posts")
-    public SuccessResponse<Slice<PostViewResponse>> getChallengePosts(
-            @PathVariable("id") Long id,
-            @AuthenticationPrincipal CustomUserDetails user,
-            @PageableDefault(sort = "id", direction = Sort.Direction.DESC) Pageable pageable) {
+    public SuccessResponse<SliceResponse<PostViewResponse>> getChallengePosts(
+        @PathVariable("id") Long id,
+        @AuthenticationPrincipal CustomUserDetails user,
+        @PageableDefault(sort = "id", direction = Sort.Direction.DESC) Pageable pageable) {
 
-        return challengePostSearchService.findPostViewListByChallengeId(id, user.getMember(), pageable);
+        return challengePostSearchService.findPostViewListByChallengeId(id, user.getMember(),
+            pageable);
     }
 
     @GetMapping("/challenges/{id}/posts/announcements")
     public SuccessResponse<Slice<PostViewResponse>> getAnnouncements(
-            @PathVariable Long id,
-            @AuthenticationPrincipal CustomUserDetails user,
-            @PageableDefault(sort = "id", direction = Sort.Direction.DESC) Pageable pageable) {
+        @PathVariable Long id,
+        @AuthenticationPrincipal CustomUserDetails user,
+        @PageableDefault(sort = "id", direction = Sort.Direction.DESC) Pageable pageable) {
 
-        return challengePostSearchService.findAnnouncementPostViewListByChallengeId(id, user.getMember(), pageable);
+        return challengePostSearchService.findAnnouncementPostViewListByChallengeId(id,
+            user.getMember(), pageable);
     }
 
     @GetMapping("/challenges/{id}/posts/me")
     public SuccessResponse<Slice<PostViewResponse>> getChallengePostsByMe(
-            @PathVariable Long id,
-            @AuthenticationPrincipal CustomUserDetails user,
-            @PageableDefault(sort = "id", direction = Sort.Direction.DESC) Pageable pageable) {
+        @PathVariable Long id,
+        @AuthenticationPrincipal CustomUserDetails user,
+        @PageableDefault(sort = "id", direction = Sort.Direction.DESC) Pageable pageable) {
 
         return challengePostSearchService.findPostViewListByMember(id, user.getMember(), pageable);
     }
@@ -81,26 +90,26 @@ public class ChallengePostApi {
 
     @PostMapping("/challenges/{id}/posts")
     public SuccessResponse<List<String>> createPost(
-            @RequestBody AddPostRequest request,
-            @PathVariable("id") Long id,
-            @AuthenticationPrincipal CustomUserDetails user) {
+        @RequestBody AddPostRequest request,
+        @PathVariable("id") Long id,
+        @AuthenticationPrincipal CustomUserDetails user) {
         return challengePostCreationService.createPost(request, id, user.getMember());
     }
 
     @PatchMapping("/challenges/{challengeId}/posts/{postId}")
     public SuccessResponse<List<String>> patchPost(
-            @RequestBody ModifyPostRequest request, @PathVariable("challengeId") Long challengeId,
-            @PathVariable("postId") Long postId,
-            @AuthenticationPrincipal CustomUserDetails user) {
+        @RequestBody ModifyPostRequest request, @PathVariable("challengeId") Long challengeId,
+        @PathVariable("postId") Long postId,
+        @AuthenticationPrincipal CustomUserDetails user) {
 
         return challengePostUpdateService.patchPost(request, challengeId, postId, user.getMember());
     }
 
     @DeleteMapping("/challenges/{challengeId}/posts/{postId}")
     public SuccessResponse<Void> deletePost(
-            @PathVariable("challengeId") Long challengeId,
-            @PathVariable("postId") Long postId,
-            @AuthenticationPrincipal CustomUserDetails user) {
+        @PathVariable("challengeId") Long challengeId,
+        @PathVariable("postId") Long postId,
+        @AuthenticationPrincipal CustomUserDetails user) {
 
         return challengePostDeleteService.deletePost(challengeId, postId, user.getMember());
     }

--- a/src/main/java/com/habitpay/habitpay/global/response/SliceResponse.java
+++ b/src/main/java/com/habitpay/habitpay/global/response/SliceResponse.java
@@ -1,0 +1,30 @@
+package com.habitpay.habitpay.global.response;
+
+import java.util.List;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.Slice;
+
+public record SliceResponse<T>(
+    List<T> content,
+    int pageNumber,
+    int size,
+    boolean isLast,
+    boolean isFirst,
+    boolean isEmpty,
+    boolean hasNextPage,
+    Pageable pageable
+) {
+
+    public static <T> SliceResponse<T> from(Slice<T> slice) {
+        return new SliceResponse<>(
+            slice.getContent(),
+            slice.getNumber() + 1,
+            slice.getNumberOfElements(),
+            slice.isLast(),
+            slice.isFirst(),
+            slice.isEmpty(),
+            slice.hasNext(),
+            slice.getPageable()
+        );
+    }
+}

--- a/src/test/java/com/habitpay/habitpay/domain/challegepost/api/ChallengePostApiTest.java
+++ b/src/test/java/com/habitpay/habitpay/domain/challegepost/api/ChallengePostApiTest.java
@@ -1,9 +1,28 @@
 package com.habitpay.habitpay.domain.challegepost.api;
 
+import static org.mockito.ArgumentMatchers.anyLong;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.any;
+import static org.springframework.restdocs.headers.HeaderDocumentation.headerWithName;
+import static org.springframework.restdocs.headers.HeaderDocumentation.requestHeaders;
+import static org.springframework.restdocs.mockmvc.MockMvcRestDocumentation.document;
+import static org.springframework.restdocs.mockmvc.RestDocumentationRequestBuilders.delete;
+import static org.springframework.restdocs.mockmvc.RestDocumentationRequestBuilders.get;
+import static org.springframework.restdocs.mockmvc.RestDocumentationRequestBuilders.patch;
+import static org.springframework.restdocs.mockmvc.RestDocumentationRequestBuilders.post;
+import static org.springframework.restdocs.payload.PayloadDocumentation.fieldWithPath;
+import static org.springframework.restdocs.payload.PayloadDocumentation.requestFields;
+import static org.springframework.restdocs.payload.PayloadDocumentation.responseFields;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.habitpay.habitpay.docs.springrestdocs.AbstractRestDocsTests;
 import com.habitpay.habitpay.domain.challengepost.api.ChallengePostApi;
-import com.habitpay.habitpay.domain.challengepost.application.*;
+import com.habitpay.habitpay.domain.challengepost.application.ChallengePostCreationService;
+import com.habitpay.habitpay.domain.challengepost.application.ChallengePostDeleteService;
+import com.habitpay.habitpay.domain.challengepost.application.ChallengePostSearchService;
+import com.habitpay.habitpay.domain.challengepost.application.ChallengePostUpdateService;
+import com.habitpay.habitpay.domain.challengepost.application.ChallengePostUtilService;
 import com.habitpay.habitpay.domain.challengepost.dto.AddPostRequest;
 import com.habitpay.habitpay.domain.challengepost.dto.ModifyPostRequest;
 import com.habitpay.habitpay.domain.challengepost.dto.PostViewResponse;
@@ -15,9 +34,12 @@ import com.habitpay.habitpay.global.config.jwt.TokenProvider;
 import com.habitpay.habitpay.global.config.jwt.TokenService;
 import com.habitpay.habitpay.global.error.exception.ErrorCode;
 import com.habitpay.habitpay.global.error.exception.ForbiddenException;
+import com.habitpay.habitpay.global.response.SliceResponse;
 import com.habitpay.habitpay.global.response.SuccessCode;
 import com.habitpay.habitpay.global.response.SuccessResponse;
 import com.habitpay.habitpay.global.security.WithMockOAuth2User;
+import java.time.LocalDateTime;
+import java.util.List;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -30,19 +52,6 @@ import org.springframework.data.domain.SliceImpl;
 import org.springframework.http.HttpHeaders;
 import org.springframework.http.MediaType;
 import org.springframework.test.web.servlet.ResultActions;
-
-import java.time.LocalDateTime;
-import java.util.List;
-
-import static org.mockito.ArgumentMatchers.anyLong;
-import static org.mockito.BDDMockito.given;
-import static org.mockito.Mockito.any;
-import static org.springframework.restdocs.headers.HeaderDocumentation.headerWithName;
-import static org.springframework.restdocs.headers.HeaderDocumentation.requestHeaders;
-import static org.springframework.restdocs.mockmvc.MockMvcRestDocumentation.document;
-import static org.springframework.restdocs.mockmvc.RestDocumentationRequestBuilders.*;
-import static org.springframework.restdocs.payload.PayloadDocumentation.*;
-import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
 @WebMvcTest(ChallengePostApi.class)
 public class ChallengePostApiTest extends AbstractRestDocsTests {
@@ -81,50 +90,50 @@ public class ChallengePostApiTest extends AbstractRestDocsTests {
 
         // given
         PostViewResponse mockPostViewResponse = PostViewResponse.builder()
-                .id(1L)
-                .challengeId(1L)
-                .content("This is test post.")
-                .writer("test user")
-                .isPostAuthor(true)
-                .profileUrl("https://picsum.photos/id/40/200/300")
-                .isAnnouncement(false)
-                .createdAt(LocalDateTime.now())
-                .photoViewList(List.of(
-                        new PostPhotoView(1L, 1L, "https://picsum.photos/id/40/200/300"),
-                        new PostPhotoView(2L, 2L, "https://picsum.photos/id/40/200/300")))
-                .build();
+            .id(1L)
+            .challengeId(1L)
+            .content("This is test post.")
+            .writer("test user")
+            .isPostAuthor(true)
+            .profileUrl("https://picsum.photos/id/40/200/300")
+            .isAnnouncement(false)
+            .createdAt(LocalDateTime.now())
+            .photoViewList(List.of(
+                new PostPhotoView(1L, 1L, "https://picsum.photos/id/40/200/300"),
+                new PostPhotoView(2L, 2L, "https://picsum.photos/id/40/200/300")))
+            .build();
 
         given(challengePostSearchService.getPostViewByPostId(anyLong(), any(Member.class)))
-                .willReturn(SuccessResponse.of(SuccessCode.NO_MESSAGE, mockPostViewResponse));
+            .willReturn(SuccessResponse.of(SuccessCode.NO_MESSAGE, mockPostViewResponse));
 
         // when
         ResultActions result = mockMvc.perform(get("/api/posts/{id}", 1L)
-                .header(HttpHeaders.AUTHORIZATION, AUTHORIZATION_HEADER_PREFIX + "ACCESS_TOKEN"));
+            .header(HttpHeaders.AUTHORIZATION, AUTHORIZATION_HEADER_PREFIX + "ACCESS_TOKEN"));
 
         //then
         result.andExpect(status().isOk())
-                .andDo(document("challengePost/get-challenge-post",
-                        requestHeaders(
-                                headerWithName(HttpHeaders.AUTHORIZATION).description("액세스 토큰")
-                        ),
-                        responseFields(
-                                fieldWithPath("message").description("응답 메시지"),
-                                fieldWithPath("data").description("응답 데이터"),
+            .andDo(document("challengePost/get-challenge-post",
+                requestHeaders(
+                    headerWithName(HttpHeaders.AUTHORIZATION).description("액세스 토큰")
+                ),
+                responseFields(
+                    fieldWithPath("message").description("응답 메시지"),
+                    fieldWithPath("data").description("응답 데이터"),
 
-                                fieldWithPath("data.id").description("포스트 id"),
-                                fieldWithPath("data.challengeId").description("포스트가 소속된 challenge id"),
-                                fieldWithPath("data.content").description("포스트 내용"),
-                                fieldWithPath("data.writer").description("작성자"),
-                                fieldWithPath("data.isPostAuthor").description("요청한 멤버가 작성자 본인인지 여부"),
-                                fieldWithPath("data.profileUrl").description("작성자 프로필 이미지 URL"),
-                                fieldWithPath("data.isAnnouncement").description("공지글 여부"),
-                                fieldWithPath("data.createdAt").description("생성 일시"),
-                                fieldWithPath("data.photoViewList").description("포스트 포토(URL 포함) 데이터를 담은 객체 배열"),
-                                fieldWithPath("data.photoViewList[].postPhotoId").description("포토 id"),
-                                fieldWithPath("data.photoViewList[].viewOrder").description("포스트 내 포토의 순서"),
-                                fieldWithPath("data.photoViewList[].imageUrl").description("포스트 포토 url")
-                        )
-                ));
+                    fieldWithPath("data.id").description("포스트 id"),
+                    fieldWithPath("data.challengeId").description("포스트가 소속된 challenge id"),
+                    fieldWithPath("data.content").description("포스트 내용"),
+                    fieldWithPath("data.writer").description("작성자"),
+                    fieldWithPath("data.isPostAuthor").description("요청한 멤버가 작성자 본인인지 여부"),
+                    fieldWithPath("data.profileUrl").description("작성자 프로필 이미지 URL"),
+                    fieldWithPath("data.isAnnouncement").description("공지글 여부"),
+                    fieldWithPath("data.createdAt").description("생성 일시"),
+                    fieldWithPath("data.photoViewList").description("포스트 포토(URL 포함) 데이터를 담은 객체 배열"),
+                    fieldWithPath("data.photoViewList[].postPhotoId").description("포토 id"),
+                    fieldWithPath("data.photoViewList[].viewOrder").description("포스트 내 포토의 순서"),
+                    fieldWithPath("data.photoViewList[].imageUrl").description("포스트 포토 url")
+                )
+            ));
     }
 
     @Test
@@ -134,87 +143,93 @@ public class ChallengePostApiTest extends AbstractRestDocsTests {
 
         // given
         List<PostViewResponse> mockPostViewResponseList = List.of(
-                PostViewResponse.builder()
-                        .id(1L)
-                        .challengeId(1L)
-                        .content("This is test post 1.")
-                        .writer("test user")
-                        .isPostAuthor(true)
-                        .profileUrl("")
-                        .isAnnouncement(false)
-                        .createdAt(LocalDateTime.now())
-                        .photoViewList(List.of(new PostPhotoView(1L, 1L, "https://picsum.photos/id/40/200/300")))
-                        .build(),
-                PostViewResponse.builder()
-                        .id(2L)
-                        .challengeId(2L)
-                        .content("This is test post 2.")
-                        .writer("test user2")
-                        .isPostAuthor(false)
-                        .profileUrl("https://picsum.photos/id/40/200/300")
-                        .isAnnouncement(false)
-                        .createdAt(LocalDateTime.now())
-                        .photoViewList(List.of(new PostPhotoView(2L, 2L, "https://picsum.photos/id/40/200/300")))
-                        .build());
+            PostViewResponse.builder()
+                .id(1L)
+                .challengeId(1L)
+                .content("This is test post 1.")
+                .writer("test user")
+                .isPostAuthor(true)
+                .profileUrl("")
+                .isAnnouncement(false)
+                .createdAt(LocalDateTime.now())
+                .photoViewList(
+                    List.of(new PostPhotoView(1L, 1L, "https://picsum.photos/id/40/200/300")))
+                .build(),
+            PostViewResponse.builder()
+                .id(2L)
+                .challengeId(2L)
+                .content("This is test post 2.")
+                .writer("test user2")
+                .isPostAuthor(false)
+                .profileUrl("https://picsum.photos/id/40/200/300")
+                .isAnnouncement(false)
+                .createdAt(LocalDateTime.now())
+                .photoViewList(
+                    List.of(new PostPhotoView(2L, 2L, "https://picsum.photos/id/40/200/300")))
+                .build());
 
         Slice<PostViewResponse> mockPostViewResponseSlice = new SliceImpl<>(
-                mockPostViewResponseList, PageRequest.of(0, 10), true
+            mockPostViewResponseList, PageRequest.of(0, 10), true
         );
 
-        given(challengePostSearchService.findPostViewListByChallengeId(anyLong(), any(Member.class), any(Pageable.class)))
-                .willReturn(SuccessResponse.of(SuccessCode.NO_MESSAGE, mockPostViewResponseSlice));
+        given(challengePostSearchService.findPostViewListByChallengeId(anyLong(), any(Member.class),
+            any(Pageable.class)))
+            .willReturn(SuccessResponse.of(SuccessCode.NO_MESSAGE,
+                SliceResponse.from(mockPostViewResponseSlice)
+            ));
 
         // when
         ResultActions result = mockMvc.perform(get("/api/challenges/{id}/posts", 1L)
-                .header(HttpHeaders.AUTHORIZATION, AUTHORIZATION_HEADER_PREFIX + "ACCESS_TOKEN"));
+            .header(HttpHeaders.AUTHORIZATION, AUTHORIZATION_HEADER_PREFIX + "ACCESS_TOKEN"));
 
         //then
         result.andExpect(status().isOk())
-                .andDo(document("challengePost/get-challenge-posts",
-                        requestHeaders(
-                                headerWithName(HttpHeaders.AUTHORIZATION).description("액세스 토큰")
-                        ),
-                        responseFields(
-                                fieldWithPath("message").description("응답 메시지"),
-                                fieldWithPath("data").description("응답 데이터"),
+            .andDo(document("challengePost/get-challenge-posts",
+                requestHeaders(
+                    headerWithName(HttpHeaders.AUTHORIZATION).description("액세스 토큰")
+                ),
+                responseFields(
+                    fieldWithPath("message").description("응답 메시지"),
+                    fieldWithPath("data").description("응답 데이터"),
 
-                                fieldWithPath("data.content").description("포스트 뷰 목록"),
-                                fieldWithPath("data.content[].id").description("포스트 id"),
-                                fieldWithPath("data.content[].challengeId").description("포스트가 소속된 challenge id"),
-                                fieldWithPath("data.content[].content").description("포스트 내용"),
-                                fieldWithPath("data.content[].writer").description("작성자"),
-                                fieldWithPath("data.content[].isPostAuthor").description("요청한 멤버가 작성자 본인인지 여부"),
-                                fieldWithPath("data.content[].profileUrl").description("작성자 프로필 이미지 URL"),
-                                fieldWithPath("data.content[].isAnnouncement").description("공지글 여부"),
-                                fieldWithPath("data.content[].createdAt").description("생성 일시"),
-                                fieldWithPath("data.content[].photoViewList").description("포스트 포토(URL 포함) 데이터를 담은 객체 배열"),
-                                fieldWithPath("data.content[].photoViewList[].postPhotoId").description("포토 id"),
-                                fieldWithPath("data.content[].photoViewList[].viewOrder").description("포스트 내 포토의 순서"),
-                                fieldWithPath("data.content[].photoViewList[].imageUrl").description("포스트 포토 url"),
+                    fieldWithPath("data.content").description("포스트 뷰 목록"),
+                    fieldWithPath("data.content[].id").description("포스트 id"),
+                    fieldWithPath("data.content[].challengeId").description(
+                        "포스트가 소속된 challenge id"),
+                    fieldWithPath("data.content[].content").description("포스트 내용"),
+                    fieldWithPath("data.content[].writer").description("작성자"),
+                    fieldWithPath("data.content[].isPostAuthor").description("요청한 멤버가 작성자 본인인지 여부"),
+                    fieldWithPath("data.content[].profileUrl").description("작성자 프로필 이미지 URL"),
+                    fieldWithPath("data.content[].isAnnouncement").description("공지글 여부"),
+                    fieldWithPath("data.content[].createdAt").description("생성 일시"),
+                    fieldWithPath("data.content[].photoViewList").description(
+                        "포스트 포토(URL 포함) 데이터를 담은 객체 배열"),
+                    fieldWithPath("data.content[].photoViewList[].postPhotoId").description(
+                        "포토 id"),
+                    fieldWithPath("data.content[].photoViewList[].viewOrder").description(
+                        "포스트 내 포토의 순서"),
+                    fieldWithPath("data.content[].photoViewList[].imageUrl").description(
+                        "포스트 포토 url"),
 
-                                fieldWithPath("data.pageable").description("포스트 뷰 페이지네이션 정보를 담은 Pageable 객체"),
-                                fieldWithPath("data.pageable.pageNumber").description("현재 페이지 번호"),
-                                fieldWithPath("data.pageable.pageSize").description("한 페이지에 포함되는 항목의 수"),
-                                fieldWithPath("data.pageable.sort").description("정렬 정보"),
-                                fieldWithPath("data.pageable.sort.empty").description("정렬 조건이 없는지 여부"),
-                                fieldWithPath("data.pageable.sort.unsorted").description("정렬되지 않았는지 여부"),
-                                fieldWithPath("data.pageable.sort.sorted").description("정렬되었는지 여부"),
-                                fieldWithPath("data.pageable.offset").description("페이징된 항목의 시작 위치"),
-                                fieldWithPath("data.pageable.paged").description("페이징된 요청인지 여부"),
-                                fieldWithPath("data.pageable.unpaged").description("페이징되지 않은 요청인지 여부"),
+                    fieldWithPath("data.pageNumber").description("현재 페이지 번호"),
+                    fieldWithPath("data.size").description("현재 페이지의 크기"),
+                    fieldWithPath("data.isFirst").description("이 페이지가 첫 번째 페이지인지 여부"),
+                    fieldWithPath("data.isLast").description("이 페이지가 마지막 페이지인지 여부"),
+                    fieldWithPath("data.isEmpty").description("페이지가 비어있는지 여부"),
+                    fieldWithPath("data.hasNextPage").description("다음 페이지 존재 여부"),
 
-                                fieldWithPath("data.size").description("한 페이지에 포함되는 항목의 수"),
-                                fieldWithPath("data.number").description("현재 페이지 번호"),
-                                fieldWithPath("data.sort").description("정렬 정보"),
-                                fieldWithPath("data.sort.empty").description("정렬 조건이 없는지 여부"),
-                                fieldWithPath("data.sort.unsorted").description("정렬되지 않았는지 여부"),
-                                fieldWithPath("data.sort.sorted").description("정렬되었는지 여부"),
-                                fieldWithPath("data.numberOfElements").description("현재 페이지에 있는 요소의 수"),
-                                fieldWithPath("data.first").description("이 페이지가 첫 번째 페이지인지 여부"),
-                                fieldWithPath("data.last").description("이 페이지가 마지막 페이지인지 여부"),
-                                fieldWithPath("data.empty").description("페이지가 비어있는지 여부")
-                        )
-                ));
+                    fieldWithPath("data.pageable").description("포스트 뷰 페이지네이션 정보를 담은 Pageable 객체"),
+                    fieldWithPath("data.pageable.pageNumber").description("현재 페이지 번호"),
+                    fieldWithPath("data.pageable.pageSize").description("한 페이지에 포함되는 항목의 수"),
+                    fieldWithPath("data.pageable.sort").description("정렬 정보"),
+                    fieldWithPath("data.pageable.sort.empty").description("정렬 조건이 없는지 여부"),
+                    fieldWithPath("data.pageable.sort.unsorted").description("정렬되지 않았는지 여부"),
+                    fieldWithPath("data.pageable.sort.sorted").description("정렬되었는지 여부"),
+                    fieldWithPath("data.pageable.offset").description("페이징된 항목의 시작 위치"),
+                    fieldWithPath("data.pageable.paged").description("페이징된 요청인지 여부"),
+                    fieldWithPath("data.pageable.unpaged").description("페이징되지 않은 요청인지 여부")
+                )
+            ));
     }
 
     @Test
@@ -224,87 +239,95 @@ public class ChallengePostApiTest extends AbstractRestDocsTests {
 
         // given
         List<PostViewResponse> mockPostViewResponseList = List.of(
-                PostViewResponse.builder()
-                        .id(1L)
-                        .challengeId(1L)
-                        .content("This is announcement test post 1.")
-                        .writer("test user")
-                        .isPostAuthor(false)
-                        .profileUrl("")
-                        .isAnnouncement(true)
-                        .createdAt(LocalDateTime.now())
-                        .photoViewList(List.of(new PostPhotoView(1L, 1L, "https://picsum.photos/id/40/200/300")))
-                        .build(),
-                PostViewResponse.builder()
-                        .id(2L)
-                        .challengeId(2L)
-                        .content("This is announcement test post 2.")
-                        .writer("test user")
-                        .isPostAuthor(false)
-                        .profileUrl("https://picsum.photos/id/40/200/300")
-                        .isAnnouncement(true)
-                        .createdAt(LocalDateTime.now())
-                        .photoViewList(List.of(new PostPhotoView(2L, 2L, "https://picsum.photos/id/40/200/300")))
-                        .build());
+            PostViewResponse.builder()
+                .id(1L)
+                .challengeId(1L)
+                .content("This is announcement test post 1.")
+                .writer("test user")
+                .isPostAuthor(false)
+                .profileUrl("")
+                .isAnnouncement(true)
+                .createdAt(LocalDateTime.now())
+                .photoViewList(
+                    List.of(new PostPhotoView(1L, 1L, "https://picsum.photos/id/40/200/300")))
+                .build(),
+            PostViewResponse.builder()
+                .id(2L)
+                .challengeId(2L)
+                .content("This is announcement test post 2.")
+                .writer("test user")
+                .isPostAuthor(false)
+                .profileUrl("https://picsum.photos/id/40/200/300")
+                .isAnnouncement(true)
+                .createdAt(LocalDateTime.now())
+                .photoViewList(
+                    List.of(new PostPhotoView(2L, 2L, "https://picsum.photos/id/40/200/300")))
+                .build());
 
         Slice<PostViewResponse> mockPostViewResponseSlice = new SliceImpl<>(
-                mockPostViewResponseList, PageRequest.of(0, 10), true
+            mockPostViewResponseList, PageRequest.of(0, 10), true
         );
 
-        given(challengePostSearchService.findAnnouncementPostViewListByChallengeId(anyLong(), any(Member.class), any(Pageable.class)))
-                .willReturn(SuccessResponse.of(SuccessCode.NO_MESSAGE, mockPostViewResponseSlice));
+        given(challengePostSearchService.findAnnouncementPostViewListByChallengeId(anyLong(),
+            any(Member.class), any(Pageable.class)))
+            .willReturn(SuccessResponse.of(SuccessCode.NO_MESSAGE, mockPostViewResponseSlice));
 
         // when
         ResultActions result = mockMvc.perform(get("/api/challenges/{id}/posts/announcements", 1L)
-                .header(HttpHeaders.AUTHORIZATION, AUTHORIZATION_HEADER_PREFIX + "ACCESS_TOKEN"));
+            .header(HttpHeaders.AUTHORIZATION, AUTHORIZATION_HEADER_PREFIX + "ACCESS_TOKEN"));
 
         //then
         result.andExpect(status().isOk())
-                .andDo(document("challengePost/get-announcement-challenge-posts",
-                        requestHeaders(
-                                headerWithName(HttpHeaders.AUTHORIZATION).description("액세스 토큰")
-                        ),
-                        responseFields(
-                                fieldWithPath("message").description("응답 메시지"),
-                                fieldWithPath("data").description("응답 데이터"),
+            .andDo(document("challengePost/get-announcement-challenge-posts",
+                requestHeaders(
+                    headerWithName(HttpHeaders.AUTHORIZATION).description("액세스 토큰")
+                ),
+                responseFields(
+                    fieldWithPath("message").description("응답 메시지"),
+                    fieldWithPath("data").description("응답 데이터"),
 
-                                fieldWithPath("data.content").description("포스트 뷰 목록"),
-                                fieldWithPath("data.content[].id").description("포스트 id"),
-                                fieldWithPath("data.content[].challengeId").description("포스트가 소속된 challenge id"),
-                                fieldWithPath("data.content[].content").description("포스트 내용"),
-                                fieldWithPath("data.content[].writer").description("작성자"),
-                                fieldWithPath("data.content[].isPostAuthor").description("요청한 멤버가 작성자 본인인지 여부"),
-                                fieldWithPath("data.content[].profileUrl").description("작성자 프로필 이미지 URL"),
-                                fieldWithPath("data.content[].isAnnouncement").description("공지글 여부"),
-                                fieldWithPath("data.content[].createdAt").description("생성 일시"),
-                                fieldWithPath("data.content[].photoViewList").description("포스트 포토(URL 포함) 데이터를 담은 객체 배열"),
-                                fieldWithPath("data.content[].photoViewList[].postPhotoId").description("포토 id"),
-                                fieldWithPath("data.content[].photoViewList[].viewOrder").description("포스트 내 포토의 순서"),
-                                fieldWithPath("data.content[].photoViewList[].imageUrl").description("포스트 포토 url"),
+                    fieldWithPath("data.content").description("포스트 뷰 목록"),
+                    fieldWithPath("data.content[].id").description("포스트 id"),
+                    fieldWithPath("data.content[].challengeId").description(
+                        "포스트가 소속된 challenge id"),
+                    fieldWithPath("data.content[].content").description("포스트 내용"),
+                    fieldWithPath("data.content[].writer").description("작성자"),
+                    fieldWithPath("data.content[].isPostAuthor").description("요청한 멤버가 작성자 본인인지 여부"),
+                    fieldWithPath("data.content[].profileUrl").description("작성자 프로필 이미지 URL"),
+                    fieldWithPath("data.content[].isAnnouncement").description("공지글 여부"),
+                    fieldWithPath("data.content[].createdAt").description("생성 일시"),
+                    fieldWithPath("data.content[].photoViewList").description(
+                        "포스트 포토(URL 포함) 데이터를 담은 객체 배열"),
+                    fieldWithPath("data.content[].photoViewList[].postPhotoId").description(
+                        "포토 id"),
+                    fieldWithPath("data.content[].photoViewList[].viewOrder").description(
+                        "포스트 내 포토의 순서"),
+                    fieldWithPath("data.content[].photoViewList[].imageUrl").description(
+                        "포스트 포토 url"),
 
-                                fieldWithPath("data.pageable").description("포스트 뷰 페이지네이션 정보를 담은 Pageable 객체"),
-                                fieldWithPath("data.pageable.pageNumber").description("현재 페이지 번호"),
-                                fieldWithPath("data.pageable.pageSize").description("한 페이지에 포함되는 항목의 수"),
-                                fieldWithPath("data.pageable.sort").description("정렬 정보"),
-                                fieldWithPath("data.pageable.sort.empty").description("정렬 조건이 없는지 여부"),
-                                fieldWithPath("data.pageable.sort.unsorted").description("정렬되지 않았는지 여부"),
-                                fieldWithPath("data.pageable.sort.sorted").description("정렬되었는지 여부"),
-                                fieldWithPath("data.pageable.offset").description("페이징된 항목의 시작 위치"),
-                                fieldWithPath("data.pageable.paged").description("페이징된 요청인지 여부"),
-                                fieldWithPath("data.pageable.unpaged").description("페이징되지 않은 요청인지 여부"),
+                    fieldWithPath("data.pageable").description("포스트 뷰 페이지네이션 정보를 담은 Pageable 객체"),
+                    fieldWithPath("data.pageable.pageNumber").description("현재 페이지 번호"),
+                    fieldWithPath("data.pageable.pageSize").description("한 페이지에 포함되는 항목의 수"),
+                    fieldWithPath("data.pageable.sort").description("정렬 정보"),
+                    fieldWithPath("data.pageable.sort.empty").description("정렬 조건이 없는지 여부"),
+                    fieldWithPath("data.pageable.sort.unsorted").description("정렬되지 않았는지 여부"),
+                    fieldWithPath("data.pageable.sort.sorted").description("정렬되었는지 여부"),
+                    fieldWithPath("data.pageable.offset").description("페이징된 항목의 시작 위치"),
+                    fieldWithPath("data.pageable.paged").description("페이징된 요청인지 여부"),
+                    fieldWithPath("data.pageable.unpaged").description("페이징되지 않은 요청인지 여부"),
 
-                                fieldWithPath("data.size").description("한 페이지에 포함되는 항목의 수"),
-                                fieldWithPath("data.number").description("현재 페이지 번호"),
-                                fieldWithPath("data.sort").description("정렬 정보"),
-                                fieldWithPath("data.sort.empty").description("정렬 조건이 없는지 여부"),
-                                fieldWithPath("data.sort.unsorted").description("정렬되지 않았는지 여부"),
-                                fieldWithPath("data.sort.sorted").description("정렬되었는지 여부"),
-                                fieldWithPath("data.numberOfElements").description("현재 페이지에 있는 요소의 수"),
-                                fieldWithPath("data.first").description("이 페이지가 첫 번째 페이지인지 여부"),
-                                fieldWithPath("data.last").description("이 페이지가 마지막 페이지인지 여부"),
-                                fieldWithPath("data.empty").description("페이지가 비어있는지 여부")
-                        )
-                ));
+                    fieldWithPath("data.size").description("한 페이지에 포함되는 항목의 수"),
+                    fieldWithPath("data.number").description("현재 페이지 번호"),
+                    fieldWithPath("data.sort").description("정렬 정보"),
+                    fieldWithPath("data.sort.empty").description("정렬 조건이 없는지 여부"),
+                    fieldWithPath("data.sort.unsorted").description("정렬되지 않았는지 여부"),
+                    fieldWithPath("data.sort.sorted").description("정렬되었는지 여부"),
+                    fieldWithPath("data.numberOfElements").description("현재 페이지에 있는 요소의 수"),
+                    fieldWithPath("data.first").description("이 페이지가 첫 번째 페이지인지 여부"),
+                    fieldWithPath("data.last").description("이 페이지가 마지막 페이지인지 여부"),
+                    fieldWithPath("data.empty").description("페이지가 비어있는지 여부")
+                )
+            ));
     }
 
     @Test
@@ -314,87 +337,95 @@ public class ChallengePostApiTest extends AbstractRestDocsTests {
 
         // given
         List<PostViewResponse> mockPostViewResponseList = List.of(
-                PostViewResponse.builder()
-                        .id(1L)
-                        .challengeId(1L)
-                        .content("This is test post 1 by me.")
-                        .writer("test user")
-                        .isPostAuthor(true)
-                        .profileUrl("")
-                        .isAnnouncement(false)
-                        .createdAt(LocalDateTime.now())
-                        .photoViewList(List.of(new PostPhotoView(1L, 1L, "https://picsum.photos/id/40/200/300")))
-                        .build(),
-                PostViewResponse.builder()
-                        .id(2L)
-                        .challengeId(2L)
-                        .content("This is test post 2 by me.")
-                        .writer("test user")
-                        .isPostAuthor(true)
-                        .profileUrl("https://picsum.photos/id/40/200/300")
-                        .isAnnouncement(false)
-                        .createdAt(LocalDateTime.now())
-                        .photoViewList(List.of(new PostPhotoView(2L, 2L, "https://picsum.photos/id/40/200/300")))
-                        .build());
+            PostViewResponse.builder()
+                .id(1L)
+                .challengeId(1L)
+                .content("This is test post 1 by me.")
+                .writer("test user")
+                .isPostAuthor(true)
+                .profileUrl("")
+                .isAnnouncement(false)
+                .createdAt(LocalDateTime.now())
+                .photoViewList(
+                    List.of(new PostPhotoView(1L, 1L, "https://picsum.photos/id/40/200/300")))
+                .build(),
+            PostViewResponse.builder()
+                .id(2L)
+                .challengeId(2L)
+                .content("This is test post 2 by me.")
+                .writer("test user")
+                .isPostAuthor(true)
+                .profileUrl("https://picsum.photos/id/40/200/300")
+                .isAnnouncement(false)
+                .createdAt(LocalDateTime.now())
+                .photoViewList(
+                    List.of(new PostPhotoView(2L, 2L, "https://picsum.photos/id/40/200/300")))
+                .build());
 
         Slice<PostViewResponse> mockPostViewResponseSlice = new SliceImpl<>(
-                mockPostViewResponseList, PageRequest.of(0, 10), true
+            mockPostViewResponseList, PageRequest.of(0, 10), true
         );
 
-        given(challengePostSearchService.findPostViewListByMember(anyLong(), any(Member.class), any(Pageable.class)))
-                .willReturn(SuccessResponse.of(SuccessCode.NO_MESSAGE, mockPostViewResponseSlice));
+        given(challengePostSearchService.findPostViewListByMember(anyLong(), any(Member.class),
+            any(Pageable.class)))
+            .willReturn(SuccessResponse.of(SuccessCode.NO_MESSAGE, mockPostViewResponseSlice));
 
         // when
         ResultActions result = mockMvc.perform(get("/api/challenges/{id}/posts/me", 1L)
-                .header(HttpHeaders.AUTHORIZATION, AUTHORIZATION_HEADER_PREFIX + "ACCESS_TOKEN"));
+            .header(HttpHeaders.AUTHORIZATION, AUTHORIZATION_HEADER_PREFIX + "ACCESS_TOKEN"));
 
         //then
         result.andExpect(status().isOk())
-                .andDo(document("challengePost/get-challenge-posts-by-me",
-                        requestHeaders(
-                                headerWithName(HttpHeaders.AUTHORIZATION).description("액세스 토큰")
-                        ),
-                        responseFields(
-                                fieldWithPath("message").description("응답 메시지"),
-                                fieldWithPath("data").description("응답 데이터"),
+            .andDo(document("challengePost/get-challenge-posts-by-me",
+                requestHeaders(
+                    headerWithName(HttpHeaders.AUTHORIZATION).description("액세스 토큰")
+                ),
+                responseFields(
+                    fieldWithPath("message").description("응답 메시지"),
+                    fieldWithPath("data").description("응답 데이터"),
 
-                                fieldWithPath("data.content").description("포스트 뷰 목록"),
-                                fieldWithPath("data.content[].id").description("포스트 id"),
-                                fieldWithPath("data.content[].challengeId").description("포스트가 소속된 challenge id"),
-                                fieldWithPath("data.content[].content").description("포스트 내용"),
-                                fieldWithPath("data.content[].writer").description("작성자"),
-                                fieldWithPath("data.content[].isPostAuthor").description("요청한 멤버가 작성자 본인인지 여부"),
-                                fieldWithPath("data.content[].profileUrl").description("작성자 프로필 이미지 URL"),
-                                fieldWithPath("data.content[].isAnnouncement").description("공지글 여부"),
-                                fieldWithPath("data.content[].createdAt").description("생성 일시"),
-                                fieldWithPath("data.content[].photoViewList").description("포스트 포토(URL 포함) 데이터를 담은 객체 배열"),
-                                fieldWithPath("data.content[].photoViewList[].postPhotoId").description("포토 id"),
-                                fieldWithPath("data.content[].photoViewList[].viewOrder").description("포스트 내 포토의 순서"),
-                                fieldWithPath("data.content[].photoViewList[].imageUrl").description("포스트 포토 url"),
+                    fieldWithPath("data.content").description("포스트 뷰 목록"),
+                    fieldWithPath("data.content[].id").description("포스트 id"),
+                    fieldWithPath("data.content[].challengeId").description(
+                        "포스트가 소속된 challenge id"),
+                    fieldWithPath("data.content[].content").description("포스트 내용"),
+                    fieldWithPath("data.content[].writer").description("작성자"),
+                    fieldWithPath("data.content[].isPostAuthor").description("요청한 멤버가 작성자 본인인지 여부"),
+                    fieldWithPath("data.content[].profileUrl").description("작성자 프로필 이미지 URL"),
+                    fieldWithPath("data.content[].isAnnouncement").description("공지글 여부"),
+                    fieldWithPath("data.content[].createdAt").description("생성 일시"),
+                    fieldWithPath("data.content[].photoViewList").description(
+                        "포스트 포토(URL 포함) 데이터를 담은 객체 배열"),
+                    fieldWithPath("data.content[].photoViewList[].postPhotoId").description(
+                        "포토 id"),
+                    fieldWithPath("data.content[].photoViewList[].viewOrder").description(
+                        "포스트 내 포토의 순서"),
+                    fieldWithPath("data.content[].photoViewList[].imageUrl").description(
+                        "포스트 포토 url"),
 
-                                fieldWithPath("data.pageable").description("포스트 뷰 페이지네이션 정보를 담은 Pageable 객체"),
-                                fieldWithPath("data.pageable.pageNumber").description("현재 페이지 번호"),
-                                fieldWithPath("data.pageable.pageSize").description("한 페이지에 포함되는 항목의 수"),
-                                fieldWithPath("data.pageable.sort").description("정렬 정보"),
-                                fieldWithPath("data.pageable.sort.empty").description("정렬 조건이 없는지 여부"),
-                                fieldWithPath("data.pageable.sort.unsorted").description("정렬되지 않았는지 여부"),
-                                fieldWithPath("data.pageable.sort.sorted").description("정렬되었는지 여부"),
-                                fieldWithPath("data.pageable.offset").description("페이징된 항목의 시작 위치"),
-                                fieldWithPath("data.pageable.paged").description("페이징된 요청인지 여부"),
-                                fieldWithPath("data.pageable.unpaged").description("페이징되지 않은 요청인지 여부"),
+                    fieldWithPath("data.pageable").description("포스트 뷰 페이지네이션 정보를 담은 Pageable 객체"),
+                    fieldWithPath("data.pageable.pageNumber").description("현재 페이지 번호"),
+                    fieldWithPath("data.pageable.pageSize").description("한 페이지에 포함되는 항목의 수"),
+                    fieldWithPath("data.pageable.sort").description("정렬 정보"),
+                    fieldWithPath("data.pageable.sort.empty").description("정렬 조건이 없는지 여부"),
+                    fieldWithPath("data.pageable.sort.unsorted").description("정렬되지 않았는지 여부"),
+                    fieldWithPath("data.pageable.sort.sorted").description("정렬되었는지 여부"),
+                    fieldWithPath("data.pageable.offset").description("페이징된 항목의 시작 위치"),
+                    fieldWithPath("data.pageable.paged").description("페이징된 요청인지 여부"),
+                    fieldWithPath("data.pageable.unpaged").description("페이징되지 않은 요청인지 여부"),
 
-                                fieldWithPath("data.size").description("한 페이지에 포함되는 항목의 수"),
-                                fieldWithPath("data.number").description("현재 페이지 번호"),
-                                fieldWithPath("data.sort").description("정렬 정보"),
-                                fieldWithPath("data.sort.empty").description("정렬 조건이 없는지 여부"),
-                                fieldWithPath("data.sort.unsorted").description("정렬되지 않았는지 여부"),
-                                fieldWithPath("data.sort.sorted").description("정렬되었는지 여부"),
-                                fieldWithPath("data.numberOfElements").description("현재 페이지에 있는 요소의 수"),
-                                fieldWithPath("data.first").description("이 페이지가 첫 번째 페이지인지 여부"),
-                                fieldWithPath("data.last").description("이 페이지가 마지막 페이지인지 여부"),
-                                fieldWithPath("data.empty").description("페이지가 비어있는지 여부")
-                        )
-                ));
+                    fieldWithPath("data.size").description("한 페이지에 포함되는 항목의 수"),
+                    fieldWithPath("data.number").description("현재 페이지 번호"),
+                    fieldWithPath("data.sort").description("정렬 정보"),
+                    fieldWithPath("data.sort.empty").description("정렬 조건이 없는지 여부"),
+                    fieldWithPath("data.sort.unsorted").description("정렬되지 않았는지 여부"),
+                    fieldWithPath("data.sort.sorted").description("정렬되었는지 여부"),
+                    fieldWithPath("data.numberOfElements").description("현재 페이지에 있는 요소의 수"),
+                    fieldWithPath("data.first").description("이 페이지가 첫 번째 페이지인지 여부"),
+                    fieldWithPath("data.last").description("이 페이지가 마지막 페이지인지 여부"),
+                    fieldWithPath("data.empty").description("페이지가 비어있는지 여부")
+                )
+            ));
     }
 
     @Test
@@ -404,41 +435,42 @@ public class ChallengePostApiTest extends AbstractRestDocsTests {
 
         //given
         AddPostRequest mockAddPostRequest = AddPostRequest.builder()
-                .content("I want to create this post.")
-                .isAnnouncement(false)
-                .photos(List.of(new AddPostPhotoData(1L, "jpg", 100L)))
-                .build();
+            .content("I want to create this post.")
+            .isAnnouncement(false)
+            .photos(List.of(new AddPostPhotoData(1L, "jpg", 100L)))
+            .build();
 
         List<String> presignedUrlList = List.of("https://please.upload/your-photo/here");
 
-        given(challengePostCreationService.createPost(any(AddPostRequest.class), anyLong(), any(Member.class)))
-                .willReturn(SuccessResponse.of(SuccessCode.CREATE_POST_SUCCESS, presignedUrlList));
+        given(challengePostCreationService.createPost(any(AddPostRequest.class), anyLong(),
+            any(Member.class)))
+            .willReturn(SuccessResponse.of(SuccessCode.CREATE_POST_SUCCESS, presignedUrlList));
 
         //when
         ResultActions result = mockMvc.perform(post("/api/challenges/{id}/posts", 1L)
-                .header(HttpHeaders.AUTHORIZATION, AUTHORIZATION_HEADER_PREFIX + "ACCESS_TOKEN")
-                .content(objectMapper.writeValueAsString(mockAddPostRequest))
-                .contentType(MediaType.APPLICATION_JSON));
+            .header(HttpHeaders.AUTHORIZATION, AUTHORIZATION_HEADER_PREFIX + "ACCESS_TOKEN")
+            .content(objectMapper.writeValueAsString(mockAddPostRequest))
+            .contentType(MediaType.APPLICATION_JSON));
 
         //then
         result.andExpect(status().isOk())
-                .andDo(document("challengePost/create-challenge-post",
-                        requestHeaders(
-                                headerWithName(HttpHeaders.AUTHORIZATION).description("액세스 토큰")
-                        ),
-                        requestFields(
-                                fieldWithPath("content").description("포스트 내용"),
-                                fieldWithPath("isAnnouncement").description("공지 포스트 여부"),
-                                fieldWithPath("photos").description("첨부한 이미지 파일 목록"),
-                                fieldWithPath("photos[].viewOrder").description("첨부한 이미지 파일의 포스트 내 정렬 순서"),
-                                fieldWithPath("photos[].imageExtension").description("첨부한 이미지 파일의 확장자명"),
-                                fieldWithPath("photos[].contentLength").description("첨부한 이미지 파일의 길이")
-                        ),
-                        responseFields(
-                                fieldWithPath("message").description("메시지"),
-                                fieldWithPath("data").description("AWS S3 업로드를 위한 preSignedUrl List<String>")
-                        )
-                ));
+            .andDo(document("challengePost/create-challenge-post",
+                requestHeaders(
+                    headerWithName(HttpHeaders.AUTHORIZATION).description("액세스 토큰")
+                ),
+                requestFields(
+                    fieldWithPath("content").description("포스트 내용"),
+                    fieldWithPath("isAnnouncement").description("공지 포스트 여부"),
+                    fieldWithPath("photos").description("첨부한 이미지 파일 목록"),
+                    fieldWithPath("photos[].viewOrder").description("첨부한 이미지 파일의 포스트 내 정렬 순서"),
+                    fieldWithPath("photos[].imageExtension").description("첨부한 이미지 파일의 확장자명"),
+                    fieldWithPath("photos[].contentLength").description("첨부한 이미지 파일의 길이")
+                ),
+                responseFields(
+                    fieldWithPath("message").description("메시지"),
+                    fieldWithPath("data").description("AWS S3 업로드를 위한 preSignedUrl List<String>")
+                )
+            ));
     }
 
     @Test
@@ -448,31 +480,32 @@ public class ChallengePostApiTest extends AbstractRestDocsTests {
 
         // given
         AddPostRequest mockAddPostRequest = AddPostRequest.builder()
-                .content("I want to create this post.")
-                .isAnnouncement(false)
-                .photos(List.of(new AddPostPhotoData(1L, "jpg", 100L)))
-                .build();
+            .content("I want to create this post.")
+            .isAnnouncement(false)
+            .photos(List.of(new AddPostPhotoData(1L, "jpg", 100L)))
+            .build();
 
-        given(challengePostCreationService.createPost(any(AddPostRequest.class), anyLong(), any(Member.class)))
-                .willThrow(new ForbiddenException(ErrorCode.POST_CREATION_FORBIDDEN_DUE_TO_GIVE_UP));
+        given(challengePostCreationService.createPost(any(AddPostRequest.class), anyLong(),
+            any(Member.class)))
+            .willThrow(new ForbiddenException(ErrorCode.POST_CREATION_FORBIDDEN_DUE_TO_GIVE_UP));
 
         // when
         ResultActions result = mockMvc.perform(post("/api/challenges/{id}/posts", 1L)
-                .header(HttpHeaders.AUTHORIZATION, AUTHORIZATION_HEADER_PREFIX + "ACCESS_TOKEN")
-                .content(objectMapper.writeValueAsString(mockAddPostRequest))
-                .contentType(MediaType.APPLICATION_JSON));
+            .header(HttpHeaders.AUTHORIZATION, AUTHORIZATION_HEADER_PREFIX + "ACCESS_TOKEN")
+            .content(objectMapper.writeValueAsString(mockAddPostRequest))
+            .contentType(MediaType.APPLICATION_JSON));
 
         // then
         result.andExpect(status().isForbidden())
-                .andDo(document("challenge/challenge-post-creation-forbidden-exception",
-                        requestHeaders(
-                                headerWithName(HttpHeaders.AUTHORIZATION).description("액세스 토큰")
-                        ),
-                        responseFields(
-                                fieldWithPath("code").description("오류 응답 코드"),
-                                fieldWithPath("message").description("오류 메세지")
-                        )
-                ));
+            .andDo(document("challenge/challenge-post-creation-forbidden-exception",
+                requestHeaders(
+                    headerWithName(HttpHeaders.AUTHORIZATION).description("액세스 토큰")
+                ),
+                responseFields(
+                    fieldWithPath("code").description("오류 응답 코드"),
+                    fieldWithPath("message").description("오류 메세지")
+                )
+            ));
     }
 
     @Test
@@ -482,47 +515,52 @@ public class ChallengePostApiTest extends AbstractRestDocsTests {
 
         //given
         ModifyPostRequest mockmodifyPostRequest = ModifyPostRequest.builder()
-                .content("I want to patch this to post.")
-                .isAnnouncement(false)
-                .newPhotos(List.of(new AddPostPhotoData(2L, "jpg", 100L)))
-                .modifiedPhotos(List.of(new ModifyPostPhotoData(3L, 1L)))
-                .deletedPhotoIds(List.of(1L))
-                .build();
+            .content("I want to patch this to post.")
+            .isAnnouncement(false)
+            .newPhotos(List.of(new AddPostPhotoData(2L, "jpg", 100L)))
+            .modifiedPhotos(List.of(new ModifyPostPhotoData(3L, 1L)))
+            .deletedPhotoIds(List.of(1L))
+            .build();
 
         List<String> presignedUrlList = List.of("https://please.upload/your-photo/here");
 
-        given(challengePostUpdateService.patchPost(any(ModifyPostRequest.class), anyLong(), anyLong(), any(Member.class)))
-                .willReturn(SuccessResponse.of(SuccessCode.PATCH_POST_SUCCESS, presignedUrlList));
+        given(
+            challengePostUpdateService.patchPost(any(ModifyPostRequest.class), anyLong(), anyLong(),
+                any(Member.class)))
+            .willReturn(SuccessResponse.of(SuccessCode.PATCH_POST_SUCCESS, presignedUrlList));
 
         //when
-        ResultActions result = mockMvc.perform(patch("/api/challenges/{challengeId}/posts/{postId}", 1L, 1L)
+        ResultActions result = mockMvc.perform(
+            patch("/api/challenges/{challengeId}/posts/{postId}", 1L, 1L)
                 .header(HttpHeaders.AUTHORIZATION, AUTHORIZATION_HEADER_PREFIX + "ACCESS_TOKEN")
                 .content(objectMapper.writeValueAsString(mockmodifyPostRequest))
                 .contentType(MediaType.APPLICATION_JSON));
 
         //then
         result.andExpect(status().isOk())
-                .andDo(document("challengePost/patch-challenge-post",
-                        requestHeaders(
-                                headerWithName(HttpHeaders.AUTHORIZATION).description("액세스 토큰")
-                        ),
-                        requestFields(
-                                fieldWithPath("content").description("포스트 수정 내용"),
-                                fieldWithPath("isAnnouncement").description("공지 포스트 여부"),
-                                fieldWithPath("newPhotos").description("새로 첨부한 이미지 파일 목록"),
-                                fieldWithPath("newPhotos[].viewOrder").description("첨부한 이미지 파일의 포스트 내 정렬 순서"),
-                                fieldWithPath("newPhotos[].imageExtension").description("첨부한 이미지 파일의 확장자명"),
-                                fieldWithPath("newPhotos[].contentLength").description("첨부한 이미지 파일의 길이"),
-                                fieldWithPath("modifiedPhotos").description("포스트 내 정렬 순서가 변경된 이미지 파일 목록"),
-                                fieldWithPath("modifiedPhotos[].photoId").description("정렬 순서를 변경하려는 이미지 파일의 PostPhotoId"),
-                                fieldWithPath("modifiedPhotos[].viewOrder").description("변경하려는 정렬 순서"),
-                                fieldWithPath("deletedPhotoIds").description("삭제할 이미지 파일 PostPhotoId List<Long>")
-                        ),
-                        responseFields(
-                                fieldWithPath("message").description("메시지"),
-                                fieldWithPath("data").description("AWS S3 업로드를 위한 preSignedUrl List<String>")
-                        )
-                ));
+            .andDo(document("challengePost/patch-challenge-post",
+                requestHeaders(
+                    headerWithName(HttpHeaders.AUTHORIZATION).description("액세스 토큰")
+                ),
+                requestFields(
+                    fieldWithPath("content").description("포스트 수정 내용"),
+                    fieldWithPath("isAnnouncement").description("공지 포스트 여부"),
+                    fieldWithPath("newPhotos").description("새로 첨부한 이미지 파일 목록"),
+                    fieldWithPath("newPhotos[].viewOrder").description("첨부한 이미지 파일의 포스트 내 정렬 순서"),
+                    fieldWithPath("newPhotos[].imageExtension").description("첨부한 이미지 파일의 확장자명"),
+                    fieldWithPath("newPhotos[].contentLength").description("첨부한 이미지 파일의 길이"),
+                    fieldWithPath("modifiedPhotos").description("포스트 내 정렬 순서가 변경된 이미지 파일 목록"),
+                    fieldWithPath("modifiedPhotos[].photoId").description(
+                        "정렬 순서를 변경하려는 이미지 파일의 PostPhotoId"),
+                    fieldWithPath("modifiedPhotos[].viewOrder").description("변경하려는 정렬 순서"),
+                    fieldWithPath("deletedPhotoIds").description(
+                        "삭제할 이미지 파일 PostPhotoId List<Long>")
+                ),
+                responseFields(
+                    fieldWithPath("message").description("메시지"),
+                    fieldWithPath("data").description("AWS S3 업로드를 위한 preSignedUrl List<String>")
+                )
+            ));
     }
 
     @Test
@@ -532,31 +570,35 @@ public class ChallengePostApiTest extends AbstractRestDocsTests {
 
         // given
         AddPostRequest mockPatchRequest = AddPostRequest.builder()
-                .content("I want to create this post.")
-                .isAnnouncement(false)
-                .photos(List.of(new AddPostPhotoData(1L, "jpg", 100L)))
-                .build();
+            .content("I want to create this post.")
+            .isAnnouncement(false)
+            .photos(List.of(new AddPostPhotoData(1L, "jpg", 100L)))
+            .build();
 
-        given(challengePostUpdateService.patchPost(any(ModifyPostRequest.class), anyLong(), anyLong(), any(Member.class)))
-                .willThrow(new ForbiddenException(ErrorCode.POST_MODIFICATION_FORBIDDEN_DUE_TO_GIVE_UP));
+        given(
+            challengePostUpdateService.patchPost(any(ModifyPostRequest.class), anyLong(), anyLong(),
+                any(Member.class)))
+            .willThrow(
+                new ForbiddenException(ErrorCode.POST_MODIFICATION_FORBIDDEN_DUE_TO_GIVE_UP));
 
         // when
-        ResultActions result = mockMvc.perform(patch("/api/challenges/{challengeId}/posts/{postId}", 1L, 1L)
+        ResultActions result = mockMvc.perform(
+            patch("/api/challenges/{challengeId}/posts/{postId}", 1L, 1L)
                 .header(HttpHeaders.AUTHORIZATION, AUTHORIZATION_HEADER_PREFIX + "ACCESS_TOKEN")
                 .content(objectMapper.writeValueAsString(mockPatchRequest))
                 .contentType(MediaType.APPLICATION_JSON));
 
         // then
         result.andExpect(status().isForbidden())
-                .andDo(document("challenge/challenge-post-modification-forbidden-exception",
-                        requestHeaders(
-                                headerWithName(HttpHeaders.AUTHORIZATION).description("액세스 토큰")
-                        ),
-                        responseFields(
-                                fieldWithPath("code").description("오류 응답 코드"),
-                                fieldWithPath("message").description("오류 메세지")
-                        )
-                ));
+            .andDo(document("challenge/challenge-post-modification-forbidden-exception",
+                requestHeaders(
+                    headerWithName(HttpHeaders.AUTHORIZATION).description("액세스 토큰")
+                ),
+                responseFields(
+                    fieldWithPath("code").description("오류 응답 코드"),
+                    fieldWithPath("message").description("오류 메세지")
+                )
+            ));
     }
 
     @Test
@@ -566,23 +608,24 @@ public class ChallengePostApiTest extends AbstractRestDocsTests {
 
         //given
         given(challengePostDeleteService.deletePost(anyLong(), anyLong(), any(Member.class)))
-                .willReturn(SuccessResponse.of(SuccessCode.DELETE_POST_SUCCESS));
+            .willReturn(SuccessResponse.of(SuccessCode.DELETE_POST_SUCCESS));
 
         //when
-        ResultActions result = mockMvc.perform(delete("/api/challenges/{challengeId}/posts/{postId}", 1L, 1L)
+        ResultActions result = mockMvc.perform(
+            delete("/api/challenges/{challengeId}/posts/{postId}", 1L, 1L)
                 .header(HttpHeaders.AUTHORIZATION, AUTHORIZATION_HEADER_PREFIX + "ACCESS_TOKEN"));
 
         //then
         result.andExpect(status().isOk())
-                .andDo(document("challengePost/delete-challenge-post",
-                        requestHeaders(
-                                headerWithName(HttpHeaders.AUTHORIZATION).description("액세스 토큰")
-                        ),
-                        responseFields(
-                                fieldWithPath("message").description("메시지"),
-                                fieldWithPath("data").description("삭제된 포스트 id")
-                        )
-                ));
+            .andDo(document("challengePost/delete-challenge-post",
+                requestHeaders(
+                    headerWithName(HttpHeaders.AUTHORIZATION).description("액세스 토큰")
+                ),
+                responseFields(
+                    fieldWithPath("message").description("메시지"),
+                    fieldWithPath("data").description("삭제된 포스트 id")
+                )
+            ));
     }
 
     @Test
@@ -592,23 +635,24 @@ public class ChallengePostApiTest extends AbstractRestDocsTests {
 
         // given
         given(challengePostDeleteService.deletePost(anyLong(), anyLong(), any(Member.class)))
-                .willThrow(new ForbiddenException(ErrorCode.POST_DELETION_FORBIDDEN_DUE_TO_GIVE_UP));
+            .willThrow(new ForbiddenException(ErrorCode.POST_DELETION_FORBIDDEN_DUE_TO_GIVE_UP));
 
         // when
-        ResultActions result = mockMvc.perform(delete("/api/challenges/{challengeId}/posts/{postId}", 1L, 1L)
+        ResultActions result = mockMvc.perform(
+            delete("/api/challenges/{challengeId}/posts/{postId}", 1L, 1L)
                 .header(HttpHeaders.AUTHORIZATION, AUTHORIZATION_HEADER_PREFIX + "ACCESS_TOKEN"));
 
         // then
         result.andExpect(status().isForbidden())
-                .andDo(document("challenge/challenge-post-deletion-forbidden-exception",
-                        requestHeaders(
-                                headerWithName(HttpHeaders.AUTHORIZATION).description("액세스 토큰")
-                        ),
-                        responseFields(
-                                fieldWithPath("code").description("오류 응답 코드"),
-                                fieldWithPath("message").description("오류 메세지")
-                        )
-                ));
+            .andDo(document("challenge/challenge-post-deletion-forbidden-exception",
+                requestHeaders(
+                    headerWithName(HttpHeaders.AUTHORIZATION).description("액세스 토큰")
+                ),
+                responseFields(
+                    fieldWithPath("code").description("오류 응답 코드"),
+                    fieldWithPath("message").description("오류 메세지")
+                )
+            ));
     }
 
 }


### PR DESCRIPTION
# 개요

`GET /challenges/{id}/posts`의 response가 2번째 페이지부터 반환하지 못하는 문제를 해결하기 위해 page number가 1부터 시작하도록 수정합니다.

# 문제 현상

![iShot_2024-12-05_19 34 50](https://github.com/user-attachments/assets/9fecf79d-9fb4-4398-a89b-ae3c1244da69)

챌린지 메인 페이지에서 스크롤을 내리면 다음 페이지 내용이 나오는 것이 아닌 첫 페이지 내용이 반복해서 표시되었습니다.

# 원인

프론트에서는 `GET /challenges/{id}/posts?page=1`와 같이 page number를 1부터 요청을 하는데, 백엔드에서는 `pageable.pageNumber`의 값이 아래와 같이 0부터 시작합니다.

```json
{
    "message": "",
    "data": {
        "content": [
            {
                "id": 13,
                "challengeId": 6,
                "content": "13",
                "writer": "joonhyeok.han",
                "isPostAuthor": true,
                "profileUrl": "",
                "isAnnouncement": false,
                "createdAt": "2024-12-05T10:23:01.272858",
                "photoViewList": []
            },
        ],
        "pageable": {
            "pageNumber": 0, // 0부터 시작하는 페이지 번호
            "pageSize": 10,
            "sort": {
                "sorted": true,
                "unsorted": false,
                "empty": false
            },
            "offset": 0,
            "paged": true,
            "unpaged": false
        },
        "size": 10,
        "number": 0,
        "sort": {
            "sorted": true,
            "unsorted": false,
            "empty": false
        },
        "first": true,
        "last": false,
        "numberOfElements": 10,
        "empty": false
    }
}
```

프론트에서는 다음 페이지를 요청할 때 `pageable.pageNumber + 1`로 보내는데, 초기값이 0이다보니 `GET /challenges/{id}/posts?page=1` 요청을 계속 보냅니다.
하지만 백엔드에서는 쿼리 파라미터 page의 값이 0이든 1이든 동일하게 첫 페이지가 반환하기 때문에 2페이지부터 정상적으로 불러올 수 없었습니다.

# 작업 내용

## `SliceResponse` 추가

Slice의 내용을 그대로 보내는 것이 아닌 `pageNumber`를 1부터 시작할 수 있도록 Wrapper DTO를 추가했습니다.

```java
public record SliceResponse<T>(
    List<T> content,
    int pageNumber,
    int size,
    boolean isLast,
    boolean isFirst,
    boolean isEmpty,
    boolean hasNextPage,
    Pageable pageable
) {

    public static <T> SliceResponse<T> from(Slice<T> slice) {
        return new SliceResponse<>(
            slice.getContent(),
            slice.getNumber() + 1, // 페이지 번호가 1부터 시작하도록 설정
            slice.getNumberOfElements(),
            slice.isLast(),
            slice.isFirst(),
            slice.isEmpty(),
            slice.hasNext(),
            slice.getPageable()
        );
    }
}
```

해당 DTO를 만든 이유는 Slice의 모든 정보를 담기보다 프론트에서만 사용하는 정보만 보내줘도 충분하다고 생각했기 때문입니다. 

참고로 DTO의 수정으로 프론트엔드 코드도 제가 함께 수정했습니다.

# 문제 해결 화면

아래의 화면과 같이 정상적으로 모든 게시물을 조회할 수 있게 되었습니다.

![iShot_2024-12-05_19 39 38](https://github.com/user-attachments/assets/a983a5e5-087f-45da-a1f1-583e94bb418a)


# 참고사항

코드에 변경 사항이 많은 이유는 IntelliJ의 자동 포맷팅 기능 때문에 변경된 부분이 많습니다. 생각보다 수정한 부분은 많이 없으니 참고 부탁드립니다!

