### PR TITLE
[fix] 챌린지 시작 전 취소 안되는 문제 수정#321

### DIFF
--- a/src/main/java/com/habitpay/habitpay/domain/challengeenrollment/domain/ChallengeEnrollment.java
+++ b/src/main/java/com/habitpay/habitpay/domain/challengeenrollment/domain/ChallengeEnrollment.java
@@ -1,16 +1,23 @@
 package com.habitpay.habitpay.domain.challengeenrollment.domain;
 
 import com.habitpay.habitpay.domain.challenge.domain.Challenge;
-import com.habitpay.habitpay.domain.challengeparticipationrecord.domain.ChallengeParticipationRecord;
 import com.habitpay.habitpay.domain.member.domain.Member;
 import com.habitpay.habitpay.domain.participationstat.domain.ParticipationStat;
-import jakarta.persistence.*;
+import jakarta.persistence.CascadeType;
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.ManyToOne;
+import jakarta.persistence.OneToOne;
+import jakarta.persistence.Table;
+import java.time.ZonedDateTime;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 import lombok.Setter;
-
-import java.time.ZonedDateTime;
 
 @Getter
 @Setter
@@ -18,6 +25,7 @@ import java.time.ZonedDateTime;
 @Entity
 @Table(name = "challenge_enrollment")
 public class ChallengeEnrollment {
+
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;
@@ -30,6 +38,10 @@ public class ChallengeEnrollment {
     @JoinColumn(name = "member_id")
     private Member member;
 
+    @OneToOne(cascade = CascadeType.REMOVE)
+    @JoinColumn(name = "participation_stat_id")
+    private ParticipationStat participationStat;
+
     @Column(nullable = false)
     private boolean isGivenUp;
 
@@ -38,10 +50,6 @@ public class ChallengeEnrollment {
 
     @Column()
     private ZonedDateTime givenUpDate;
-
-    @OneToOne
-    @JoinColumn(name = "participation_stat_id")
-    private ParticipationStat participationStat;
 
     @Builder
     public ChallengeEnrollment(Challenge challenge, Member member) {
@@ -53,8 +61,8 @@ public class ChallengeEnrollment {
 
     public static ChallengeEnrollment of(Member member, Challenge challenge) {
         return ChallengeEnrollment.builder()
-                .challenge(challenge)
-                .member(member)
-                .build();
+            .challenge(challenge)
+            .member(member)
+            .build();
     }
 }

--- a/src/main/java/com/habitpay/habitpay/domain/participationstat/domain/ParticipationStat.java
+++ b/src/main/java/com/habitpay/habitpay/domain/participationstat/domain/ParticipationStat.java
@@ -1,15 +1,24 @@
 package com.habitpay.habitpay.domain.participationstat.domain;
 
 import com.habitpay.habitpay.domain.challengeenrollment.domain.ChallengeEnrollment;
-
-import jakarta.persistence.*;
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.FetchType;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.OneToOne;
+import jakarta.persistence.Table;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
+import lombok.Setter;
 
 @Entity
 @NoArgsConstructor
 @Getter
+@Setter
 @Table(name = "participation_stat")
 public class ParticipationStat {
 
@@ -40,15 +49,7 @@ public class ParticipationStat {
 
     public static ParticipationStat of(ChallengeEnrollment enrollment) {
         return ParticipationStat.builder()
-                .enrollment(enrollment)
-                .build();
+            .enrollment(enrollment)
+            .build();
     }
-
-    public void setSuccessCount(int value) {
-        this.successCount = value;
-    }
-
-    public void setFailureCount(int value) { this.failureCount = value; }
-
-    public void setTotalFee(int value) { this.totalFee = value; }
 }


### PR DESCRIPTION
# 개요

챌린지 주최자 및 챌린지 참여자가 챌린지 시작 전에 챌린지를 취소하는 API 요청(`POST /challenges/{id}/cancel`)이 정상적으로 처리되지 않는 문제를 수정했습니다.

오류가 발생한 백엔드 로그는 다음과 같습니다.

>backend   | Hibernate: delete from challenge_enrollment where id=?
backend   | 2024-12-01T03:59:39.114Z  WARN 289 --- [io-8080-exec-10] o.h.engine.jdbc.spi.SqlExceptionHelper   : SQL Error: 0, SQLState: 23503
backend   | 2024-12-01T03:59:39.114Z ERROR 289 --- [io-8080-exec-10] o.h.engine.jdbc.spi.SqlExceptionHelper   : ERROR: update or delete on table "challenge_enrollment" violates foreign key constraint "fkmx1pul0k5cnhr79cf0y70neht" on table "participation_stat"
backend   |   Detail: Key (id)=(4) is still referenced from table "participation_stat".
backend   | 2024-12-01T03:59:39.117Z  WARN 289 --- [io-8080-exec-10] .m.m.a.ExceptionHandlerExceptionResolver : Resolved [org.springframework.dao.DataIntegrityViolationException: could not execute statement [ERROR: update or delete on table "challenge_enrollment" violates foreign key constraint "fkmx1pul0k5cnhr79cf0y70neht" on table "participation_stat"<EOL>  Detail: Key (id)=(4) is still referenced from table "participation_stat".] [delete from challenge_enrollment where id=?]; SQL [delete from challenge_enrollment where id=?]; constraint [fkmx1pul0k5cnhr79cf0y70neht]]

# 작업 내용

## 1. ChallengeEnrollment 조회 오류 수정

### 기존 코드

기존 코드에서 `ChallengeEnrollment`를 조회할 때 `member`만으로 조회했습니다.

```java
// ChallengeEnrollmentService.java

ChallengeEnrollment challengeEnrollment = challengeEnrollmentRepository.findByMember(member)
        .orElseThrow(() -> new NotEnrolledChallengeException(challengeId, member.getId()));
```

그러다보니 사용자가 여러 챌린지에 등록한 경우에는 참여 취소하려는 챌린지를 찾지 못해 다음과 같은 오류가 발생했습니다.

>Query did not return a unique result: 3 results were returned

### 변경 코드

`challenge`도 함께 조회하여 정확한 챌린지 등록 정보를 가져오도록 했습니다.

```java
// ChallengeEnrollmentService.java

ChallengeEnrollment challengeEnrollment = challengeEnrollmentSearchService.getByMemberAndChallenge(
    member, challenge);
```

## 2. ParticipationStat 엔티티 cascade 삭제 옵션 추가

### 기존 코드

챌린지 참여 취소 요청 시, `ChallengeEnrollment`와 1:1 관계에 설정된 `ParticipationStat` 엔티티가 삭제되지 않아 아래와 같은 오류가 발생했습니다.

> could not execute statement[
    ERROR: update or delete on table "challenge_enrollment"violates foreign key constraint "fkmx1pul0k5cnhr79cf0y70neht"on table "participation_stat"Detail: Key(id)=(13)is still referenced from table "participation_stat".
][
    delete from challenge_enrollment where id=?
];SQL[
    delete from challenge_enrollment where id=?
];constraint[
    fkmx1pul0k5cnhr79cf0y70neht
]

```java
// ChallengeEnrollment.java

@OneToOne() // cascade 옵션이 설정되지 않음
@JoinColumn(name = "participation_stat_id")
private ParticipationStat participationStat;
```

### 변경 코드

`cascade = CascadeType.REMOVE` 옵션을 추가하여 부모가 삭제되면 자식도 삭제되도록 설정했습니다.

```java
// ChallengeEnrollment.java

@OneToOne(cascade = CascadeType.REMOVE)
@JoinColumn(name = "participation_stat_id")
private ParticipationStat participationStat;
```

참고로 `ChallengeEnrollment`와 `ParticipationStat`을 Hard Delete 하는 이유는 챌린지 참여 취소 후 다시 참여할 수 있도록 하기 위함입니다. 챌린지 참여 등록 시 `ChallengeEnrollment` 엔티티는 `Challenge`와 `Member`가 기본키가 되어 생성되는데, Soft Delete를 한다면 동일한 챌린지에 대해 여러 `ChallengeEnrollment` 객체가 저장됩니다. 이는 특정 멤버의 특정 챌린지 참여 여부를 조회할 때 `ChallengeEnrollment`가 여러 개 조회되는 문제로 이어질 수 있습니다.

물론 Soft Delete로 구현할 수도 있지만, 챌린지 참여 등록 시 함께 생성되는 `ParticipationStat` 객체를 챌린지 시작 후에도 계속 저장하고 있을 이유가 없다고 판단하여 Hard Delete로 구현했습니다.

## 3. ParticipationStat 도메인 @Setter 어노테이션 추가

기존에 setter를 직접 구현한 코드가 있어서 Lombok의 `@Setter` 어노테이션으로 대체했습니다.
