### PR TITLE
[fix] nginx 변경 시 컨테이너 실행 시간 기준으로 비교 #355

### DIFF
--- a/scripts/switch.sh
+++ b/scripts/switch.sh
@@ -50,15 +50,15 @@ switch() {
 }
 
 main() {
-    local is_blue_running=$(grep -q "http://blue" $NGINX_CONFIGURATION_FILE && echo "running")
-    local is_green_running=$(grep -q "http://green" $NGINX_CONFIGURATION_FILE && echo "running")
+    local blue_start_time=$(sudo docker container inspect blue --format='{{.State.StartedAt}}')
+    local green_start_time=$(sudo docker container inspect green --format='{{.State.StartedAt}}')
 
-    if [ "$is_blue_running" = "running" ]; then
-        log "Blue container is running."
+    if [ "$blue_start_time" "<" "$green_start_time" ]; then
+        log "Previous running container is Blue."
         healthcheck "$GREEN_CONTAINER:$PORT_NUMBER/$HEALTHCHECK_API"
         switch blue green
     elif [ "$is_green_running" = "running" ]; then
-        log "Green container is running."
+        log "Previous running container is Green."
         healthcheck "$BLUE_CONTAINER:$PORT_NUMBER/$HEALTHCHECK_API"
         switch green blue
     else


### PR DESCRIPTION
기존 스크립트에서 nginx 파일을 원본으로 돌리면 green으로 리버스 프록싱 하도록 되어있었습니다. 그러다보니 nginx에서 스위칭을 수행할 때 실제로는 blue 컨테이너가 켜져있는 상황인데, 설정 파일에는 green 컨테이너가 실행되고 있는 것으로 판단해서 정상적인 스위칭이 일어나지 않았습니다. 이를 수정하기 위해 컨테이너 실행 시간을 비교하여 스위칭 하도록 했습니다.