### PR TITLE
[Feat] 챌린지 상세 페이지 우상단의 멤버들 사진을 클릭하면, 챌린지 등록 멤버들 데이터 얻기 #330

### DIFF
--- a/src/docs/asciidoc/api/challenge.adoc
+++ b/src/docs/asciidoc/api/challenge.adoc
@@ -43,6 +43,12 @@ operation::challenge/get-challenge-details[snippets='http-request,http-response,
 
 operation::challenge/get-challenge-details-not-found-exception[snippets='http-request,http-response,response-fields']
 
+=== 챌린지 등록 멤버 조회
+
+특정 챌린지 내에 등록한 멤버들의 목록을 조회합니다.
+
+operation::challenge/get-challenge-members[snippets='http-request,http-response,response-fields']
+
 === 챌린지 별 참여 기록 조회
 
 챌린지 별 참여 기록을 조회합니다.

--- a/src/main/java/com/habitpay/habitpay/domain/challenge/api/ChallengeApi.java
+++ b/src/main/java/com/habitpay/habitpay/domain/challenge/api/ChallengeApi.java
@@ -27,6 +27,7 @@ public class ChallengeApi {
     private final ChallengeSearchService challengeSearchService;
     private final ChallengeDeleteService challengeDeleteService;
     private final ChallengeRecordsService challengeRecordsService;
+    private final ChallengeMemberSearchService challengeMemberSearchService;
 
     @GetMapping("/challenges")
     public SuccessResponse<PageResponse<ChallengePageResponse>> getChallengePage(
@@ -45,6 +46,12 @@ public class ChallengeApi {
     public SuccessResponse<ChallengeDetailsResponse> getChallengeDetails(@PathVariable("id") Long id,
                                                                          @AuthenticationPrincipal CustomUserDetails user) {
         return challengeDetailsService.getChallengeDetails(id, user.getMember());
+    }
+
+    @GetMapping("/challenges/{id}/members")
+    public SuccessResponse<?> getChallengeMemberList(@PathVariable("id") Long id,
+                                                     @AuthenticationPrincipal CustomUserDetails user) {
+        return challengeMemberSearchService.getChallengeMemberList();
     }
 
     @GetMapping("/challenges/{id}/records")

--- a/src/main/java/com/habitpay/habitpay/domain/challenge/api/ChallengeApi.java
+++ b/src/main/java/com/habitpay/habitpay/domain/challenge/api/ChallengeApi.java
@@ -49,9 +49,9 @@ public class ChallengeApi {
     }
 
     @GetMapping("/challenges/{id}/members")
-    public SuccessResponse<?> getEnrolledMemberList(@PathVariable("id") Long id,
+    public SuccessResponse<List<ChallengeEnrolledMember>> getEnrolledMemberList(@PathVariable("id") Long id,
                                                     @AuthenticationPrincipal CustomUserDetails user) {
-        return challengeMemberSearchService.getEnrolledMemberList();
+        return challengeMemberSearchService.getEnrolledMemberList(id, user.getMember());
     }
 
     @GetMapping("/challenges/{id}/records")

--- a/src/main/java/com/habitpay/habitpay/domain/challenge/api/ChallengeApi.java
+++ b/src/main/java/com/habitpay/habitpay/domain/challenge/api/ChallengeApi.java
@@ -49,9 +49,9 @@ public class ChallengeApi {
     }
 
     @GetMapping("/challenges/{id}/members")
-    public SuccessResponse<?> getChallengeMemberList(@PathVariable("id") Long id,
-                                                     @AuthenticationPrincipal CustomUserDetails user) {
-        return challengeMemberSearchService.getChallengeMemberList();
+    public SuccessResponse<?> getEnrolledMemberList(@PathVariable("id") Long id,
+                                                    @AuthenticationPrincipal CustomUserDetails user) {
+        return challengeMemberSearchService.getEnrolledMemberList();
     }
 
     @GetMapping("/challenges/{id}/records")

--- a/src/main/java/com/habitpay/habitpay/domain/challenge/application/ChallengeMemberSearchService.java
+++ b/src/main/java/com/habitpay/habitpay/domain/challenge/application/ChallengeMemberSearchService.java
@@ -24,7 +24,7 @@ public class ChallengeMemberSearchService {
     public SuccessResponse<List<ChallengeEnrolledMember>> getEnrolledMemberList(Long challengeId, Member myself) {
         Challenge challenge = challengeSearchService.getChallengeById(challengeId);
         List<Member> memberList = challengeEnrollmentRepository.findAllMemberByChallenge(challenge);
-        List<ChallengeEnrolledMember> enrolledMemberList = makeEnrolledMemberList(memberList);
+        List<ChallengeEnrolledMember> enrolledMemberList = makeEnrolledMemberList(memberList, myself);
 
         return SuccessResponse.of(
                 SuccessCode.NO_MESSAGE,
@@ -32,11 +32,12 @@ public class ChallengeMemberSearchService {
         );
     }
 
-    private List<ChallengeEnrolledMember> makeEnrolledMemberList(List<Member> memberList) {
+    private List<ChallengeEnrolledMember> makeEnrolledMemberList(List<Member> memberList, Member myself) {
         return memberList.stream()
                 .map(member -> {
                     String imageUrl = memberSearchService.getMemberProfileImageUrl(member.getImageFileName());
-                    return ChallengeEnrolledMember.of(member.getId(), member.getNickname(), imageUrl);
+                    Boolean isMyself = member.equals(myself);
+                    return ChallengeEnrolledMember.of(member.getId(), member.getNickname(), imageUrl, isMyself);
                 })
                 .collect(Collectors.toList());
     }

--- a/src/main/java/com/habitpay/habitpay/domain/challenge/application/ChallengeMemberSearchService.java
+++ b/src/main/java/com/habitpay/habitpay/domain/challenge/application/ChallengeMemberSearchService.java
@@ -1,0 +1,17 @@
+package com.habitpay.habitpay.domain.challenge.application;
+
+import com.habitpay.habitpay.global.response.SuccessCode;
+import com.habitpay.habitpay.global.response.SuccessResponse;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+@Service
+@RequiredArgsConstructor
+public class ChallengeMemberSearchService {
+
+    public SuccessResponse<?> getChallengeMemberList() {
+        return SuccessResponse.of(
+                SuccessCode.NO_MESSAGE
+        );
+    }
+}

--- a/src/main/java/com/habitpay/habitpay/domain/challenge/application/ChallengeMemberSearchService.java
+++ b/src/main/java/com/habitpay/habitpay/domain/challenge/application/ChallengeMemberSearchService.java
@@ -1,17 +1,43 @@
 package com.habitpay.habitpay.domain.challenge.application;
 
+import com.habitpay.habitpay.domain.challenge.domain.Challenge;
+import com.habitpay.habitpay.domain.challenge.dto.ChallengeEnrolledMember;
+import com.habitpay.habitpay.domain.challengeenrollment.dao.ChallengeEnrollmentRepository;
+import com.habitpay.habitpay.domain.member.application.MemberSearchService;
+import com.habitpay.habitpay.domain.member.domain.Member;
 import com.habitpay.habitpay.global.response.SuccessCode;
 import com.habitpay.habitpay.global.response.SuccessResponse;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 
+import java.util.List;
+import java.util.stream.Collectors;
+
 @Service
 @RequiredArgsConstructor
 public class ChallengeMemberSearchService {
 
-    public SuccessResponse<?> getEnrolledMemberList() {
+    private final ChallengeSearchService challengeSearchService;
+    private final MemberSearchService memberSearchService;
+    private final ChallengeEnrollmentRepository challengeEnrollmentRepository;
+
+    public SuccessResponse<List<ChallengeEnrolledMember>> getEnrolledMemberList(Long challengeId, Member myself) {
+        Challenge challenge = challengeSearchService.getChallengeById(challengeId);
+        List<Member> memberList = challengeEnrollmentRepository.findAllMemberByChallenge(challenge);
+        List<ChallengeEnrolledMember> enrolledMemberList = makeEnrolledMemberList(memberList);
+
         return SuccessResponse.of(
-                SuccessCode.NO_MESSAGE
+                SuccessCode.NO_MESSAGE,
+                enrolledMemberList
         );
+    }
+
+    private List<ChallengeEnrolledMember> makeEnrolledMemberList(List<Member> memberList) {
+        return memberList.stream()
+                .map(member -> {
+                    String imageUrl = memberSearchService.getMemberProfileImageUrl(member.getImageFileName());
+                    return ChallengeEnrolledMember.of(member.getId(), member.getNickname(), imageUrl);
+                })
+                .collect(Collectors.toList());
     }
 }

--- a/src/main/java/com/habitpay/habitpay/domain/challenge/application/ChallengeMemberSearchService.java
+++ b/src/main/java/com/habitpay/habitpay/domain/challenge/application/ChallengeMemberSearchService.java
@@ -9,7 +9,7 @@ import org.springframework.stereotype.Service;
 @RequiredArgsConstructor
 public class ChallengeMemberSearchService {
 
-    public SuccessResponse<?> getChallengeMemberList() {
+    public SuccessResponse<?> getEnrolledMemberList() {
         return SuccessResponse.of(
                 SuccessCode.NO_MESSAGE
         );

--- a/src/main/java/com/habitpay/habitpay/domain/challenge/dto/ChallengeEnrolledMember.java
+++ b/src/main/java/com/habitpay/habitpay/domain/challenge/dto/ChallengeEnrolledMember.java
@@ -1,0 +1,19 @@
+package com.habitpay.habitpay.domain.challenge.dto;
+
+import lombok.Builder;
+import lombok.Getter;
+
+@Getter
+@Builder
+public class ChallengeEnrolledMember {
+    private Long id;
+    private String nickname;
+    private String profileImage;
+
+//    public static ChallengeEnrolledMember of() {
+//        return ChallengeEnrolledMember.builder()
+//                .id()
+//                .nickname()
+//                .profileImage();
+//    }
+}

--- a/src/main/java/com/habitpay/habitpay/domain/challenge/dto/ChallengeEnrolledMember.java
+++ b/src/main/java/com/habitpay/habitpay/domain/challenge/dto/ChallengeEnrolledMember.java
@@ -1,5 +1,6 @@
 package com.habitpay.habitpay.domain.challenge.dto;
 
+import com.habitpay.habitpay.domain.member.domain.Member;
 import lombok.Builder;
 import lombok.Getter;
 
@@ -8,12 +9,13 @@ import lombok.Getter;
 public class ChallengeEnrolledMember {
     private Long id;
     private String nickname;
-    private String profileImage;
+    private String profileImageUrl;
 
-//    public static ChallengeEnrolledMember of() {
-//        return ChallengeEnrolledMember.builder()
-//                .id()
-//                .nickname()
-//                .profileImage();
-//    }
+    public static ChallengeEnrolledMember of(Long id, String nickname, String imageUrl) {
+        return ChallengeEnrolledMember.builder()
+                .id(id)
+                .nickname(nickname)
+                .profileImageUrl(imageUrl)
+                .build();
+    }
 }

--- a/src/main/java/com/habitpay/habitpay/domain/challenge/dto/ChallengeEnrolledMember.java
+++ b/src/main/java/com/habitpay/habitpay/domain/challenge/dto/ChallengeEnrolledMember.java
@@ -10,12 +10,14 @@ public class ChallengeEnrolledMember {
     private Long id;
     private String nickname;
     private String profileImageUrl;
+    private Boolean isMyself;
 
-    public static ChallengeEnrolledMember of(Long id, String nickname, String imageUrl) {
+    public static ChallengeEnrolledMember of(Long id, String nickname, String imageUrl, Boolean isMyself) {
         return ChallengeEnrolledMember.builder()
                 .id(id)
                 .nickname(nickname)
                 .profileImageUrl(imageUrl)
+                .isMyself(isMyself)
                 .build();
     }
 }

--- a/src/main/java/com/habitpay/habitpay/domain/challenge/dto/ChallengeEnrolledMember.java
+++ b/src/main/java/com/habitpay/habitpay/domain/challenge/dto/ChallengeEnrolledMember.java
@@ -1,20 +1,19 @@
 package com.habitpay.habitpay.domain.challenge.dto;
 
-import com.habitpay.habitpay.domain.member.domain.Member;
 import lombok.Builder;
 import lombok.Getter;
 
 @Getter
 @Builder
 public class ChallengeEnrolledMember {
-    private Long id;
+    private Long memberId;
     private String nickname;
     private String profileImageUrl;
     private Boolean isMyself;
 
     public static ChallengeEnrolledMember of(Long id, String nickname, String imageUrl, Boolean isMyself) {
         return ChallengeEnrolledMember.builder()
-                .id(id)
+                .memberId(id)
                 .nickname(nickname)
                 .profileImageUrl(imageUrl)
                 .isMyself(isMyself)

--- a/src/main/java/com/habitpay/habitpay/domain/challengeenrollment/dao/ChallengeEnrollmentRepository.java
+++ b/src/main/java/com/habitpay/habitpay/domain/challengeenrollment/dao/ChallengeEnrollmentRepository.java
@@ -19,6 +19,11 @@ public interface ChallengeEnrollmentRepository extends JpaRepository<ChallengeEn
     List<ChallengeEnrollment> findTop3ByChallenge(Challenge challenge);
     List<ChallengeEnrollment> findAllByChallenge(Challenge challenge);
 
+    @Query("SELECT e.member " +
+    "FROM ChallengeEnrollment e " +
+    "WHERE e.challenge = :challenge")
+    List<Member> findAllMemberByChallenge(Challenge challenge);
+
     @Query("SELECT new com.habitpay.habitpay.domain.challengeabsencefee.dto.MemberFeeView(m.id, m.nickname, s.totalFee, (s.successCount / :totalCount) * 100) " +
     "FROM ChallengeEnrollment e " +
     "JOIN e.member m " +

--- a/src/main/java/com/habitpay/habitpay/domain/member/application/MemberSearchService.java
+++ b/src/main/java/com/habitpay/habitpay/domain/member/application/MemberSearchService.java
@@ -21,7 +21,7 @@ public class MemberSearchService {
 
     public SuccessResponse<MemberProfileResponse> getMemberProfile(Member member) {
         String imageFileName = Optional.ofNullable(member.getImageFileName()).orElse("");
-        String imageUrl = imageFileName.isEmpty() ? "" : s3FileService.getGetPreSignedUrl("profiles", imageFileName);
+        String imageUrl = getMemberProfileImageUrl(imageFileName);
         
         return SuccessResponse.of(SuccessCode.NO_MESSAGE, MemberProfileResponse.of(member, imageUrl));
     }
@@ -30,5 +30,9 @@ public class MemberSearchService {
     public Member getMemberById(Long id) {
         return memberRepository.findById(id)
                 .orElseThrow(() -> new MemberNotFoundException(id));
+    }
+
+    public String getMemberProfileImageUrl(String imageFileName) {
+        return imageFileName.isEmpty() ? "" : s3FileService.getGetPreSignedUrl("profiles", imageFileName);
     }
 }

--- a/src/main/java/com/habitpay/habitpay/domain/member/application/MemberSearchService.java
+++ b/src/main/java/com/habitpay/habitpay/domain/member/application/MemberSearchService.java
@@ -21,7 +21,7 @@ public class MemberSearchService {
 
     public SuccessResponse<MemberProfileResponse> getMemberProfile(Member member) {
         String imageFileName = Optional.ofNullable(member.getImageFileName()).orElse("");
-        String imageUrl = getMemberProfileImageUrl(imageFileName);
+        String imageUrl = imageFileName.isEmpty() ? "" : s3FileService.getGetPreSignedUrl("profiles", imageFileName);
         
         return SuccessResponse.of(SuccessCode.NO_MESSAGE, MemberProfileResponse.of(member, imageUrl));
     }
@@ -33,6 +33,7 @@ public class MemberSearchService {
     }
 
     public String getMemberProfileImageUrl(String imageFileName) {
+        if (imageFileName == null) { imageFileName = ""; }
         return imageFileName.isEmpty() ? "" : s3FileService.getGetPreSignedUrl("profiles", imageFileName);
     }
 }


### PR DESCRIPTION
### 개요

* 챌린지 상세 페이지의 우상단에는, 챌린지에 가입한 멤버 중 상위 3명의 사진과 전체 인원 수가 미리보기로 제공됩니다.
![Screenshot 2024-12-13 at 10 44 56 AM](https://github.com/user-attachments/assets/7864ed9d-db28-4e85-a841-179289e97a2c)

* 이때 미리보기 구역을 클릭하면, 해당 챌린지에 등록되어 있는 멤버들의 데이터를 제공하는 API를 추가했습니다.

---

### 코드 상세

* 특정 챌린지 내 등록된 멤버들의 데이터 리스트를 제공하는 API 메서드입니다.

```java
// ChallengeApi.java

@GetMapping("/challenges/{id}/members")
public SuccessResponse<List<ChallengeEnrolledMember>> getEnrolledMemberList(@PathVariable("id") Long id,
                                                @AuthenticationPrincipal CustomUserDetails user) {
    return challengeMemberSearchService.getEnrolledMemberList(id, user.getMember());
}
```

---

* 필요한 데이터를 담는 `ChallengeEnrolledMember DTO`를 만들었습니다.

```java
// challenge/dto/ChallengeEnrolledMember.java

public class ChallengeEnrolledMember {
    private Long memberId;
    private String nickname;
    private String profileImageUrl;
    private Boolean isMyself;

    public static ChallengeEnrolledMember of(Long id, String nickname, String imageUrl, Boolean isMyself) {
        return ChallengeEnrolledMember.builder()
                .memberId(id)
                .nickname(nickname)
                .profileImageUrl(imageUrl)
                .isMyself(isMyself)
                .build();
    }
}
```

* 멤버 데이터는 약식으로 제공되기 때문에, `식별 id, 닉네임, 이미지 url`의 요소만 있습니다.
* `isMyself`는, 해당 데이터가 로그인한 멤버 당사자의 것인지 여부를 판별하는 요소입니다.
   멤버 목록에서 자기자신을 표시하는 시각 효과를 주거나, 멤버 클릭 시 본인이라면 다른 행동을 할 수 있도록 추가했습니다.
* 프론트엔드 작업에 따라 요소를 추가하거나 삭제할 수 있습니다.

---

* 챌린지 내 등록 멤버를 조회하기 위한 `ChallengeMemberSearchService` 클래스를 새로 만들었습니다.

```java
// challenge/application/ChallengeMemberSearchService.java

public class ChallengeMemberSearchService {
    ...

    public SuccessResponse<List<ChallengeEnrolledMember>> getEnrolledMemberList(Long challengeId, Member myself) {
        Challenge challenge = challengeSearchService.getChallengeById(challengeId);
        List<Member> memberList = challengeEnrollmentRepository.findAllMemberByChallenge(challenge);
        List<ChallengeEnrolledMember> enrolledMemberList = makeEnrolledMemberList(memberList, myself);

        return SuccessResponse.of(
                SuccessCode.NO_MESSAGE,
                enrolledMemberList
        );
    }
   ...
}
```

* `챌린지` 객체를 통해, 해당 챌린지 내에 등록되어 있는 멤버의 `List`를 얻습니다.
* 이후 이 `멤버 List`를 가공해 `ChallengeEnrolledMember` DTO의 `List`를 만듭니다.

---

* `멤버 List`를 가공해 `ChallengeEnrolledMember` DTO의 `List`를 만드는 `makeEnrolledMemberList` 메서드입니다.

```java
// challenge/application/ChallengeMemberSearchService.java

private List<ChallengeEnrolledMember> makeEnrolledMemberList(List<Member> memberList, Member myself) {
    return memberList.stream()
            .map(member -> {
                String imageUrl = memberSearchService.getMemberProfileImageUrl(member.getImageFileName());
                Boolean isMyself = member.equals(myself);
                return ChallengeEnrolledMember.of(member.getId(), member.getNickname(), imageUrl, isMyself);
            })
            .collect(Collectors.toList());
}
```

* `프로필 이미지 url`을 쉽게 구하기 위해, `memberSearchService` 내에 `imageFileName`을 이용해 url을 제공하는 메서드를 추가했습니다.

```java
// member/application/MemberSearchService.java

public String getMemberProfileImageUrl(String imageFileName) {
    if (imageFileName == null) { imageFileName = ""; }
    return imageFileName.isEmpty() ? "" : s3FileService.getGetPreSignedUrl("profiles", imageFileName);
}
```

* 준한님이 이미 만드신 코드 일부를 그대로 사용했는데요,
그래서 해당 로직을 사용하는 부분을 다 위의 메서드로 대체할까 했지만,,!
`imageFileName`을 얻는 과정이 조금씩 달라, 코드를 더 수정해야 하거나 중복되는 내용이 생겨서 우선 건드리지 않기로 했습니다.
ex) 다른 곳에 `Optional<Member>` 형태로 받은 후 `imageFileName`이 없다면 선제적으로 빈 문자열인 `""`을 대입하는 코드가 있는데, 위의 `null 가드`와 기능적으로 중복됨 등
* 서로 다른 메서드라고 우선 생각하기로 했읍니다,,!

---

* `ChallengeEnrollmentRepository`에서 `Challenge` 객체를 이용해 `챌린지 내 모든 멤버`를 얻는 메서드를 추가했습니다.

```java
// ChallengeEnrollmentRepository.java

@Query("SELECT e.member " +
"FROM ChallengeEnrollment e " +
"WHERE e.challenge = :challenge")
List<Member> findAllMemberByChallenge(Challenge challenge);
```

* `ChallengeEnrollment` 테이블에서 `Member 필드`만 필요하기 때문입니다.

---

* 관련 테스트 코드 및 문서 내용을 추가했습니다.
* 프론트엔드 작업에 따라 수정될 수 있습니다.

---

### 사족

* 굉장히 오랜만에 풀리퀘 작성하는 느낌,,,!