### PR TITLE
[fix] 벌금 현황 페이지에서 달성율이 올바르게 표시되지 않는 문제 해결 #352

### DIFF
--- a/src/main/java/com/habitpay/habitpay/domain/challengeabsencefee/dto/MemberFeeView.java
+++ b/src/main/java/com/habitpay/habitpay/domain/challengeabsencefee/dto/MemberFeeView.java
@@ -11,10 +11,10 @@ public class MemberFeeView {
     private int totalFee;
     private int completionRate;
 
-    public MemberFeeView(Long memberId, String nickname, int totalFee, int completionRate) {
+    public MemberFeeView(Long memberId, String nickname, int totalFee, double completionRate) {
         this.memberId = memberId;
         this.nickname = nickname;
         this.totalFee = totalFee;
-        this.completionRate = completionRate;
+        this.completionRate = (int) Math.round(completionRate);
     }
 }

--- a/src/main/java/com/habitpay/habitpay/domain/challengeenrollment/dao/ChallengeEnrollmentRepository.java
+++ b/src/main/java/com/habitpay/habitpay/domain/challengeenrollment/dao/ChallengeEnrollmentRepository.java
@@ -24,7 +24,7 @@ public interface ChallengeEnrollmentRepository extends JpaRepository<ChallengeEn
     "WHERE e.challenge = :challenge")
     List<Member> findAllMemberByChallenge(Challenge challenge);
 
-    @Query("SELECT new com.habitpay.habitpay.domain.challengeabsencefee.dto.MemberFeeView(m.id, m.nickname, s.totalFee, (s.successCount / :totalCount) * 100) " +
+    @Query("SELECT new com.habitpay.habitpay.domain.challengeabsencefee.dto.MemberFeeView(m.id, m.nickname, s.totalFee, (s.successCount * 1.0 / :totalCount) * 100) " +
     "FROM ChallengeEnrollment e " +
     "JOIN e.member m " +
     "JOIN e.participationStat s " +


### PR DESCRIPTION
## 개요

* `챌린지 상세 화면`의 `벌금 현황` 페이지에서 `달성율`이 올바르게 표시되지 않는 문제가 있었습니다.
* 소름 돋는 이야기인데요,
* 나눗셈 계산에서 식을 가당치 않게 썼기 때문입니다.
* 이를 고쳤습니다.

---

## 코드 내용

### 1. 달성율 구하는 식의 데이터 타입을 `부동소수점`으로 변경하기

```java
// ChallengeEnrollmentRepository.java

@Query("SELECT new com...MemberFeeView(..., (s.successCount * 1.0 / :totalCount) * 100) " +
...)
List<MemberFeeView> findMemberFeeViewByChallenge(...);
```

* 기존 달성율을 구하는 식은 `(s.successCount / :totalCount) * 100)`였습니다.
* `전체 참여해야 하는 횟수` 중 `성공 횟수`의 비율을 구하는 식입니다.
* 그러나 `/` 연산은 `몫`만 취하기에, 100% 성공을 의미하는 `1`이 나오지 않는다면 (`나머지`를 무시하므로) 모두 `0%`로 계산됩니다.
* 어쩐지 `100%` 아니면 `0%`만 있더라니..
* 소름 돋을 정도로 가당치 않은 식이었습니다..

---

* `나머지`를 유의미하게 계산하기 위해, 데이터 타입을 `부동소수점`으로 바꿀 필요가 있습니다.
* `Cast`를 이용한 명시적 타입 변환 방법도 있고 이는 `PostgresQL`에서 지원하는 문법이기도 했으나,
* 좀 더 DB 독립적인 방법이라는 `* 1.0`식을 이용해 데이터 타입을 변환했습니다.
* 최종 식은 `(s.successCount * 1.0 / :totalCount) * 100)`입니다.

---

### 2. 부동소수점을 반올림하여 `int 달성율` 값 계산하기

```java
// MemberFeeView.java

public class MemberFeeView {
    ...

    public MemberFeeView(..., double completionRate) {
        ...
        this.completionRate = (int) Math.round(completionRate);
    }
}
```

* 위의 `repository 메서드`에서 부동소수점 값을 받으면, 반올림하여 다시 `int`로 형변환을 해 DTO에 적용하는 식을 추가했습니다.
* 반올림한 기준은, 프론트엔드에서 달성율을 구할 때 반올림하여 계산하고 있기 때문입니다.

---

### 사족

* `챌린지 목록`에 나오는 `달성율`은 프론트엔드에서 안정적으로 계산하기 때문에 문제가 없었습니다.
* 서버에서 `전체 참여 횟수`와 `성공 횟수` 데이터를 보내주고, 그 데이터를 기반으로 프론트엔드에서 계산했기 때문입니다.
* `챌린지 목록의 달성율`과 `벌금 현황의 달성율`을 구하는 위치가 각기 프론트와 백으로 다른데, 추가 기능으로 개발하다보니 이러한 일관성을 미처 고려하지 못했었네요.
* 이젠 잘 되어라!
