### PR TITLE
[Feat] 다른 멤버의 프로필 상세 정보를 얻는 api 추가#344

### DIFF
--- a/src/docs/asciidoc/api/member.adoc
+++ b/src/docs/asciidoc/api/member.adoc
@@ -15,6 +15,12 @@ Request Header 에는 ``Authorization: Bearer {access token}`` 와 같은 형식
 
 operation::member/get-member[snippets='http-request,http-response,response-fields']
 
+=== 타 사용자 포함 상세 조회
+
+사용자의 상세 정보를 조회합니다. 본인이 아닌 다른 멤버의 정보도 조회할 수 있습니다.
+
+operation::member/get-member-details[snippets='http-request,http-response,response-fields']
+
 === 사용자 닉네임 변경
 
 사용자의 닉네임을 변경합니다.

--- a/src/main/java/com/habitpay/habitpay/domain/member/api/MemberApi.java
+++ b/src/main/java/com/habitpay/habitpay/domain/member/api/MemberApi.java
@@ -18,10 +18,18 @@ public class MemberApi {
     private final MemberSearchService memberSearchService;
     private final MemberUpdateService memberUpdateService;
     private final MemberDeleteService memberDeleteService;
+    private final MemberDetailsService memberDetailsService;
 
     @GetMapping("/member")
     public SuccessResponse<MemberProfileResponse> getMember(@AuthenticationPrincipal CustomUserDetails user) {
         return memberSearchService.getMemberProfile(user.getMember());
+    }
+
+    @GetMapping("/members/{id}")
+    public SuccessResponse<MemberDetailsResponse> getMemberDetails(
+            @PathVariable("id") Long id,
+            @AuthenticationPrincipal CustomUserDetails user) {
+        return memberDetailsService.getMemberDetails(id, user.getMember());
     }
 
     @PatchMapping("/member/nickname")

--- a/src/main/java/com/habitpay/habitpay/domain/member/application/MemberDetailsService.java
+++ b/src/main/java/com/habitpay/habitpay/domain/member/application/MemberDetailsService.java
@@ -1,0 +1,29 @@
+package com.habitpay.habitpay.domain.member.application;
+
+import com.habitpay.habitpay.domain.member.domain.Member;
+import com.habitpay.habitpay.domain.member.dto.MemberDetailsResponse;
+import com.habitpay.habitpay.domain.member.dto.MemberProfileResponse;
+import com.habitpay.habitpay.global.config.aws.S3FileService;
+import com.habitpay.habitpay.global.response.SuccessCode;
+import com.habitpay.habitpay.global.response.SuccessResponse;
+import lombok.AllArgsConstructor;
+import org.springframework.stereotype.Service;
+
+import java.util.Optional;
+
+@Service
+@AllArgsConstructor
+public class MemberDetailsService {
+    private final MemberSearchService memberSearchService;
+    private final S3FileService s3FileService;
+
+    public SuccessResponse<MemberDetailsResponse> getMemberDetails(Long memberId, Member currentUser) {
+        Member member = memberSearchService.getMemberById(memberId);
+        Boolean isCurrentUser = currentUser.equals(member);
+
+        String imageFileName = Optional.ofNullable(member.getImageFileName()).orElse("");
+        String imageUrl = imageFileName.isEmpty() ? "" : s3FileService.getGetPreSignedUrl("profiles", imageFileName);
+
+        return SuccessResponse.of(SuccessCode.NO_MESSAGE, MemberDetailsResponse.of(member, imageUrl, isCurrentUser));
+    }
+}

--- a/src/main/java/com/habitpay/habitpay/domain/member/dto/MemberDetailsResponse.java
+++ b/src/main/java/com/habitpay/habitpay/domain/member/dto/MemberDetailsResponse.java
@@ -1,0 +1,23 @@
+package com.habitpay.habitpay.domain.member.dto;
+
+import com.habitpay.habitpay.domain.member.domain.Member;
+import lombok.Builder;
+import lombok.Getter;
+
+@Getter
+@Builder
+public class MemberDetailsResponse {
+    private Long memberId;
+    private String nickname;
+    private String imageUrl;
+    private Boolean isCurrentUser;
+
+    public static MemberDetailsResponse of(Member member, String imageUrl, Boolean isCurrentUser) {
+        return MemberDetailsResponse.builder()
+                .memberId(member.getId())
+                .nickname(member.getNickname())
+                .imageUrl(imageUrl)
+                .isCurrentUser(isCurrentUser)
+                .build();
+    }
+}


### PR DESCRIPTION
## 개요

* 현재 요청한 `사용자 본인`의 프로필 데이터를 불러오는 `GET /api/member` 컨트롤러가 존재합니다.
* 그러나 `다른 멤버의 챌린지 목록`을 불러올 수 있게 되면서, 동시에 `다른 멤버의 프로필 데이터`가 필요해졌습니다.
* 이에 `다른 멤버`의 `프로필 상세 정보`를 얻는 api를 추가했습니다.

---

## 코드 내용

### 1. 다른 멤버의 상세 정보를 불러오는 api 컨트롤러 메서드 추가

```java
// MemberApi.java

@GetMapping("/members/{id}")
public SuccessResponse<MemberDetailsResponse> getMemberDetails(
        @PathVariable("id") Long id,
        @AuthenticationPrincipal CustomUserDetails user) {
    return memberDetailsService.getMemberDetails(id, user.getMember());
}
```

* 상세 정보를 얻고 싶은 `멤버의 id`를 경로 변수로 받습니다.

---

### 2. 다른 멤버의 상세 정보를 위한 `MemberDetailsResponse DTO` 생성

```java
// member/dto/MemberDetailsResponse.java

public class MemberDetailsResponse {
    private Long memberId;
    private String nickname;
    private String imageUrl;
    private Boolean isCurrentUser;

    ...
}
```

* 기존에 본인의 프로필 데이터를 제공하는 DTO인 `MemberProfileResponse`과의 차이는 `Long memberId`, `Boolean isCurrentUser` 요소의 추가입니다.

---

### 3. `MemberDetailsService` 클래스 및 메서드 생성

```java
// MemberDetailsService.java

public class MemberDetailsService {
    ...

    public SuccessResponse<MemberDetailsResponse> getMemberDetails(Long memberId, Member currentUser) {
        Member member = memberSearchService.getMemberById(memberId);
        Boolean isCurrentUser = currentUser.equals(member);

        String imageFileName = Optional.ofNullable(member.getImageFileName()).orElse("");
        String imageUrl = imageFileName.isEmpty() ? "" : s3FileService.getGetPreSignedUrl("profiles", imageFileName);

        return SuccessResponse.of(SuccessCode.NO_MESSAGE, MemberDetailsResponse.of(member, imageUrl, isCurrentUser));
    }
}
```

* `getMemberDetails` api 컨트롤러 메서드가 사용하는 `getMemberDetails` 서비스 메서드가 구현되어 있습니다.

---

* 특이사항은 기존의 `MemberSearchService` 내부에 만들지 않고, `MemberDetailsService` 서비스 클래스를 따로 생성한 점입니다.
* 처음에는 의미 상 `MemberSearchService` 클래스 내부에 있어도 적합하다고 생각했는데요.
* `memberSearchService.getMemberById()` 메서드가 `@Transactional(readOnly = true)` 어노테이션을 포함하고 있습니다.
* 이때, 동일한 클래스 내에 있는 다른 `Transactional` 메서드를 이용하면, 해당 어노테이션 기능이 적용되지 않는다고 합니다.

```java
// intelliJ의 알림 내용입니다.

@Transactional 자동 호출(실질적으로 타깃 객체 내의 메서드가 타깃 객체 내의 다른 메서드를 호출)은 런타임 시 실제 트랜잭션을 발생시키지 않습니다.
```

* 그래서 `@Transactional`이 안정적으로 작동하도록, 다른 서비스 클래스를 만들어 분리했습니다.

---

### 4. 테스트 코드 및 문서 작성

* 관련된 테스트 코드 및 api 문서를 추가했습니다.

---

## 기타

*  `GET /api/member`와 `GET /api/members/{id}`의 기능이 사실상 비슷하고, 반환하는 데이터 타입의 내용도 비슷합니다.
* 그래서 반환하는 데이터 타입을 통일할 수 있지 않을까 생각했습니다(`Long memberId`, `Boolean isCurrentUser` 요소 추가 버전).
* 그러고 나면 두 api 컨트롤러 메서드가, 동일한 서비스 메서드를 사용할 수 있습니다.
* 그런데 그 경우 `GET /api/member` 내에서 Member를 한 번 더 조회하는 중복이 발생,,,!하는 문제가 있습니다.
* 이전의 `다른 멤버 챌린지 목록 조회` 건과 비슷한 상황인 듯 합니다.

---

* `멤버`와 `챌린지 목록 조회` 건을 합친다면?
* `GET /api/member` 대신 `GET /api/members/{id}`만 남겨서 본인 자신도 `id`로 조회한다면?
   (이 경우 프론트엔드에서 요청자 본인의 `id`를 파악하고 있어야 함)
* 그러면 `GET /api/challenges/me` 대신 `GET /api/challenges/memebers/{id}`를 이용해 본인 자신의 챌린지 목록도 `id`로 조회하는 메서드를 이용해 코드 중복을 줄일 수 있음

---

* 위의 다른 가능성도 생각해봤지만,
* `@AuthenticationPrincipal CustomUserDetails user`를 이용하는 기존의 안정적인 방식 유지도 괜찮은 것 같긴 합니다.
  (본인의 데이터와 다른 사용자의 데이터를 얻는 api 및 메서드 분리하는 현재 방식 유지)