### PR TITLE
[feat] 게시물 이미지 프로필 이미지 업로드 파일 크기 제한 상향#327

### DIFF
--- a/src/main/java/com/habitpay/habitpay/domain/member/application/MemberUpdateService.java
+++ b/src/main/java/com/habitpay/habitpay/domain/member/application/MemberUpdateService.java
@@ -8,7 +8,6 @@ import com.habitpay.habitpay.domain.member.dto.NicknameDto;
 import com.habitpay.habitpay.domain.member.exception.InvalidNicknameException;
 import com.habitpay.habitpay.global.config.aws.S3FileService;
 import com.habitpay.habitpay.global.error.exception.ErrorCode;
-import com.habitpay.habitpay.global.error.exception.InvalidValueException;
 import com.habitpay.habitpay.global.response.SuccessCode;
 import com.habitpay.habitpay.global.response.SuccessResponse;
 import com.habitpay.habitpay.global.util.ImageUtil;
@@ -48,7 +47,7 @@ public class MemberUpdateService {
         Member member) {
 
         // 이미지 형식(파일 크기, 확장자) 유효성 검사
-        validateImageFormat(request.getContentLength(), request.getExtension());
+        imageUtil.validateImageFormat(request.getContentLength(), request.getExtension());
 
         // 기존 프로필 이미지 삭제
         deleteExistingImageIfExists(member);
@@ -79,22 +78,6 @@ public class MemberUpdateService {
     private void deleteExistingImageIfExists(Member member) {
         Optional.ofNullable(member.getImageFileName())
             .ifPresent((imageFileName) -> s3FileService.deleteImage("profiles", imageFileName));
-    }
-
-    private void validateImageFormat(Long contentLength, String extension) {
-
-        // 1. 이미지 크기 제한이 넘을 경우
-        if (!imageUtil.isValidFileSize(contentLength)) {
-            throw new InvalidValueException(
-                String.format("size: %dMB", contentLength / 1024 / 1024),
-                ErrorCode.PROFILE_IMAGE_SIZE_TOO_LARGE);
-        }
-
-        // 2. 이미지 확장자가 허용되지 않은 경우
-        if (!imageUtil.isValidImageExtension(extension)) {
-            throw new InvalidValueException(String.format("extension: %s", extension),
-                ErrorCode.UNSUPPORTED_IMAGE_EXTENSION);
-        }
     }
 
     private boolean isNicknameValidFormat(String nickname) {

--- a/src/main/java/com/habitpay/habitpay/domain/member/application/MemberUpdateService.java
+++ b/src/main/java/com/habitpay/habitpay/domain/member/application/MemberUpdateService.java
@@ -26,6 +26,7 @@ import org.springframework.stereotype.Service;
 public class MemberUpdateService {
 
     private final MemberRepository memberRepository;
+    private final ImageUtil imageUtil;
     private final S3FileService s3FileService;
 
     public SuccessResponse<NicknameDto> updateNickname(NicknameDto nicknameDto, Member member) {
@@ -73,14 +74,14 @@ public class MemberUpdateService {
     private void validateImageFormat(Long contentLength, String extension) {
 
         // 1. 이미지 크기 제한이 넘을 경우
-        if (!ImageUtil.isValidFileSize(contentLength)) {
+        if (!imageUtil.isValidFileSize(contentLength)) {
             throw new InvalidValueException(
                 String.format("size: %dMB", contentLength / 1024 / 1024),
                 ErrorCode.PROFILE_IMAGE_SIZE_TOO_LARGE);
         }
 
         // 2. 이미지 확장자가 허용되지 않은 경우
-        if (!ImageUtil.isValidImageExtension(extension)) {
+        if (!imageUtil.isValidImageExtension(extension)) {
             throw new InvalidValueException(String.format("extension: %s", extension),
                 ErrorCode.UNSUPPORTED_IMAGE_EXTENSION);
         }

--- a/src/main/java/com/habitpay/habitpay/domain/postphoto/application/PostPhotoCreationService.java
+++ b/src/main/java/com/habitpay/habitpay/domain/postphoto/application/PostPhotoCreationService.java
@@ -8,13 +8,12 @@ import com.habitpay.habitpay.global.config.aws.S3FileService;
 import com.habitpay.habitpay.global.error.exception.ErrorCode;
 import com.habitpay.habitpay.global.error.exception.InvalidValueException;
 import com.habitpay.habitpay.global.util.ImageUtil;
-import lombok.RequiredArgsConstructor;
-import lombok.extern.slf4j.Slf4j;
-import org.springframework.stereotype.Service;
-
 import java.util.ArrayList;
 import java.util.List;
 import java.util.UUID;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Service;
 
 @RequiredArgsConstructor
 @Service
@@ -24,6 +23,7 @@ public class PostPhotoCreationService {
     private final S3FileService s3FileService;
     private final PostPhotoRepository postPhotoRepository;
     private final PostPhotoUtilService postPhotoUtilService;
+    private final ImageUtil imageUtil;
 
     public List<String> createPhotoUrlList(ChallengePost post, List<AddPostPhotoData> photos) {
 
@@ -45,12 +45,15 @@ public class PostPhotoCreationService {
         String imageExtension = photo.getImageExtension();
         Long contentLength = photo.getContentLength();
 
-        if (!ImageUtil.isValidFileSize(contentLength)) {
-            throw new InvalidValueException(String.format("size: %dMB", contentLength / 1024 / 1024), ErrorCode.POST_PHOTO_IMAGE_SIZE_TOO_LARGE);
+        if (!imageUtil.isValidFileSize(contentLength)) {
+            throw new InvalidValueException(
+                String.format("size: %dMB", contentLength / 1024 / 1024),
+                ErrorCode.POST_PHOTO_IMAGE_SIZE_TOO_LARGE);
         }
 
-        if (!ImageUtil.isValidImageExtension(imageExtension)) {
-            throw new InvalidValueException(String.format("extension: %s", imageExtension), ErrorCode.UNSUPPORTED_IMAGE_EXTENSION);
+        if (!imageUtil.isValidImageExtension(imageExtension)) {
+            throw new InvalidValueException(String.format("extension: %s", imageExtension),
+                ErrorCode.UNSUPPORTED_IMAGE_EXTENSION);
         }
 
         String randomFileName = UUID.randomUUID().toString();
@@ -58,13 +61,14 @@ public class PostPhotoCreationService {
         log.info("[save] savedFileName: {}", savedFileName);
 
         PostPhoto postPhoto = postPhotoRepository.save(PostPhoto.builder()
-                .post(post)
-                .imageFileName(savedFileName)
-                .viewOrder(photo.getViewOrder())
-                .build());
+            .post(post)
+            .imageFileName(savedFileName)
+            .viewOrder(photo.getViewOrder())
+            .build());
 
         String targetUrl = postPhotoUtilService.makeS3TargetPath(postPhoto);
-        return s3FileService.getPutPreSignedUrl(targetUrl, savedFileName, imageExtension, contentLength);
+        return s3FileService.getPutPreSignedUrl(targetUrl, savedFileName, imageExtension,
+            contentLength);
     }
 
 }

--- a/src/main/java/com/habitpay/habitpay/domain/postphoto/application/PostPhotoUpdateService.java
+++ b/src/main/java/com/habitpay/habitpay/domain/postphoto/application/PostPhotoUpdateService.java
@@ -1,12 +1,10 @@
 package com.habitpay.habitpay.domain.postphoto.application;
 
 import com.habitpay.habitpay.domain.postphoto.dto.ModifyPostPhotoData;
-import lombok.RequiredArgsConstructor;
-import org.springframework.stereotype.Service;
-
-import java.util.Collections;
 import java.util.List;
 import java.util.Optional;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
 
 @RequiredArgsConstructor
 @Service
@@ -15,7 +13,8 @@ public class PostPhotoUpdateService {
     private final PostPhotoUtilService postPhotoUtilService;
 
     public void changePhotoViewOrder(List<ModifyPostPhotoData> modifyPostPhotoDataList) {
-        Optional.ofNullable(modifyPostPhotoDataList).orElse(Collections.emptyList())
-                .forEach(photo -> postPhotoUtilService.changeViewOrder(photo.getPhotoId(), photo.getViewOrder()));
+        Optional.ofNullable(modifyPostPhotoDataList).ifPresent(list -> list.forEach(
+            photo -> postPhotoUtilService.changeViewOrder(photo.getPhotoId(),
+                photo.getViewOrder())));
     }
 }

--- a/src/main/java/com/habitpay/habitpay/global/util/ImageUtil.java
+++ b/src/main/java/com/habitpay/habitpay/global/util/ImageUtil.java
@@ -1,6 +1,8 @@
 package com.habitpay.habitpay.global.util;
 
 import com.habitpay.habitpay.domain.model.Image;
+import com.habitpay.habitpay.global.error.exception.ErrorCode;
+import com.habitpay.habitpay.global.error.exception.InvalidValueException;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Component;
 import org.springframework.util.unit.DataSize;
@@ -10,6 +12,21 @@ public class ImageUtil {
 
     @Value("${app.max-upload-file-size}")
     private DataSize maxUploadSize;
+
+    public void validateImageFormat(Long contentLength, String extension) {
+        // 1. 이미지 크기 제한이 넘을 경우
+        if (isValidFileSize(contentLength)) {
+            throw new InvalidValueException(
+                String.format("size: %dMB", contentLength / 1024 / 1024),
+                ErrorCode.PROFILE_IMAGE_SIZE_TOO_LARGE);
+        }
+
+        // 2. 이미지 확장자가 허용되지 않은 경우
+        if (isValidImageExtension(extension)) {
+            throw new InvalidValueException(String.format("extension: %s", extension),
+                ErrorCode.UNSUPPORTED_IMAGE_EXTENSION);
+        }
+    }
 
     public boolean isValidImageExtension(String extension) {
         return Image.VALID_EXTENSION.contains(extension.toUpperCase());

--- a/src/main/java/com/habitpay/habitpay/global/util/ImageUtil.java
+++ b/src/main/java/com/habitpay/habitpay/global/util/ImageUtil.java
@@ -15,14 +15,14 @@ public class ImageUtil {
 
     public void validateImageFormat(Long contentLength, String extension) {
         // 1. 이미지 크기 제한이 넘을 경우
-        if (isValidFileSize(contentLength)) {
+        if (!isValidFileSize(contentLength)) {
             throw new InvalidValueException(
                 String.format("size: %dMB", contentLength / 1024 / 1024),
                 ErrorCode.PROFILE_IMAGE_SIZE_TOO_LARGE);
         }
 
         // 2. 이미지 확장자가 허용되지 않은 경우
-        if (isValidImageExtension(extension)) {
+        if (!isValidImageExtension(extension)) {
             throw new InvalidValueException(String.format("extension: %s", extension),
                 ErrorCode.UNSUPPORTED_IMAGE_EXTENSION);
         }

--- a/src/main/java/com/habitpay/habitpay/global/util/ImageUtil.java
+++ b/src/main/java/com/habitpay/habitpay/global/util/ImageUtil.java
@@ -16,7 +16,6 @@ public class ImageUtil {
     }
 
     public boolean isValidFileSize(Long size) {
-        System.out.printf("maxUploadSize: %d\n", maxUploadSize.toBytes());
         return 0 < size && size <= maxUploadSize.toBytes();
     }
 }

--- a/src/main/java/com/habitpay/habitpay/global/util/ImageUtil.java
+++ b/src/main/java/com/habitpay/habitpay/global/util/ImageUtil.java
@@ -3,14 +3,15 @@ package com.habitpay.habitpay.global.util;
 import com.habitpay.habitpay.domain.model.Image;
 
 public class ImageUtil {
+
     public static final long MB = 1024 * 1024;
-    public static final long PROFILE_IMAGE_SIZE_LIMIT = 1 * MB;
+    public static final long IMAGE_SIZE_LIMIT = 10 * MB;
 
     public static boolean isValidImageExtension(String extension) {
         return Image.VALID_EXTENSION.contains(extension.toUpperCase());
     }
 
     public static boolean isValidFileSize(Long size) {
-        return 0 < size && size <= PROFILE_IMAGE_SIZE_LIMIT;
+        return 0 < size && size <= IMAGE_SIZE_LIMIT;
     }
 }

--- a/src/main/java/com/habitpay/habitpay/global/util/ImageUtil.java
+++ b/src/main/java/com/habitpay/habitpay/global/util/ImageUtil.java
@@ -1,17 +1,22 @@
 package com.habitpay.habitpay.global.util;
 
 import com.habitpay.habitpay.domain.model.Image;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Component;
+import org.springframework.util.unit.DataSize;
 
+@Component
 public class ImageUtil {
 
-    public static final long MB = 1024 * 1024;
-    public static final long IMAGE_SIZE_LIMIT = 10 * MB;
+    @Value("${app.max-upload-file-size}")
+    private DataSize maxUploadSize;
 
-    public static boolean isValidImageExtension(String extension) {
+    public boolean isValidImageExtension(String extension) {
         return Image.VALID_EXTENSION.contains(extension.toUpperCase());
     }
 
-    public static boolean isValidFileSize(Long size) {
-        return 0 < size && size <= IMAGE_SIZE_LIMIT;
+    public boolean isValidFileSize(Long size) {
+        System.out.printf("maxUploadSize: %d\n", maxUploadSize.toBytes());
+        return 0 < size && size <= maxUploadSize.toBytes();
     }
 }

--- a/src/main/resources/application.yaml
+++ b/src/main/resources/application.yaml
@@ -40,6 +40,9 @@ spring:
     enabled: true
     baseline-on-migrate: true
 ---
+app:
+  max-upload-file-size: "10MB"
+---
 jwt:
   issuer: ${JWT_ISSUER}
   secret: ${JWT_SECRET}

--- a/src/test/resources/application.yaml
+++ b/src/test/resources/application.yaml
@@ -45,6 +45,9 @@ spring:
   flyway:
     enabled: false
 ---
+app:
+  max-upload-file-size: "10MB"
+---
 cors:
   allowed-origins: http://localhost:3000
 ---


### PR DESCRIPTION
# 개요

게시물 업로드 이미지와 프로필 업로드 이미지 파일의 크기 제한을 상향합니다.
최신 기종 스마트폰의 사진 품질이 높아서 모바일에서 이미지를 업로드 하지 못하는 문제를 해결하기 위한 방안입니다. (10MB 넘는 경우도 있음)

## 게시물 업로드 이미지

||1개당 용량|개수|총 용량|
|---|---|---|---|
|기존|1MB|5개|5MB|
|변경|10MB|5개|50MB|

## 프로필 업로드 이미지

||1개당 용량|개수|총 용량|
|---|---|---|---|
|기존|1MB|1개|1MB|
|변경|10MB|1개|10MB|

# 작업 내용

## 1. 이미지 파일 최대 크기를 `application.yaml` 파일에서 주입

기존에 `ImageUtil` 클래스에서 하드 코딩으로 관리했던 이미지 파일 크기를 `application.yaml` 파일에서 일괄적으로 관리하도록 했습니다.
유지보수 할 때 설정값을 관리하는 지점을 하나로 통합하여 관리의 복잡성을 줄이기 위해 이와 같이 변경했습니다.

기존에 static 클래스였던 `ImageUtil`는 외부에서 값을 주입받기 때문에 `@Component` 어노테이션을 이용해서 Bean으로 등록했습니다.

또한, 서비스 계층에서는 의존성을 주입하여 사용하도록 변경했습니다.

### 기존 코드

```java
// ImageUtil.java

public class ImageUtil {
    public static final long MB = 1024 * 1024;
    public static final long PROFILE_IMAGE_SIZE_LIMIT = 1 * MB;

   // ...
}
```

```java
// MemberUpdateService.java

if (ImageUtil.isValidFileSize(contentLength) == false) { // static 메서드 호출
  // ...
}
```

### 변경 코드

```yaml
// application.yaml

app:
  max-upload-file-size: "10MB"
```

```java
// ImageUtil.java

@Component
public class ImageUtil {

    @Value("${app.max-upload-file-size}")
    private DataSize maxUploadSize;

    // ...
}
```

```java
// MemberUpdateService.java

@Slf4j
@Service
@AllArgsConstructor
public class MemberUpdateService {

    private final MemberRepository memberRepository;
    private final ImageUtil imageUtil; // 의존성 주입
    private final S3FileService s3FileService;

    // ...

    public SuccessResponse<ImageUpdateResponse> updateImage(ImageUpdateRequest request,
            Member member) {
    
            // 이미지 형식(파일 크기, 확장자) 유효성 검사
            imageUtil.validateImageFormat(request.getContentLength(), request.getExtension());

            // ...
    }
}
```

## 2. 이미지 파일 최대 크기 제한 상향

프로필, 게시물 이미지 모두 파일 크기 제한을 1MB에서 10MB로 상향했습니다.

## 3. 코드 리팩터링

작업한 파일에서 관련된 메서드들에 대해 일부 리팩터링을 진행했습니다.

### 1) 서비스 계층의 메서드 추상화를 위한 하위 메서드 추출

서비스 계층 메서드의 내용을 한 눈에 알아보기 쉽도록 비슷한 기능을 하는 코드를 메서드로 묶어서 추출했습니다.

#### 기존 코드

```java
// MemberUpdateService.java

public SuccessResponse<ImageUpdateResponse> updateImage(ImageUpdateRequest imageUpdateRequest, Member member) {
    Long contentLength = imageUpdateRequest.getContentLength();
    String extension = imageUpdateRequest.getExtension();

    validateImageFormat(contentLength, extension);

    // 프로필 이미지가 이미 존재하는 경우 기존 이미지 삭제
    Optional.ofNullable(member.getImageFileName())
            .ifPresent((imageFileName) -> s3FileService.deleteImage("profiles", imageFileName));

    //  프론트엔드에 preSignedUrl 발급
    String randomFileName = UUID.randomUUID().toString();
    String savedFileName = String.format("%s.%s", randomFileName, extension);
    String preSignedUrl = s3FileService.getPutPreSignedUrl("profiles", savedFileName, extension, contentLength);
    log.info("[PATCH /member/image] savedFileName: {}", savedFileName);

    member.setImageFileName(savedFileName);
    memberRepository.save(member);

    return SuccessResponse.of(
            SuccessCode.PROFILE_IMAGE_UPDATE_SUCCESS.getMessage(),
            ImageUpdateResponse.from(preSignedUrl)
    );
}
```

#### 변경 코드

마틴 파울러의 <리팩터링 2판>에 따르면 지역 변수는 변수 관리의 부담을 증가시킬 수 있어서 최대한 지역 변수 대신 getter를 이용하는 것을 권장합니다. 지역 변수를 사용해야 하는 경우는 값이 변경될 가능성이 있어서 일관성을 유지해야 하거나, 값이 매우 자주 사용되는 경우라고 합니다. 또한, getter를 사용하면서 길어진 코드를 줄이기 위해 메서드 매개변수명도 `imageUpdateRequest`에서 `request`로 변경했습니다. 

```java
// MemberUpdateService.java

public SuccessResponse<ImageUpdateResponse> updateImage(ImageUpdateRequest request,
    Member member) {

    // 이미지 형식(파일 크기, 확장자) 유효성 검사
    imageUtil.validateImageFormat(request.getContentLength(), request.getExtension());

    // 기존 프로필 이미지 삭제
    deleteExistingImageIfExists(member);

    // 새로운 이미지 저장 및 URL 생성
    String preSignedUrl = saveNewImage(request, member);

    return SuccessResponse.of(
        SuccessCode.PROFILE_IMAGE_UPDATE_SUCCESS.getMessage(),
        ImageUpdateResponse.from(preSignedUrl)
    );
}
```

### 2) 이미지 유효성 검사 메서드 추출

프로필, 게시물 이미지 업로드 시 이미지 유효성 검사하는 중복된 코드를 제거하기 위해 `ImageUtil` 클래스에 메서드를 생성했습니다.

```java
// ImageUtil.java

public void validateImageFormat(Long contentLength, String extension) {
    // 1. 이미지 크기 제한이 넘을 경우
    if (!isValidFileSize(contentLength)) {
        throw new InvalidValueException(
            String.format("size: %dMB", contentLength / 1024 / 1024),
            ErrorCode.PROFILE_IMAGE_SIZE_TOO_LARGE);
    }

    // 2. 이미지 확장자가 허용되지 않은 경우
    if (!isValidImageExtension(extension)) {
        throw new InvalidValueException(String.format("extension: %s", extension),
            ErrorCode.UNSUPPORTED_IMAGE_EXTENSION);
    }
}

public boolean isValidImageExtension(String extension) {
    return Image.VALID_EXTENSION.contains(extension.toUpperCase());
}

public boolean isValidFileSize(Long size) {
    return 0 < size && size <= maxUploadSize.toBytes();
}
```

### 3) Optional 체이닝 메서드 수정

리팩터링을 하면서 코드를 살펴보다가 이전에 작성하셨던 코드에서 Optional 체이닝 사용할 때 `orElse()`에 빈 리스트를 생성하는 부분을 변경했습니다.

#### 기존 코드

```java
public void changePhotoViewOrder(List<ModifyPostPhotoData> modifyPostPhotoDataList) {
    Optional.ofNullable(modifyPostPhotoDataList).orElse(Collections.emptyList())
            .forEach(photo -> postPhotoUtilService.changeViewOrder(photo.getPhotoId(), photo.getViewOrder()));
}
```

#### 변경 코드

```java
public void changePhotoViewOrder(List<ModifyPostPhotoData> modifyPostPhotoDataList) {
    Optional.ofNullable(modifyPostPhotoDataList).ifPresent(list -> list.forEach(
        photo -> postPhotoUtilService.changeViewOrder(photo.getPhotoId(),
            photo.getViewOrder())));
}
```