### PR TITLE
feat: nginx 버전 정보 제거 #366

### DIFF
--- a/conf/nginx.conf
+++ b/conf/nginx.conf
@@ -16,6 +16,7 @@ server {
     listen 80;
 
     server_name "api.habitpay.link";
+    server_tokens off;
 
     location / {
         limit_req zone=ddos_limit burst=10 nodelay;
@@ -39,6 +40,6 @@ server {
         proxy_redirect off;
         proxy_set_header X-Script-Name /pgadmin;
         proxy_set_header X-Forwarded-Host $host;
-        
+
     }
 }


### PR DESCRIPTION
# 개요

백엔드 API 요청 시 반환되는 응답의 header 중에서 `Server` 속성에 nginx의 버전이 아래와 같이 표시되고 있었습니다.

![Image](https://github.com/user-attachments/assets/7dcf87c5-dc28-44e0-8fb6-bc36d7dd2a1e)

버전 노출에 따른 보안 공격을 방지하기 위해 버전을 표시하지 않도록 nginx 설정 파일을 수정합니다.

# 작업 내용

`nginx.conf` 파일에서 `server_tokens` 옵션을 off로 설정했습니다.

```
server_tokens off;
```

아래와 같이 nginx의 버전이 표시되지 않도록 수정했습니다.

<img width="429" alt="image" src="https://github.com/user-attachments/assets/4c67b86c-fb82-42e6-80ef-773a01ffe0bb" />


# 참고자료
- [nginx version 숨기기 및 header 정보 숨기기 ( nginx remove the server header )](https://xinet.kr/?p=3478) [xinet.kr]