### PR TITLE
[fix] 배포 shell script 수정 #355

### DIFF
--- a/scripts/down-running-container.sh
+++ b/scripts/down-running-container.sh
@@ -61,6 +61,8 @@ get_previous_running_image() {
 }
 
 main() {
+    sleep 30
+
     local is_blue_running=$(sudo docker container inspect blue --format='{{json .State.Status}}' | sed 's/"//g')
     local is_green_running=$(sudo docker container inspect green --format='{{json .State.Status}}' | sed 's/"//g')
     local blue_start_time=$(sudo docker container inspect blue --format='{{.State.StartedAt}}')


### PR DESCRIPTION
찐찐찐찐찐막...
기존에 실행 중인 컨테이너 종료하기 전에 30초 딜레이를 추가했습니다. nginx 스위칭이 이루어지지 않은 상황에서 기존 실행 컨테이너를 종료하면 nginx가 upstream을 찾지 못하는 오류를 방지하기 위해서입니다.