### PR TITLE
chore: nginx upstream 설정 sed 명령어 수정 #368

### DIFF
--- a/scripts/switch.sh
+++ b/scripts/switch.sh
@@ -44,7 +44,7 @@ switch() {
     local target=$2
 
     log "Switching from $current to $target..."
-    sed -i "s|http://$current|http://$target|" $NGINX_CONFIGURATION_FILE
+    sed -i -E "s|proxy_pass[[:space:]]+http://[^;]+;|proxy_pass http://$target;|g" $NGINX_CONFIGURATION_FILE
     docker exec nginx nginx -s reload
     log "Complete to switch container. ($current -> $target)"
 }


### PR DESCRIPTION
# 개요 

blue/green 무중단 배포 중, green 컨테이너에서 blue 컨테이너로 전환이 정상적으로 이루어지지 않는 문제를 수정했습니다.

# 원인

nginx의 upstream이 green으로 바뀌지 않고 blue로 남아있던 것이 원인이었습니다.
nginx 설정 파일의 내용을 변경하기 위한 ShellScript에서 sed 명령어가 정상적으로 작동하지 않았기 때문입니다.

```bash
sed -i "s|http://$current|http://$target|" $NGINX_CONFIGURATION_FILE
```

무중단 배포를 수행하기 전에 로컬 환경에 있는 변경 사항을 모두 되돌리는데, 이때 nginx 설정 파일의 upstream의 기본 값은 blue로 설정됩니다.
그러다보니 nginx 설정 파일에는 `proxy_pass http://blue`로 존재하게 되는데, sed 명령어가 찾고자 하는 문자열 `http://green`을 찾지 못해 `http://blue`로 변경하지 못했던 것입니다.

# 작업 내용

sed 명령어가 찾고자 하는 문자열을 `http://$current`가 아닌 `proxy_pass http://`를 찾도록 변경했습니다.

```bash
sed -i -E "s|proxy_pass[[:space:]]+http://[^;]+;|proxy_pass http://$target;|g" $NGINX_CONFIGURATION_FILE
```