### PR TITLE
Fix/게시물 내용 255자 제한 상향#335

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -34,6 +34,7 @@ dependencies {
     implementation 'org.springframework.boot:spring-boot-starter-oauth2-client'
     implementation 'org.springframework.boot:spring-boot-starter-web'
     implementation 'org.springframework.boot:spring-boot-starter-actuator'
+    implementation 'org.springframework.boot:spring-boot-starter-validation'
     implementation 'io.jsonwebtoken:jjwt:0.9.1'
     implementation 'com.sun.xml.bind:jaxb-impl:4.0.1'
     implementation 'com.sun.xml.bind:jaxb-core:4.0.1'

--- a/src/docs/asciidoc/api/challengePost.adoc
+++ b/src/docs/asciidoc/api/challengePost.adoc
@@ -55,6 +55,12 @@ operation::challengePost/create-challenge-post[snippets='http-request,http-respo
 
 ==== 에러 응답
 
+===== 게시물 본문 길이 제한 초과 (400 Bad Request)
+
+게시물 본문 길이 제한을 초과한 경우입니다.
+
+operation::challenge/challenge-post-creation-content-length-too-long-exception[snippets='http-request,http-response,response-fields']
+
 ===== 중도 포기한 경우 (403 Forbidden)
 
 챌린지를 중도 포기한 이후 게시물을 생성할 수 없습니다.
@@ -69,6 +75,12 @@ operation::challenge/challenge-post-creation-forbidden-exception[snippets='http-
 operation::challengePost/patch-challenge-post[snippets='http-request,http-response,request-fields,response-fields']
 
 ==== 에러 응답
+
+===== 게시물 본문 길이 제한 초과 (400 Bad Request)
+
+게시물 본문 길이 제한을 초과한 경우입니다.
+
+operation::challenge/challenge-post-patch-content-length-too-long-exception[snippets='http-request,http-response,response-fields']
 
 ===== 중도 포기한 경우 (403 Forbidden)
 

--- a/src/main/java/com/habitpay/habitpay/domain/challengepost/api/ChallengePostApi.java
+++ b/src/main/java/com/habitpay/habitpay/domain/challengepost/api/ChallengePostApi.java
@@ -10,6 +10,7 @@ import com.habitpay.habitpay.domain.challengepost.dto.PostViewResponse;
 import com.habitpay.habitpay.global.config.auth.CustomUserDetails;
 import com.habitpay.habitpay.global.response.SliceResponse;
 import com.habitpay.habitpay.global.response.SuccessResponse;
+import jakarta.validation.Valid;
 import java.util.List;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
@@ -90,7 +91,7 @@ public class ChallengePostApi {
 
     @PostMapping("/challenges/{id}/posts")
     public SuccessResponse<List<String>> createPost(
-        @RequestBody AddPostRequest request,
+        @Valid @RequestBody AddPostRequest request,
         @PathVariable("id") Long id,
         @AuthenticationPrincipal CustomUserDetails user) {
         return challengePostCreationService.createPost(request, id, user.getMember());
@@ -98,7 +99,8 @@ public class ChallengePostApi {
 
     @PatchMapping("/challenges/{challengeId}/posts/{postId}")
     public SuccessResponse<List<String>> patchPost(
-        @RequestBody ModifyPostRequest request, @PathVariable("challengeId") Long challengeId,
+        @Valid @RequestBody ModifyPostRequest request,
+        @PathVariable("challengeId") Long challengeId,
         @PathVariable("postId") Long postId,
         @AuthenticationPrincipal CustomUserDetails user) {
 

--- a/src/main/java/com/habitpay/habitpay/domain/challengepost/domain/ChallengePost.java
+++ b/src/main/java/com/habitpay/habitpay/domain/challengepost/domain/ChallengePost.java
@@ -4,7 +4,16 @@ import com.habitpay.habitpay.domain.challenge.domain.Challenge;
 import com.habitpay.habitpay.domain.challengeenrollment.domain.ChallengeEnrollment;
 import com.habitpay.habitpay.domain.member.domain.Member;
 import com.habitpay.habitpay.domain.model.BaseTime;
-import jakarta.persistence.*;
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.EntityListeners;
+import jakarta.persistence.FetchType;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.ManyToOne;
+import jakarta.persistence.Table;
 import lombok.AccessLevel;
 import lombok.Builder;
 import lombok.Getter;
@@ -17,6 +26,7 @@ import org.springframework.data.jpa.domain.support.AuditingEntityListener;
 @Getter
 @Table(name = "challenge_post")
 public class ChallengePost extends BaseTime {
+
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;
@@ -29,7 +39,7 @@ public class ChallengePost extends BaseTime {
     @JoinColumn(name = "challenge_enrollment_id")
     private ChallengeEnrollment challengeEnrollment;
 
-    @Column()
+    @Column(length = 1000)
     private String content;
 
     @Column(nullable = false)
@@ -37,10 +47,10 @@ public class ChallengePost extends BaseTime {
 
     @Builder
     public ChallengePost(
-            Challenge challenge,
-            ChallengeEnrollment enrollment,
-            String content,
-            boolean isAnnouncement) {
+        Challenge challenge,
+        ChallengeEnrollment enrollment,
+        String content,
+        boolean isAnnouncement) {
         this.challenge = challenge;
         this.challengeEnrollment = enrollment;
         this.content = content;

--- a/src/main/java/com/habitpay/habitpay/domain/challengepost/dto/AddPostRequest.java
+++ b/src/main/java/com/habitpay/habitpay/domain/challengepost/dto/AddPostRequest.java
@@ -4,28 +4,31 @@ import com.habitpay.habitpay.domain.challenge.domain.Challenge;
 import com.habitpay.habitpay.domain.challengeenrollment.domain.ChallengeEnrollment;
 import com.habitpay.habitpay.domain.challengepost.domain.ChallengePost;
 import com.habitpay.habitpay.domain.postphoto.dto.AddPostPhotoData;
+import jakarta.validation.constraints.Size;
+import java.util.List;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
-
-import java.util.List;
 
 @Getter
 @NoArgsConstructor
 @AllArgsConstructor
 @Builder
 public class AddPostRequest {
+
+    @Size(max = 1000, message = "본문 길이는 최대 {max}자 입니다.")
     private String content;
+
     private Boolean isAnnouncement;
     private List<AddPostPhotoData> photos;
 
     public ChallengePost toEntity(Challenge challenge, ChallengeEnrollment enrollment) {
         return ChallengePost.builder()
-                .content(content)
-                .isAnnouncement(isAnnouncement)
-                .challenge(challenge)
-                .enrollment(enrollment)
-                .build();
+            .content(content)
+            .isAnnouncement(isAnnouncement)
+            .challenge(challenge)
+            .enrollment(enrollment)
+            .build();
     }
 }

--- a/src/main/java/com/habitpay/habitpay/domain/challengepost/dto/ModifyPostRequest.java
+++ b/src/main/java/com/habitpay/habitpay/domain/challengepost/dto/ModifyPostRequest.java
@@ -2,19 +2,22 @@ package com.habitpay.habitpay.domain.challengepost.dto;
 
 import com.habitpay.habitpay.domain.postphoto.dto.AddPostPhotoData;
 import com.habitpay.habitpay.domain.postphoto.dto.ModifyPostPhotoData;
+import jakarta.validation.constraints.Size;
+import java.util.List;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
-
-import java.util.List;
 
 @AllArgsConstructor
 @NoArgsConstructor
 @Getter
 @Builder
 public class ModifyPostRequest {
+
+    @Size(max = 1000, message = "본문 길이는 최대 {max}자 입니다.")
     private String content;
+
     private Boolean isAnnouncement;
     private List<AddPostPhotoData> newPhotos;
     private List<ModifyPostPhotoData> modifiedPhotos;

--- a/src/main/java/com/habitpay/habitpay/global/error/ErrorResponse.java
+++ b/src/main/java/com/habitpay/habitpay/global/error/ErrorResponse.java
@@ -18,7 +18,16 @@ public class ErrorResponse {
         this.message = code.getMessage();
     }
 
+    private ErrorResponse(String code, String message) {
+        this.code = code;
+        this.message = message;
+    }
+
     public static ErrorResponse of(final ErrorCode code) {
         return new ErrorResponse(code);
+    }
+
+    public static ErrorResponse of(String code, String message) {
+        return new ErrorResponse(code, message);
     }
 }

--- a/src/main/java/com/habitpay/habitpay/global/error/exception/ErrorCode.java
+++ b/src/main/java/com/habitpay/habitpay/global/error/exception/ErrorCode.java
@@ -18,7 +18,8 @@ public enum ErrorCode {
 
     // JWT
     JWT_CLIENT_HAS_NO_IDEA_ABOUT_GRANT_TYPE(HttpStatus.BAD_REQUEST, "인증 방법을 알 수 없습니다."),
-    JWT_REQUEST_IP_AND_LOGIN_IP_NOT_SAME_FOR_REFRESH(HttpStatus.BAD_REQUEST, "로그인한 IP 주소와 요청 IP 주소가 일치하지 않습니다."),
+    JWT_REQUEST_IP_AND_LOGIN_IP_NOT_SAME_FOR_REFRESH(HttpStatus.BAD_REQUEST,
+        "로그인한 IP 주소와 요청 IP 주소가 일치하지 않습니다."),
     JWT_REFRESH_TOKEN_NOT_FOUND(HttpStatus.NOT_FOUND, "리프레시 토큰이 존재하지 않습니다."),
     JWT_FORBIDDEN_TO_MODIFY_OTHERS_POST(HttpStatus.FORBIDDEN, "본인의 포스트만 수정할 수 있습니다."),
 
@@ -26,15 +27,17 @@ public enum ErrorCode {
     USER_NOT_FOUND(HttpStatus.NOT_FOUND, "사용자를 찾을 수 없습니다."),
     INVALID_NICKNAME_RULE(HttpStatus.BAD_REQUEST, "닉네임 규칙에 맞지 않습니다. (규칙: 길이 2~15자, 특수문자 제외)"),
     DUPLICATED_NICKNAME(HttpStatus.BAD_REQUEST, "이전과 동일한 닉네임으로 변경할 수 없습니다."),
-    PROFILE_IMAGE_SIZE_TOO_LARGE(HttpStatus.BAD_REQUEST, "이미지 파일의 크기가 제한을 초과했습니다. (최대 1MB)"),
-    UNSUPPORTED_IMAGE_EXTENSION(HttpStatus.BAD_REQUEST, "지원하지 않는 이미지 확장자입니다. (png, jpg, jpeg 만 가능)"),
+    PROFILE_IMAGE_SIZE_TOO_LARGE(HttpStatus.BAD_REQUEST, "이미지 파일의 크기가 제한을 초과했습니다. (최대 10MB)"),
+    UNSUPPORTED_IMAGE_EXTENSION(HttpStatus.BAD_REQUEST,
+        "지원하지 않는 이미지 확장자입니다. (png, jpg, jpeg 만 가능)"),
 
     // Challenge
     CHALLENGE_NOT_FOUND(HttpStatus.NOT_FOUND, "챌린지가 존재하지 않습니다."),
     CHALLENGE_START_TIME_INVALID(HttpStatus.BAD_REQUEST, "챌린지 시작 시간은 현재 시간 이후만 가능합니다."),
     ONLY_HOST_CAN_MODIFY(HttpStatus.FORBIDDEN, "챌린지 주최자만 수정 가능합니다."),
     DUPLICATED_CHALLENGE_DESCRIPTION(HttpStatus.BAD_REQUEST, "변경 사항이 없습니다."),
-    INVALID_CHALLENGE_PARTICIPATING_DAYS(HttpStatus.BAD_REQUEST, "챌린지 진행 기간에 선택한 챌린지 참여 요일이 포함되지 않았습니다."),
+    INVALID_CHALLENGE_PARTICIPATING_DAYS(HttpStatus.BAD_REQUEST,
+        "챌린지 진행 기간에 선택한 챌린지 참여 요일이 포함되지 않았습니다."),
     INVALID_CHALLENGE_REGISTRATION_TIME(HttpStatus.BAD_REQUEST, "챌린지 등록 가능 시간이 아닙니다."),
     INVALID_CHALLENGE_CANCELLATION_TIME(HttpStatus.BAD_REQUEST, "챌린지 취소 가능한 시간이 지났습니다."),
     TOO_EARLY_GIVEN_UP_CHALLENGE(HttpStatus.BAD_REQUEST, "챌린지 중도 포기는 챌린지 시작 이후에만 가능합니다."),
@@ -49,19 +52,23 @@ public enum ErrorCode {
     MANDATORY_RECORD_NOT_FOUND(HttpStatus.NOT_FOUND, "챌린지 참여 기록 연결 중 문제가 발생했습니다. 관리자에게 문의하십시오."),
 
     // Challenge Absence Fee
-    TOTAL_PARTICIPATING_DAYS_COUNT_VALUE_IS_ILLEGAL(HttpStatus.BAD_REQUEST, "총 참여 일수 값이 유효하지 않습니다."),
+    TOTAL_PARTICIPATING_DAYS_COUNT_VALUE_IS_ILLEGAL(HttpStatus.BAD_REQUEST,
+        "총 참여 일수 값이 유효하지 않습니다."),
 
     // Challenge Post
     POST_NOT_FOUND(HttpStatus.NOT_FOUND, "포스트가 존재하지 않습니다."),
     ONLY_HOST_CAN_UPLOAD_ANNOUNCEMENT(HttpStatus.FORBIDDEN, "공지 포스트는 챌린지 주최자만 작성할 수 있습니다."),
     ONLY_HOST_CAN_DELETE_ANNOUNCEMENT(HttpStatus.FORBIDDEN, "공지 포스트는 챌린지 호스트만 삭제할 수 있습니다."),
     POST_CANNOT_BE_DELETED(HttpStatus.FORBIDDEN, "일반 포스트 삭제는 제공되지 않는 기능입니다."),
-    POST_PHOTO_IMAGE_SIZE_TOO_LARGE(HttpStatus.BAD_REQUEST, "이미지 파일의 크기가 제한을 초과했습니다. (최대 1MB)"),
+    POST_PHOTO_IMAGE_SIZE_TOO_LARGE(HttpStatus.BAD_REQUEST, "이미지 파일의 크기가 제한을 초과했습니다. (최대 10MB)"),
     PHOTO_NOT_FOUND(HttpStatus.NOT_FOUND, "포스트 포토가 존재하지 않습니다."),
-    NEED_TO_WAIT_FOR_CHALLENGE_SET(HttpStatus.BAD_REQUEST, "챌린지 시작을 위한 설정 진행 중입니다. 잠시 후 다시 시도해주세요."),
-    POST_EDITABLE_ONLY_WITHIN_CHALLENGE_PERIOD(HttpStatus.BAD_REQUEST, "챌린지 유효 기간에만 포스트를 작성 및 수정할 수 있습니다."),
+    NEED_TO_WAIT_FOR_CHALLENGE_SET(HttpStatus.BAD_REQUEST,
+        "챌린지 시작을 위한 설정 진행 중입니다. 잠시 후 다시 시도해주세요."),
+    POST_EDITABLE_ONLY_WITHIN_CHALLENGE_PERIOD(HttpStatus.BAD_REQUEST,
+        "챌린지 유효 기간에만 포스트를 작성 및 수정할 수 있습니다."),
     POST_CREATION_FORBIDDEN_DUE_TO_GIVE_UP(HttpStatus.FORBIDDEN, "챌린지 중도 포기 이후에는 게시물을 생성할 수 없습니다."),
-    POST_MODIFICATION_FORBIDDEN_DUE_TO_GIVE_UP(HttpStatus.FORBIDDEN, "챌린지 중도 포기 이후에는 게시물을 수정할 수 없습니다."),
+    POST_MODIFICATION_FORBIDDEN_DUE_TO_GIVE_UP(HttpStatus.FORBIDDEN,
+        "챌린지 중도 포기 이후에는 게시물을 수정할 수 없습니다."),
     POST_DELETION_FORBIDDEN_DUE_TO_GIVE_UP(HttpStatus.FORBIDDEN, "챌린지 중도 포기 이후에는 게시물을 삭제할 수 없습니다.");
 
     private HttpStatus status;

--- a/src/main/java/com/habitpay/habitpay/global/handler/GlobalExceptionHandler.java
+++ b/src/main/java/com/habitpay/habitpay/global/handler/GlobalExceptionHandler.java
@@ -7,6 +7,7 @@ import com.habitpay.habitpay.global.error.exception.ForbiddenException;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.MethodArgumentNotValidException;
 import org.springframework.web.bind.annotation.ExceptionHandler;
 import org.springframework.web.bind.annotation.RestControllerAdvice;
 
@@ -28,6 +29,14 @@ public class GlobalExceptionHandler {
         final ErrorCode errorCode = ex.getErrorCode();
         final ErrorResponse response = ErrorResponse.of(errorCode);
         return ResponseEntity.status(errorCode.getStatus()).body(response);
+    }
+
+    @ExceptionHandler(MethodArgumentNotValidException.class)
+    public ResponseEntity<ErrorResponse> handleMethodArgumentNotValidException(
+        MethodArgumentNotValidException ex) {
+        final ErrorResponse response = ErrorResponse.of("BAD_REQUEST",
+            ex.getBindingResult().getAllErrors().get(0).getDefaultMessage());
+        return ResponseEntity.status(HttpStatus.BAD_REQUEST).body(response);
     }
 
     @ExceptionHandler(Exception.class)

--- a/src/main/resources/db/migration/V202412281745__Change_challengepost_content_length.sql
+++ b/src/main/resources/db/migration/V202412281745__Change_challengepost_content_length.sql
@@ -1,0 +1,2 @@
+ALTER TABLE challenge_post
+    ALTER COLUMN content TYPE varchar(1000);


### PR DESCRIPTION
# 개요

게시물 내용이 255자 이상인 경우 백엔드에서 아래의 오류가 발생했습니다.

>could not execute statement[
    ERROR: value too long for type character varying(255)

길이 제한을 1,000자로 상향하고, DTO 길이를 검증하는 로직을 추가했습니다. 

# 작업 내용

## 1. 챌린지 게시물 도메인 길이 수정

`@Column` 어노테이션에 length 속성을 이용해서 길이 제한을 255자에서 1,000자로 수정했습니다.

```java
// challengepost/domain/ChallengePost.java

@Column(length = 1000)
private String content;
```

PostgreSQL에서는 기본적으로 String을 `varchar(255)`으로 저장합니다. 그래서 이를 `varchar(1000)`로 변경해주었습니다.
참고로 1GB 용량의 텍스트를 저장할 수 있는 `text` 데이터 타입도 존재하지만, 의도적으로 긴 문자열을 전송해서 서버의 용량을 소모하는 공격을 제한하기 위해 사용하지 않았습니다. 

## 2. flyway DDL SQL 추가

DB에서 챌린지 게시물 내용 컬럼의 길이를 `varchar(255)`에서 `varchar(1000)`으로 변경하기 위해 sql 파일을 추가했습니다.

```sql
ALTER TABLE challenge_post
    ALTER COLUMN content TYPE varchar(1000);
```

## 3. 게시물 생성 및 수정 DTO 길이 검증 추가

Bean Validation을 이용하면 어노테이션을 이용해서 제약 조건을 생성할 수 있습니다.

1. 컨트롤러의 매개변수에 `@Valid` 어노테이션을 추가합니다.

```java
// challengepost/api/ChallengePostApi.java

@PostMapping("/challenges/{id}/posts")
public SuccessResponse<List<String>> createPost(
    @Valid @RequestBody AddPostRequest request,
    @PathVariable("id") Long id,
    @AuthenticationPrincipal CustomUserDetails user) {
    return challengePostCreationService.createPost(request, id, user.getMember());
}
```

2. DTO 클래스에서 검증하고자 하는 필드에 어노테이션을 추가합니다.

```java
// challengepost/dto/AddPostRequest.java

@Getter
@NoArgsConstructor
@AllArgsConstructor
@Builder
public class AddPostRequest {

    @Size(max = 1000, message = "본문 길이는 최대 {max}자 입니다.")
    private String content;
}
```

`@Size` 어노테이션은 문자열의 길이를 검증할 때 사용합니다. 참고로 `@Min`과  `@Max`는 숫자형 데이터를 검증할 때 사용합니다. 

## 4. Bean Validation 예외처리 Exception Handler 추가

Bean Validation을 이용한 어노테이션에 설정한 `message` 속성에 작성한 내용만 응답으로 보낼 수 있도록 아래와 같은 Exception Handler를 추가했습니다.

```java
// global/handler/GlobalExceptionHandler.java

@ExceptionHandler(MethodArgumentNotValidException.class)
public ResponseEntity<ErrorResponse> handleMethodArgumentNotValidException(
    MethodArgumentNotValidException ex) {
    final ErrorResponse response = ErrorResponse.of("BAD_REQUEST",
        ex.getBindingResult().getAllErrors().get(0).getDefaultMessage());
    return ResponseEntity.status(HttpStatus.BAD_REQUEST).body(response);
}
```
