### PR TITLE
[fix] GET /challenges 챌린지 총 참여 일수 dto 변수 추가#347

### DIFF
--- a/src/main/java/com/habitpay/habitpay/domain/challenge/dto/ChallengePageResponse.java
+++ b/src/main/java/com/habitpay/habitpay/domain/challenge/dto/ChallengePageResponse.java
@@ -1,38 +1,39 @@
 package com.habitpay.habitpay.domain.challenge.dto;
 
 import com.habitpay.habitpay.domain.challenge.domain.Challenge;
-import lombok.Builder;
-
 import java.time.ZonedDateTime;
+import lombok.Builder;
 
 @Builder
 public record ChallengePageResponse(
-        Long id,
-        String title,
-        ZonedDateTime startDate,
-        ZonedDateTime endDate,
-        ZonedDateTime stopDate,
-        int numberOfParticipants,
-        int participatingDays,
-        Boolean isStarted,
-        Boolean isEnded,
-        String hostNickname,
-        String hostProfileImage
+    Long id,
+    String title,
+    ZonedDateTime startDate,
+    ZonedDateTime endDate,
+    ZonedDateTime stopDate,
+    int numberOfParticipants,
+    int participatingDays,
+    int totalParticipatingDaysCount,
+    Boolean isStarted,
+    Boolean isEnded,
+    String hostNickname,
+    String hostProfileImage
 ) {
 
     public static ChallengePageResponse of(Challenge challenge, String hostProfileImage) {
         return ChallengePageResponse.builder()
-                .id(challenge.getId())
-                .title(challenge.getTitle())
-                .startDate(challenge.getStartDate())
-                .endDate(challenge.getEndDate())
-                .stopDate(challenge.getStopDate())
-                .numberOfParticipants(challenge.getNumberOfParticipants())
-                .participatingDays(challenge.getParticipatingDays())
-                .isStarted(ZonedDateTime.now().isAfter(challenge.getStartDate()))
-                .isEnded(ZonedDateTime.now().isAfter(challenge.getEndDate()))
-                .hostNickname(challenge.getHost().getNickname())
-                .hostProfileImage(hostProfileImage)
-                .build();
+            .id(challenge.getId())
+            .title(challenge.getTitle())
+            .startDate(challenge.getStartDate())
+            .endDate(challenge.getEndDate())
+            .stopDate(challenge.getStopDate())
+            .numberOfParticipants(challenge.getNumberOfParticipants())
+            .participatingDays(challenge.getParticipatingDays())
+            .totalParticipatingDaysCount(challenge.getTotalParticipatingDaysCount())
+            .isStarted(ZonedDateTime.now().isAfter(challenge.getStartDate()))
+            .isEnded(ZonedDateTime.now().isAfter(challenge.getEndDate()))
+            .hostNickname(challenge.getHost().getNickname())
+            .hostProfileImage(hostProfileImage)
+            .build();
     }
 }


### PR DESCRIPTION
# 개요

챌린지 목록을 불러오는 `GET /challenges` API의 DTO에 챌린지 기간 동안 참여해야 하는 요일 수를 보여주는 `totalParticipatingDaysCount` 변수를 추가합니다.