### PR TITLE
[fix] 참여 실패한 record를 삭제하는 로직 수정 #326

### DIFF
--- a/src/main/java/com/habitpay/habitpay/domain/challengescheduler/application/SchedulerTaskHelperService.java
+++ b/src/main/java/com/habitpay/habitpay/domain/challengescheduler/application/SchedulerTaskHelperService.java
@@ -78,7 +78,6 @@ public class SchedulerTaskHelperService {
     public void checkFailedParticipation(List<Challenge> challengeList, ZonedDateTime yesterday) {
         HashMap<Challenge, Integer> challengeFailureCountMap = new HashMap<>();
         List<ParticipationStat> failureStatList = new ArrayList<>();
-        List<ChallengeParticipationRecord> failureRecordList = new ArrayList<>();
 
         challengeParticipationRecordSearchService.findByChallengesAndTargetDate(challengeList, yesterday)
                 .forEach(record -> {
@@ -92,14 +91,12 @@ public class SchedulerTaskHelperService {
                         stat.setTotalFee(stat.getTotalFee() + challenge.getFeePerAbsence());
 
                         failureStatList.add(record.getParticipationStat());
-                        failureRecordList.add(record);
                     }
                 });
 
         List<Challenge> feeAddedChallengeList = calculateFeeForChallenges(challengeFailureCountMap);
 
         participationStatRepository.saveAll(failureStatList);
-        challengeParticipationRecordRepository.deleteAll(failureRecordList);
         challengeRepository.saveAll(feeAddedChallengeList);
     }
 


### PR DESCRIPTION
### 개요

* 매일 자정 `챌린지 참여를 확인`하는 `스케쥴러 서비스`에서는, `참여 실패`로 판명날 경우 해당 `record`를 삭제했습니다.
* 그러나 `성공` 뿐만 아니라 `실패`한 기록 역시 `record`로 저장 관리해 기록성을 높이고자 합니다.

---

### 주요 코드

```java
// before
// SchedulerTaskHelperService.java

public void checkFailedParticipation(List<Challenge> challengeList, ZonedDateTime yesterday) {
  ...
  List<ChallengeParticipationRecord> failureRecordList = new ArrayList<>();
  ...
  challengeParticipationRecordSearchService.findByChallengesAndTargetDate(challengeList, yesterday)
  .forEach(record -> {
          ...
          failureRecordList.add(record);
      }
  });
  ...
  challengeParticipationRecordRepository.deleteAll(failureRecordList);
  ...
}
```

```java
// after
// SchedulerTaskHelperService.java

public void checkFailedParticipation(List<Challenge> challengeList, ZonedDateTime yesterday) {
  ...
  challengeParticipationRecordSearchService.findByChallengesAndTargetDate(challengeList, yesterday)
  .forEach(record -> {
          ...
      }
  });
  ...
}
```

* 참여 실패로 판명된 `record List`를 모아 `repository`에서 삭제하던 코드를 없앴습니다.

---

### 기타

* 챌린지 참여 `성공 날짜 목록`, `실패 날짜 목록`, `다가올 날짜 목록`을 보내주는 서비스 로직은 변경이 없습니다.
* 왜냐하면 그 로직은 이미 성공과 실패 `record`가 모두 존재함을 전제한 로직이었기 때문,,!