### PR TITLE
[Refact] SliceResponse 타입 적용 등 소소한 리팩토링 #332

### DIFF
--- a/src/main/java/com/habitpay/habitpay/domain/challenge/application/ChallengeMemberSearchService.java
+++ b/src/main/java/com/habitpay/habitpay/domain/challenge/application/ChallengeMemberSearchService.java
@@ -21,10 +21,10 @@ public class ChallengeMemberSearchService {
     private final MemberSearchService memberSearchService;
     private final ChallengeEnrollmentRepository challengeEnrollmentRepository;
 
-    public SuccessResponse<List<ChallengeEnrolledMember>> getEnrolledMemberList(Long challengeId, Member myself) {
+    public SuccessResponse<List<ChallengeEnrolledMember>> getEnrolledMemberList(Long challengeId, Member currentUser) {
         Challenge challenge = challengeSearchService.getChallengeById(challengeId);
         List<Member> memberList = challengeEnrollmentRepository.findAllMemberByChallenge(challenge);
-        List<ChallengeEnrolledMember> enrolledMemberList = makeEnrolledMemberList(memberList, myself);
+        List<ChallengeEnrolledMember> enrolledMemberList = makeEnrolledMemberList(memberList, currentUser);
 
         return SuccessResponse.of(
                 SuccessCode.NO_MESSAGE,
@@ -32,12 +32,12 @@ public class ChallengeMemberSearchService {
         );
     }
 
-    private List<ChallengeEnrolledMember> makeEnrolledMemberList(List<Member> memberList, Member myself) {
+    private List<ChallengeEnrolledMember> makeEnrolledMemberList(List<Member> memberList, Member currentUser) {
         return memberList.stream()
                 .map(member -> {
                     String imageUrl = memberSearchService.getMemberProfileImageUrl(member.getImageFileName());
-                    Boolean isMyself = member.equals(myself);
-                    return ChallengeEnrolledMember.of(member.getId(), member.getNickname(), imageUrl, isMyself);
+                    Boolean isCurrentUser = member.equals(currentUser);
+                    return ChallengeEnrolledMember.of(member.getId(), member.getNickname(), imageUrl, isCurrentUser);
                 })
                 .collect(Collectors.toList());
     }

--- a/src/main/java/com/habitpay/habitpay/domain/challenge/dto/ChallengeEnrolledMember.java
+++ b/src/main/java/com/habitpay/habitpay/domain/challenge/dto/ChallengeEnrolledMember.java
@@ -9,14 +9,14 @@ public class ChallengeEnrolledMember {
     private Long memberId;
     private String nickname;
     private String profileImageUrl;
-    private Boolean isMyself;
+    private Boolean isCurrentUser;
 
     public static ChallengeEnrolledMember of(Long id, String nickname, String imageUrl, Boolean isMyself) {
         return ChallengeEnrolledMember.builder()
                 .memberId(id)
                 .nickname(nickname)
                 .profileImageUrl(imageUrl)
-                .isMyself(isMyself)
+                .isCurrentUser(isMyself)
                 .build();
     }
 }

--- a/src/main/java/com/habitpay/habitpay/domain/challenge/dto/ChallengeEnrolledMember.java
+++ b/src/main/java/com/habitpay/habitpay/domain/challenge/dto/ChallengeEnrolledMember.java
@@ -11,12 +11,12 @@ public class ChallengeEnrolledMember {
     private String profileImageUrl;
     private Boolean isCurrentUser;
 
-    public static ChallengeEnrolledMember of(Long id, String nickname, String imageUrl, Boolean isMyself) {
+    public static ChallengeEnrolledMember of(Long id, String nickname, String imageUrl, Boolean isCurrentUser) {
         return ChallengeEnrolledMember.builder()
                 .memberId(id)
                 .nickname(nickname)
                 .profileImageUrl(imageUrl)
-                .isCurrentUser(isMyself)
+                .isCurrentUser(isCurrentUser)
                 .build();
     }
 }

--- a/src/main/java/com/habitpay/habitpay/domain/challengeabsencefee/dto/MemberFee.java
+++ b/src/main/java/com/habitpay/habitpay/domain/challengeabsencefee/dto/MemberFee.java
@@ -12,14 +12,14 @@ public class MemberFee {
     private String nickname;
     private int totalFee;
     private int completionRate;
-    private Boolean isMe;
+    private Boolean isCurrentUser;
 
     public static MemberFee of(MemberFeeView memberFeeView, Long memberId) {
         return MemberFee.builder()
                 .nickname(memberFeeView.getNickname())
                 .totalFee(memberFeeView.getTotalFee())
                 .completionRate(memberFeeView.getCompletionRate())
-                .isMe(memberFeeView.getMemberId().equals(memberId))
+                .isCurrentUser(memberFeeView.getMemberId().equals(memberId))
                 .build();
     }
 

--- a/src/main/java/com/habitpay/habitpay/domain/challengepost/api/ChallengePostApi.java
+++ b/src/main/java/com/habitpay/habitpay/domain/challengepost/api/ChallengePostApi.java
@@ -57,7 +57,7 @@ public class ChallengePostApi {
     }
 
     @GetMapping("/challenges/{id}/posts/announcements")
-    public SuccessResponse<Slice<PostViewResponse>> getAnnouncements(
+    public SuccessResponse<SliceResponse<PostViewResponse>> getAnnouncements(
         @PathVariable Long id,
         @AuthenticationPrincipal CustomUserDetails user,
         @PageableDefault(sort = "id", direction = Sort.Direction.DESC) Pageable pageable) {
@@ -67,7 +67,7 @@ public class ChallengePostApi {
     }
 
     @GetMapping("/challenges/{id}/posts/me")
-    public SuccessResponse<Slice<PostViewResponse>> getChallengePostsByMe(
+    public SuccessResponse<SliceResponse<PostViewResponse>> getChallengePostsByMe(
         @PathVariable Long id,
         @AuthenticationPrincipal CustomUserDetails user,
         @PageableDefault(sort = "id", direction = Sort.Direction.DESC) Pageable pageable) {
@@ -78,7 +78,7 @@ public class ChallengePostApi {
     // -----------------------------------------------------------------------------
     // todo : 'memberId' 등 멤버 식별할 수 있는 데이터를 받은 후 수정
 //    @GetMapping("/challenges/{id}/posts/member")
-//    public SuccessResponse<Slice<PostViewResponse>> getChallengePostsByMember(
+//    public SuccessResponse<SliceResponse<PostViewResponse>> getChallengePostsByMember(
 //            @PathVariable Long id,
 //            @PageableDefault(sort = "id", direction = Sort.Direction.DESC) Pageable pageable) {
 //

--- a/src/main/java/com/habitpay/habitpay/domain/challengepost/application/ChallengePostSearchService.java
+++ b/src/main/java/com/habitpay/habitpay/domain/challengepost/application/ChallengePostSearchService.java
@@ -75,7 +75,7 @@ public class ChallengePostSearchService {
         );
     }
 
-    public SuccessResponse<Slice<PostViewResponse>> findAnnouncementPostViewListByChallengeId(
+    public SuccessResponse<SliceResponse<PostViewResponse>> findAnnouncementPostViewListByChallengeId(
         Long challengeId, Member member, Pageable pageable) {
 
         Slice<ChallengePost> postSlice = challengePostRepository.findAllByChallengeIdAndIsAnnouncementTrue(
@@ -87,11 +87,11 @@ public class ChallengePostSearchService {
 
         return SuccessResponse.of(
             SuccessCode.NO_MESSAGE,
-            postViewResponseSlice
+                SliceResponse.from(postViewResponseSlice)
         );
     }
 
-    public SuccessResponse<Slice<PostViewResponse>> findPostViewListByMember(Long challengeId,
+    public SuccessResponse<SliceResponse<PostViewResponse>> findPostViewListByMember(Long challengeId,
         Member member, Pageable pageable) {
         Challenge challenge = challengeSearchService.getChallengeById(challengeId);
         ChallengeEnrollment enrollment = challengeEnrollmentSearchService.findByMemberAndChallenge(
@@ -107,7 +107,7 @@ public class ChallengePostSearchService {
 
         return SuccessResponse.of(
             SuccessCode.NO_MESSAGE,
-            postViewResponseSlice
+                SliceResponse.from(postViewResponseSlice)
         );
     }
 

--- a/src/main/java/com/habitpay/habitpay/domain/member/application/MemberSearchService.java
+++ b/src/main/java/com/habitpay/habitpay/domain/member/application/MemberSearchService.java
@@ -33,7 +33,9 @@ public class MemberSearchService {
     }
 
     public String getMemberProfileImageUrl(String imageFileName) {
-        if (imageFileName == null) { imageFileName = ""; }
-        return imageFileName.isEmpty() ? "" : s3FileService.getGetPreSignedUrl("profiles", imageFileName);
+        return Optional.ofNullable(imageFileName)
+                .filter(fileName -> !fileName.isEmpty())
+                .map(fileName -> s3FileService.getGetPreSignedUrl("profiles", fileName))
+                .orElse("");
     }
 }

--- a/src/test/java/com/habitpay/habitpay/domain/challegepost/api/ChallengePostApiTest.java
+++ b/src/test/java/com/habitpay/habitpay/domain/challegepost/api/ChallengePostApiTest.java
@@ -270,7 +270,7 @@ public class ChallengePostApiTest extends AbstractRestDocsTests {
 
         given(challengePostSearchService.findAnnouncementPostViewListByChallengeId(anyLong(),
             any(Member.class), any(Pageable.class)))
-            .willReturn(SuccessResponse.of(SuccessCode.NO_MESSAGE, mockPostViewResponseSlice));
+            .willReturn(SuccessResponse.of(SuccessCode.NO_MESSAGE, SliceResponse.from(mockPostViewResponseSlice)));
 
         // when
         ResultActions result = mockMvc.perform(get("/api/challenges/{id}/posts/announcements", 1L)
@@ -305,6 +305,13 @@ public class ChallengePostApiTest extends AbstractRestDocsTests {
                     fieldWithPath("data.content[].photoViewList[].imageUrl").description(
                         "포스트 포토 url"),
 
+                    fieldWithPath("data.pageNumber").description("현재 페이지 번호"),
+                    fieldWithPath("data.size").description("현재 페이지의 크기"),
+                    fieldWithPath("data.isFirst").description("이 페이지가 첫 번째 페이지인지 여부"),
+                    fieldWithPath("data.isLast").description("이 페이지가 마지막 페이지인지 여부"),
+                    fieldWithPath("data.isEmpty").description("페이지가 비어있는지 여부"),
+                    fieldWithPath("data.hasNextPage").description("다음 페이지 존재 여부"),
+
                     fieldWithPath("data.pageable").description("포스트 뷰 페이지네이션 정보를 담은 Pageable 객체"),
                     fieldWithPath("data.pageable.pageNumber").description("현재 페이지 번호"),
                     fieldWithPath("data.pageable.pageSize").description("한 페이지에 포함되는 항목의 수"),
@@ -314,18 +321,7 @@ public class ChallengePostApiTest extends AbstractRestDocsTests {
                     fieldWithPath("data.pageable.sort.sorted").description("정렬되었는지 여부"),
                     fieldWithPath("data.pageable.offset").description("페이징된 항목의 시작 위치"),
                     fieldWithPath("data.pageable.paged").description("페이징된 요청인지 여부"),
-                    fieldWithPath("data.pageable.unpaged").description("페이징되지 않은 요청인지 여부"),
-
-                    fieldWithPath("data.size").description("한 페이지에 포함되는 항목의 수"),
-                    fieldWithPath("data.number").description("현재 페이지 번호"),
-                    fieldWithPath("data.sort").description("정렬 정보"),
-                    fieldWithPath("data.sort.empty").description("정렬 조건이 없는지 여부"),
-                    fieldWithPath("data.sort.unsorted").description("정렬되지 않았는지 여부"),
-                    fieldWithPath("data.sort.sorted").description("정렬되었는지 여부"),
-                    fieldWithPath("data.numberOfElements").description("현재 페이지에 있는 요소의 수"),
-                    fieldWithPath("data.first").description("이 페이지가 첫 번째 페이지인지 여부"),
-                    fieldWithPath("data.last").description("이 페이지가 마지막 페이지인지 여부"),
-                    fieldWithPath("data.empty").description("페이지가 비어있는지 여부")
+                    fieldWithPath("data.pageable.unpaged").description("페이징되지 않은 요청인지 여부")
                 )
             ));
     }
@@ -368,7 +364,7 @@ public class ChallengePostApiTest extends AbstractRestDocsTests {
 
         given(challengePostSearchService.findPostViewListByMember(anyLong(), any(Member.class),
             any(Pageable.class)))
-            .willReturn(SuccessResponse.of(SuccessCode.NO_MESSAGE, mockPostViewResponseSlice));
+            .willReturn(SuccessResponse.of(SuccessCode.NO_MESSAGE, SliceResponse.from(mockPostViewResponseSlice)));
 
         // when
         ResultActions result = mockMvc.perform(get("/api/challenges/{id}/posts/me", 1L)
@@ -403,6 +399,13 @@ public class ChallengePostApiTest extends AbstractRestDocsTests {
                     fieldWithPath("data.content[].photoViewList[].imageUrl").description(
                         "포스트 포토 url"),
 
+                    fieldWithPath("data.pageNumber").description("현재 페이지 번호"),
+                    fieldWithPath("data.size").description("현재 페이지의 크기"),
+                    fieldWithPath("data.isFirst").description("이 페이지가 첫 번째 페이지인지 여부"),
+                    fieldWithPath("data.isLast").description("이 페이지가 마지막 페이지인지 여부"),
+                    fieldWithPath("data.isEmpty").description("페이지가 비어있는지 여부"),
+                    fieldWithPath("data.hasNextPage").description("다음 페이지 존재 여부"),
+
                     fieldWithPath("data.pageable").description("포스트 뷰 페이지네이션 정보를 담은 Pageable 객체"),
                     fieldWithPath("data.pageable.pageNumber").description("현재 페이지 번호"),
                     fieldWithPath("data.pageable.pageSize").description("한 페이지에 포함되는 항목의 수"),
@@ -412,18 +415,7 @@ public class ChallengePostApiTest extends AbstractRestDocsTests {
                     fieldWithPath("data.pageable.sort.sorted").description("정렬되었는지 여부"),
                     fieldWithPath("data.pageable.offset").description("페이징된 항목의 시작 위치"),
                     fieldWithPath("data.pageable.paged").description("페이징된 요청인지 여부"),
-                    fieldWithPath("data.pageable.unpaged").description("페이징되지 않은 요청인지 여부"),
-
-                    fieldWithPath("data.size").description("한 페이지에 포함되는 항목의 수"),
-                    fieldWithPath("data.number").description("현재 페이지 번호"),
-                    fieldWithPath("data.sort").description("정렬 정보"),
-                    fieldWithPath("data.sort.empty").description("정렬 조건이 없는지 여부"),
-                    fieldWithPath("data.sort.unsorted").description("정렬되지 않았는지 여부"),
-                    fieldWithPath("data.sort.sorted").description("정렬되었는지 여부"),
-                    fieldWithPath("data.numberOfElements").description("현재 페이지에 있는 요소의 수"),
-                    fieldWithPath("data.first").description("이 페이지가 첫 번째 페이지인지 여부"),
-                    fieldWithPath("data.last").description("이 페이지가 마지막 페이지인지 여부"),
-                    fieldWithPath("data.empty").description("페이지가 비어있는지 여부")
+                    fieldWithPath("data.pageable.unpaged").description("페이징되지 않은 요청인지 여부")
                 )
             ));
     }

--- a/src/test/java/com/habitpay/habitpay/domain/challenge/api/ChallengeApiTest.java
+++ b/src/test/java/com/habitpay/habitpay/domain/challenge/api/ChallengeApiTest.java
@@ -300,13 +300,13 @@ public class ChallengeApiTest extends AbstractRestDocsTests {
                         .memberId(1L)
                         .nickname("test user1")
                         .profileImageUrl("https://picsum.photos/id/40/200/300")
-                        .isMyself(true)
+                        .isCurrentUser(true)
                         .build(),
                 ChallengeEnrolledMember.builder()
                         .memberId(2L)
                         .nickname("test user2")
                         .profileImageUrl("")
-                        .isMyself(false)
+                        .isCurrentUser(false)
                         .build());
 
         given(challengeMemberSearchService.getEnrolledMemberList(anyLong(), any(Member.class)))

--- a/src/test/java/com/habitpay/habitpay/domain/challenge/api/ChallengeApiTest.java
+++ b/src/test/java/com/habitpay/habitpay/domain/challenge/api/ChallengeApiTest.java
@@ -327,7 +327,7 @@ public class ChallengeApiTest extends AbstractRestDocsTests {
                                 fieldWithPath("data[].memberId").description("멤버 아이디"),
                                 fieldWithPath("data[].nickname").description("멤버 이름"),
                                 fieldWithPath("data[].profileImageUrl").description("프로필 이미지 url"),
-                                fieldWithPath("data[].isMyself").description("해당 멤버 데이터가 로그인한 본인의 것인지 여부")
+                                fieldWithPath("data[].isCurrentUser").description("해당 멤버 데이터가 로그인한 본인의 것인지 여부")
                         )
                 ));
     }

--- a/src/test/java/com/habitpay/habitpay/domain/challengeabsencefee/api/ChallengeAbsenceFeeApiTest.java
+++ b/src/test/java/com/habitpay/habitpay/domain/challengeabsencefee/api/ChallengeAbsenceFeeApiTest.java
@@ -78,7 +78,7 @@ public class ChallengeAbsenceFeeApiTest extends AbstractRestDocsTests {
                                 fieldWithPath("data.memberFeeList[].nickname").description("멤버 닉네임"),
                                 fieldWithPath("data.memberFeeList[].totalFee").description("챌린지 내 멤버의 누적 벌금 총합"),
                                 fieldWithPath("data.memberFeeList[].completionRate").description("챌린지 내 멤버의 달성률"),
-                                fieldWithPath("data.memberFeeList[].isMe").description("나의 벌금 현황 여부")
+                                fieldWithPath("data.memberFeeList[].isCurrentUser").description("나의 벌금 현황 여부")
                                 )
                 ));
     }


### PR DESCRIPTION
### 개요

* `SliceResponse`를 사용할 수 있는 API 컨트롤러 메서드 2개에 해당 반환 타입을 적용했습니다.
* `프로필 이미지 url을 얻는 메서드`에 `조건문 null 가드` 대신 `Optional`을 적용해 가독성을 높였습니다.
* 멤버 본인인지 여부를 담는 변수명을 `isCurrentUser`로 통일했습니다.

---

### 코드 내용

* 반환 타입에 `Slice`를 사용하던 API 컨트롤러 메서드가 2개 존재합니다.
* 이를 `SliceResponse` 타입으로 변경하여, 데이터 전송량을 절약했습니다.

```java
// ChallengePostApi.java

...
public SuccessResponse<SliceResponse<PostViewResponse>> getAnnouncements(..) {..}
...
public SuccessResponse<SliceResponse<PostViewResponse>> findPostViewListByMember(..) {..}
...
```

(* 근데 사실 현재 사용 중인 컨트롤러는 아닙니다. 그래도 미리 바꿔놓기!)

---

* `MemberSearchService`에 `프로필 이미지 url을 얻는 메서드`를 생성했었습니다.
* 그러나 if 조건문으로 null 가드를 하드코딩했기 때문에, 가독성이 떨어졌습니다.
* 이 대신 `Optional`을 적용해 가독성을 높였습니다.

```java
// MemberSearchService.java

public String getMemberProfileImageUrl(String imageFileName) {
    return Optional.ofNullable(imageFileName)
            .filter(fileName -> !fileName.isEmpty())
            .map(fileName -> s3FileService.getGetPreSignedUrl("profiles", fileName))
            .orElse("");
}
```

---

* 요청자가 로그인한 `멤버 본인`인지 여부를 담는 변수명을 `isCurrentUser`로 통일했습니다.
* 변수명 변경이 일어난 DTO는 `ChallengeEnrolledMember`, `MemberFee`로 총 2개입니다.

```java
// challenge/dto/ChallengeEnrolledMember.java

public class ChallengeEnrolledMember {
    ...
    private Boolean isCurrentUser;
    ...
}
```

```java
// challengeabsencefee/dto/MemberFee.java

public class MemberFee {
    ...
    private Boolean isCurrentUser;
    ...
}
```

---

* 관련 테스트 코드 및 변수명을 수정했습니다.

---

* `MemberFee DTO` 변수명의 수정은 운영서버에 영향을 줄 수 있어, 프론트에 전달 후 머지하도록 하겠습니다.