### PR TITLE
[feat] 챌린지 종료 이후 정산하는 API 생성 #362

### DIFF
--- a/src/docs/asciidoc/api/challenge.adoc
+++ b/src/docs/asciidoc/api/challenge.adoc
@@ -96,6 +96,12 @@ operation::challenge/create-challenge-invalid-start-time[snippets='http-request,
 
 operation::challenge/create-challenge-invalid-participating-days[snippets='http-request,http-response,response-fields']
 
+=== 챌린지 정산
+
+종료된 챌린지의 상태를 정산 완료로 변경합니다.
+
+operation::challenge/settlement[snippets='http-request,http-response,response-fields']
+
 === 챌린지 정보 수정
 
 챌린지 정보를 수정합니다.

--- a/src/main/java/com/habitpay/habitpay/domain/challenge/api/ChallengeApi.java
+++ b/src/main/java/com/habitpay/habitpay/domain/challenge/api/ChallengeApi.java
@@ -72,16 +72,16 @@ public class ChallengeApi {
         return challengeCreationService.createChallenge(challengeCreationRequest, user.getMember());
     }
 
+    @PostMapping("/challenges/{id}/settlement")
+    public SuccessResponse<Void> setChallengeSettled(@PathVariable("id") Long id,
+                                                     @AuthenticationPrincipal CustomUserDetails user) {
+        return challengeSettlementService.settleChallenge(id, user.getMember());
+    }
+
     @PatchMapping("/challenges/{id}")
     public SuccessResponse<ChallengePatchResponse> patchChallengeDetails(@PathVariable("id") Long id, @RequestBody ChallengePatchRequest challengePatchRequest,
                                                                          @AuthenticationPrincipal CustomUserDetails user) {
         return challengePatchService.patch(id, challengePatchRequest, user.getMember());
-    }
-
-    @PatchMapping("/challenges/{id}/settlement")
-    public SuccessResponse<Void> setChallengeSettled(@PathVariable("id") Long id,
-                                                                         @AuthenticationPrincipal CustomUserDetails user) {
-        return challengeSettlementService.settleChallenge(id, user.getMember());
     }
 
     @DeleteMapping("/challenges/{id}")

--- a/src/main/java/com/habitpay/habitpay/domain/challenge/api/ChallengeApi.java
+++ b/src/main/java/com/habitpay/habitpay/domain/challenge/api/ChallengeApi.java
@@ -28,6 +28,7 @@ public class ChallengeApi {
     private final ChallengeDeleteService challengeDeleteService;
     private final ChallengeRecordsService challengeRecordsService;
     private final ChallengeMemberSearchService challengeMemberSearchService;
+    private final ChallengeSettlementService challengeSettlementService;
 
     @GetMapping("/challenges")
     public SuccessResponse<PageResponse<ChallengePageResponse>> getChallengePage(
@@ -75,6 +76,12 @@ public class ChallengeApi {
     public SuccessResponse<ChallengePatchResponse> patchChallengeDetails(@PathVariable("id") Long id, @RequestBody ChallengePatchRequest challengePatchRequest,
                                                                          @AuthenticationPrincipal CustomUserDetails user) {
         return challengePatchService.patch(id, challengePatchRequest, user.getMember());
+    }
+
+    @PatchMapping("/challenges/{id}/settlement")
+    public SuccessResponse<Void> setChallengeSettled(@PathVariable("id") Long id,
+                                                                         @AuthenticationPrincipal CustomUserDetails user) {
+        return challengeSettlementService.settleChallenge(id, user.getMember());
     }
 
     @DeleteMapping("/challenges/{id}")

--- a/src/main/java/com/habitpay/habitpay/domain/challenge/application/ChallengeSettlementService.java
+++ b/src/main/java/com/habitpay/habitpay/domain/challenge/application/ChallengeSettlementService.java
@@ -1,0 +1,16 @@
+package com.habitpay.habitpay.domain.challenge.application;
+
+import com.habitpay.habitpay.domain.member.domain.Member;
+import com.habitpay.habitpay.global.response.SuccessCode;
+import com.habitpay.habitpay.global.response.SuccessResponse;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+@Service
+@RequiredArgsConstructor
+public class ChallengeSettlementService {
+
+    public SuccessResponse<Void> settleChallenge(Long challengeId, Member member) {
+        return SuccessResponse.of(SuccessCode.CHALLENGE_SETTLEMENT_SUCCESS);
+    }
+}

--- a/src/main/java/com/habitpay/habitpay/domain/challenge/application/ChallengeSettlementService.java
+++ b/src/main/java/com/habitpay/habitpay/domain/challenge/application/ChallengeSettlementService.java
@@ -1,16 +1,45 @@
 package com.habitpay.habitpay.domain.challenge.application;
 
+import com.habitpay.habitpay.domain.challenge.dao.ChallengeRepository;
+import com.habitpay.habitpay.domain.challenge.domain.Challenge;
+import com.habitpay.habitpay.domain.challenge.domain.ChallengeState;
+import com.habitpay.habitpay.domain.member.application.MemberUtilsService;
 import com.habitpay.habitpay.domain.member.domain.Member;
+import com.habitpay.habitpay.global.config.timezone.TimeZoneConverter;
+import com.habitpay.habitpay.global.error.exception.BadRequestException;
+import com.habitpay.habitpay.global.error.exception.ErrorCode;
 import com.habitpay.habitpay.global.response.SuccessCode;
 import com.habitpay.habitpay.global.response.SuccessResponse;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 
+import java.time.ZonedDateTime;
+
 @Service
 @RequiredArgsConstructor
 public class ChallengeSettlementService {
 
+    private final ChallengeSearchService challengeSearchService;
+    private final MemberUtilsService memberUtilsService;
+    private final ChallengeRepository challengeRepository;
+
     public SuccessResponse<Void> settleChallenge(Long challengeId, Member member) {
+        Challenge challenge = challengeSearchService.getChallengeById(challengeId);
+
+        memberUtilsService.isChallengeHost(challenge, member);
+
+        ZonedDateTime now = TimeZoneConverter.convertEtcToLocalTimeZone(ZonedDateTime.now());
+        if (!now.isAfter(challenge.getEndDate())) {
+            throw new BadRequestException(ErrorCode.INVALID_CHALLENGE_SETTLEMENT_TIME);
+        }
+
+        if (!(challenge.getState() == ChallengeState.COMPLETED_PENDING_SETTLEMENT)) {
+            throw new BadRequestException(ErrorCode.INVALID_CHALLENGE_STATE_FOR_SETTLEMENT);
+        }
+
+        challenge.setStateCompletedSettled();
+        challengeRepository.save(challenge);
+
         return SuccessResponse.of(SuccessCode.CHALLENGE_SETTLEMENT_SUCCESS);
     }
 }

--- a/src/main/java/com/habitpay/habitpay/domain/challenge/domain/Challenge.java
+++ b/src/main/java/com/habitpay/habitpay/domain/challenge/domain/Challenge.java
@@ -160,7 +160,10 @@ public class Challenge extends BaseTime {
         this.state = ChallengeState.COMPLETED_PENDING_SETTLEMENT;
     }
 
-    public void setStateCompletedSettled() { this.state = ChallengeState.COMPLETED_SETTLED; }
+    public void setStateCompletedSettled() {
+        this.isPaidAll = true;
+        this.state = ChallengeState.COMPLETED_SETTLED;
+    }
 
     public boolean isTodayParticipatingDay() {
         ZonedDateTime nowInLocal = TimeZoneConverter.convertEtcToLocalTimeZone(ZonedDateTime.now());

--- a/src/main/java/com/habitpay/habitpay/domain/challenge/domain/Challenge.java
+++ b/src/main/java/com/habitpay/habitpay/domain/challenge/domain/Challenge.java
@@ -160,6 +160,8 @@ public class Challenge extends BaseTime {
         this.state = ChallengeState.COMPLETED_PENDING_SETTLEMENT;
     }
 
+    public void setStateCompletedSettled() { this.state = ChallengeState.COMPLETED_SETTLED; }
+
     public boolean isTodayParticipatingDay() {
         ZonedDateTime nowInLocal = TimeZoneConverter.convertEtcToLocalTimeZone(ZonedDateTime.now());
         DayOfWeek today = nowInLocal.getDayOfWeek();

--- a/src/main/java/com/habitpay/habitpay/domain/challengescheduler/application/SchedulerTaskHelperService.java
+++ b/src/main/java/com/habitpay/habitpay/domain/challengescheduler/application/SchedulerTaskHelperService.java
@@ -37,7 +37,6 @@ public class SchedulerTaskHelperService {
         ZonedDateTime now = TimeZoneConverter.convertEtcToLocalTimeZone(ZonedDateTime.now());
         ZonedDateTime startOfMinute = now.withSecond(0).withNano(0);
         ZonedDateTime endOfMinute = now.plusMinutes(1).withSecond(0).withNano(0);
-        log.info("Fetching challenges starting at {}", startOfMinute);
 
         return challengeRepository.findAllByStartDateBetweenAndState(startOfMinute, endOfMinute, ChallengeState.SCHEDULED);
     }
@@ -118,7 +117,6 @@ public class SchedulerTaskHelperService {
         ZonedDateTime now = TimeZoneConverter.convertEtcToLocalTimeZone(ZonedDateTime.now());
         ZonedDateTime startOfMinute = now.withSecond(0).withNano(0);
         ZonedDateTime endOfMinute = now.plusMinutes(1).withSecond(0).withNano(0);
-        log.info("Fetching challenges ending at {}", startOfMinute);
 
         return challengeRepository.findAllByEndDateBetweenAndState(startOfMinute, endOfMinute, ChallengeState.IN_PROGRESS);
     }

--- a/src/main/java/com/habitpay/habitpay/global/error/exception/ErrorCode.java
+++ b/src/main/java/com/habitpay/habitpay/global/error/exception/ErrorCode.java
@@ -46,6 +46,8 @@ public enum ErrorCode {
     NOT_ENROLLED_IN_CHALLENGE(HttpStatus.BAD_REQUEST, "참여하지 않은 챌린지 입니다."),
     NOT_ALLOWED_TO_CANCEL_ENROLLMENT_OF_HOST(HttpStatus.BAD_REQUEST, "챌린지 주최자는 참여 취소가 불가능 합니다."),
     NOT_ALLOWED_TO_DELETE_CHALLENGE(HttpStatus.FORBIDDEN, "챌린지 삭제는 챌린지 주최자만 가능합니다."),
+    INVALID_CHALLENGE_SETTLEMENT_TIME(HttpStatus.BAD_REQUEST, "정산은 챌린지 종료 이후에 가능합니다."),
+    INVALID_CHALLENGE_STATE_FOR_SETTLEMENT(HttpStatus.BAD_REQUEST, "정산은 챌린지가 종료 이후 정산 대기 상태일 때만 가능합니다."),
 
     // Challenge Participation Record
     RECORD_NOT_FOUND(HttpStatus.NOT_FOUND, "챌린지 참여 기록이 존재하지 않습니다."),

--- a/src/main/java/com/habitpay/habitpay/global/response/SuccessCode.java
+++ b/src/main/java/com/habitpay/habitpay/global/response/SuccessCode.java
@@ -22,6 +22,7 @@ public enum SuccessCode {
     CANCEL_CHALLENGE_ENROLLMENT_SUCCESS("정상적으로 챌린지 등록을 취소했습니다."),
     GIVING_UP_CHALLENGE("정상적으로 챌린지 중도 포기 처리가 되었습니다."),
     DELETE_CHALLENGE_SUCCESS("정상적으로 챌린지를 삭제했습니다."),
+    CHALLENGE_SETTLEMENT_SUCCESS("정상적으로 챌린지 정산이 완료되었습니다."),
 
     // Post
     CREATE_POST_SUCCESS("정상적으로 포스트를 생성했습니다."),

--- a/src/test/java/com/habitpay/habitpay/domain/challenge/api/ChallengeApiTest.java
+++ b/src/test/java/com/habitpay/habitpay/domain/challenge/api/ChallengeApiTest.java
@@ -17,13 +17,7 @@ import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.
 
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.habitpay.habitpay.docs.springrestdocs.AbstractRestDocsTests;
-import com.habitpay.habitpay.domain.challenge.application.ChallengeCreationService;
-import com.habitpay.habitpay.domain.challenge.application.ChallengeDeleteService;
-import com.habitpay.habitpay.domain.challenge.application.ChallengeDetailsService;
-import com.habitpay.habitpay.domain.challenge.application.ChallengeMemberSearchService;
-import com.habitpay.habitpay.domain.challenge.application.ChallengePatchService;
-import com.habitpay.habitpay.domain.challenge.application.ChallengeRecordsService;
-import com.habitpay.habitpay.domain.challenge.application.ChallengeSearchService;
+import com.habitpay.habitpay.domain.challenge.application.*;
 import com.habitpay.habitpay.domain.challenge.dto.ChallengeCreationRequest;
 import com.habitpay.habitpay.domain.challenge.dto.ChallengeCreationResponse;
 import com.habitpay.habitpay.domain.challenge.dto.ChallengeDetailsResponse;
@@ -93,6 +87,9 @@ public class ChallengeApiTest extends AbstractRestDocsTests {
 
     @MockBean
     ChallengeMemberSearchService challengeMemberSearchService;
+
+    @MockBean
+    ChallengeSettlementService challengeSettlementService;
 
     @MockBean
     TimeZoneProperties timeZoneProperties;
@@ -592,6 +589,31 @@ public class ChallengeApiTest extends AbstractRestDocsTests {
             ));
     }
 
+    @Test
+    @WithMockOAuth2User
+    @DisplayName("챌린지 정산")
+    void settleChallenge() throws Exception {
+
+        // given
+        given(challengeSettlementService.settleChallenge(anyLong(), any(Member.class)))
+                .willReturn(SuccessResponse.of(SuccessCode.CHALLENGE_SETTLEMENT_SUCCESS));
+
+        // when
+        ResultActions result = mockMvc.perform(post("/api/challenges/{id}/settlement", 1L)
+                .header(HttpHeaders.AUTHORIZATION, AUTHORIZATION_HEADER_PREFIX + "ACCESS_TOKEN"));
+
+        // then
+        result.andExpect(status().isOk())
+                .andDo(document("challenge/settlement",
+                        requestHeaders(
+                                headerWithName(HttpHeaders.AUTHORIZATION).description("액세스 토큰")
+                        ),
+                        responseFields(
+                                fieldWithPath("message").description("메세지"),
+                                fieldWithPath("data").description("null")
+                        )
+                ));
+    }
 
     @Test
     @WithMockOAuth2User


### PR DESCRIPTION
## 개요

* `챌린지`가 (중간 취소 등 없이) 정상적으로 `종료`되면 `COMPLETED_PENDING_SETTLEMENT`의 상태가 됩니다.
    * 이 상태는 챌린지가 종료되었으나 아직 `정산되지 않았음`을 의미합니다.
* 이때 `정산` API를 추가하여 벌금 처리 등 챌린지를 완료할 수 있도록 합니다.
    * 이때 챌린지의 상태가 `COMPLETED_SETTLED`로 변경됩니다.
    * 또한 챌린지 내 `isPaidAll` 변수값이 `true`로 변경됩니다.
    * 현재는 앱 내 벌금 결제나 분배 등 다른 기능이 없으므로, 호스트가 자율적으로 정산하게 됩니다.

---

## 코드 내용

### 1. 정산 api를 위한 컨트롤러 메서드 생성

```java
// ChallengeApi.java

@PostMapping("/challenges/{id}/settlement")
public SuccessResponse<Void> setChallengeSettled(@PathVariable("id") Long id,
                                                 @AuthenticationPrincipal CustomUserDetails user) {
    return challengeSettlementService.settleChallenge(id, user.getMember());
}
```

---


### 2. 정산 api를 위한 서비스 클래스 및 메서드 생성

```java
// challenge/application/ChallengeSettlementService.java

public class ChallengeSettlementService {
    ...

    public SuccessResponse<Void> settleChallenge(Long challengeId, Member member) {
        Challenge challenge = challengeSearchService.getChallengeById(challengeId);

        memberUtilsService.isChallengeHost(challenge, member);

        ZonedDateTime now = TimeZoneConverter.convertEtcToLocalTimeZone(ZonedDateTime.now());
        if (!now.isAfter(challenge.getEndDate())) {
            throw new BadRequestException(ErrorCode.INVALID_CHALLENGE_SETTLEMENT_TIME);
        }

        if (!(challenge.getState() == ChallengeState.COMPLETED_PENDING_SETTLEMENT)) {
            throw new BadRequestException(ErrorCode.INVALID_CHALLENGE_STATE_FOR_SETTLEMENT);
        }

        challenge.setStateCompletedSettled();
        challengeRepository.save(challenge);

        return SuccessResponse.of(SuccessCode.CHALLENGE_SETTLEMENT_SUCCESS);
    }
}
```

* 정산 로직을 담당하는 메서드입니다.
* 호스트 여부, 종료 날짜 이후인지 검증, 챌린지의 기존 상태가 `COMPLETED_PENDING_SETTLEMENT`인지 총 3가지를 확인합니다.
* 이후 챌린지의 상태를 변경하고 저장합니다.

---

### 3. 챌린지 상태 변경을 위한 set 메서드 추가

```java
// Challenge.java

...
public void setStateCompletedSettled() {
    this.isPaidAll = true;
    this.state = ChallengeState.COMPLETED_SETTLED;
}
...
```

* 챌린지의 상태를 `COMPLETED_SETTLED`로 변경하고 `isPaidAll` 변수의 값을 `true`로 변경합니다.

---

### 4. 기타

* 관련 테스트 코드 및 문서를 작성했습니다.
* 스케쥴러 메서드 내의 디버깅 용도 로그 출력 코드를 삭제했습니다.